### PR TITLE
Fix failing get_page function

### DIFF
--- a/github/PaginatedList.py
+++ b/github/PaginatedList.py
@@ -74,7 +74,7 @@ class PaginatedList(PaginatedListBase):
         self.__requester = requester
         self.__contentClass = contentClass
         self.__firstUrl = firstUrl
-        self.__firstParams = firstParams
+        self.__firstParams = firstParams or ()
         self.__nextUrl = firstUrl
         self.__nextParams = firstParams
 


### PR DESCRIPTION
- if firstParams was None, PaginatedList was calling dict(None)
  which fails with a TypeError. If firstParams is None, just use
  an empty tuple, which dict() handles properly
