### PR TITLE
bugfix: using custom per_page in repo.get_comments

### DIFF
--- a/github/PaginatedList.py
+++ b/github/PaginatedList.py
@@ -97,7 +97,7 @@ class PaginatedList(PaginatedListBase):
         self.__firstUrl = firstUrl
         self.__firstParams = firstParams or ()
         self.__nextUrl = firstUrl
-        self.__nextParams = firstParams
+        self.__nextParams = firstParams or {}
         if self.__requester.per_page != 30:
             self.__nextParams["per_page"] = self.__requester.per_page
 

--- a/github/tests/PaginatedList.py
+++ b/github/tests/PaginatedList.py
@@ -15,7 +15,8 @@
 # You should have received a copy of the GNU Lesser General Public License along with PyGithub.  If not, see <http://www.gnu.org/licenses/>.
 
 import Framework
-
+import CommitComment
+from github.PaginatedList import PaginatedList as PaginatedListImpl
 
 class PaginatedList(Framework.TestCase):
     def setUp(self):
@@ -88,6 +89,15 @@ class PaginatedList(Framework.TestCase):
         self.g.per_page = 100
         self.assertEqual(self.g.per_page, 100)
         self.assertEqual(len(list(self.repo.get_issues())), 456)
+    
+    def testCustomPerPageWithNoUrlParams(self):
+        self.g.per_page = 100
+        paginated_list = PaginatedListImpl(
+            CommitComment.CommitComment,
+            self.repo._requester,
+            self.repo.url + "/comments",
+            None
+        )
 
     def testCustomPerPageWithGetPage(self):
         self.g.per_page = 100


### PR DESCRIPTION
I got an exception when trying to fetch 100 comments per page from a repo.
Before this fix I was getting an exception when line 102 set the `per_page` key in `self.__nextParams`.
This is because `self.__nextParams` was `None` in this case.
