### PR TITLE
Support http 302 redirect responses in get_dir_contents

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -891,6 +891,16 @@ class Repository(github.GithubObject.CompletableGithubObject):
             url_parameters,
             None
         )
+
+        # Handle 302 redirect response
+        if headers.get('status') == '302 Found' and headers.get('location'):
+            headers, data = self._requester.requestJsonAndCheck(
+                "GET",
+                headers['location'],
+                url_parameters,
+                None
+            )
+            
         return [
             github.ContentFile.ContentFile(self._requester, attributes, completed=(attributes["type"] != "file"))  # Lazy completion only makes sense for files. See discussion here: https://github.com/jacquev6/PyGithub/issues/140#issuecomment-13481130
             for attributes in data


### PR DESCRIPTION
I'm seeing http 302 responses for the Repo.get_dir_contents function call:
http://jacquev6.github.io/PyGithub/github_objects/Repository.html#github.Repository.Repository.get_dir_contents

I don't know if any of this is releated, but it is a private repo owned by an organization (not a user).  

I had originalized gone to add the redirect handling at a lower level, but after some experimentation this seems to be the only function call that's exhibiting this behavior.
