### PR TITLE
Add 'assignee' attribute to PullRequest

### DIFF
--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -30,6 +30,11 @@ class PullRequest(GithubObject.GithubObject):
         return self._NoneIfNotSet(self._additions)
 
     @property
+    def assignee(self):
+        self._completeIfNotSet(self._assignee)
+        return self._NoneIfNotSet(self._assignee)
+
+    @property
     def base(self):
         self._completeIfNotSet(self._base)
         return self._NoneIfNotSet(self._base)
@@ -290,6 +295,7 @@ class PullRequest(GithubObject.GithubObject):
 
     def _initAttributes(self):
         self._additions = GithubObject.NotSet
+        self._assignee = GithubObject.NotSet
         self._base = GithubObject.NotSet
         self._body = GithubObject.NotSet
         self._changed_files = GithubObject.NotSet
@@ -320,6 +326,9 @@ class PullRequest(GithubObject.GithubObject):
         if "additions" in attributes:  # pragma no branch
             assert attributes["additions"] is None or isinstance(attributes["additions"], int), attributes["additions"]
             self._additions = attributes["additions"]
+        if "assignee" in attributes:  # pragma no branch
+            assert attributes["assignee"] is None or isinstance(attributes["assignee"], dict), attributes["assignee"]
+            self._assignee = None if attributes["assignee"] is None else NamedUser.NamedUser(self._requester, attributes["assignee"], completed=False)
         if "base" in attributes:  # pragma no branch
             assert attributes["base"] is None or isinstance(attributes["base"], dict), attributes["base"]
             self._base = None if attributes["base"] is None else PullRequestPart.PullRequestPart(self._requester, attributes["base"], completed=False)


### PR DESCRIPTION
It seems as though this may have been added to
the github API and was not being included in the
PullRequest object.

I stumbled upon this when attempting to get the current
assignee of a pull request while playing with the API,
and noticed I could not get it via PyGithub. I need this
for a project I'm working on.

This verifies that the attribute's existence in github's API:
`curl -i "https://api.github.com/repos/jacquev6/PyGithub/pulls/31" | grep assignee`
Output:
`"assignee": null,`

I was also going to update the tests to include the attribute,
but I wasn't able to set the assignee on the test data.
