### PR TITLE
Update AuthenticatedUser.get_repo to accept a full repo path

### DIFF
--- a/github/Github.py
+++ b/github/Github.py
@@ -70,6 +70,16 @@ class Github(object):
         )
         return Organization.Organization(self.__requester, data, completed=True)
 
+    def get_repo(self, path):
+        assert isinstance(path, (str, unicode)), name
+        headers, data = self.__requester.requestAndCheck(
+            "GET",
+            "/repos/" + path,
+            None,
+            None
+        )
+        return Repository.Repository(self.__requester, data, completed=True)
+
     def get_gist(self, id):
         assert isinstance(id, (str, unicode)), id
         headers, data = self.__requester.requestAndCheck(


### PR DESCRIPTION
### Why?
- For projects I dont own, but I am a collaborator, or for directly accessing organisation repos without needing to traverse user.get_orgs.
### Example

``` python
user.get_repo("my_repo") # existing behaviour still works
user.get_repo("my_org/repo") # this is now possible
```

Thanks,
Luke Cawood
