### PR TITLE
Populates Issue's repository from URL when not in response.

### DIFF
--- a/github/Issue.py
+++ b/github/Issue.py
@@ -135,7 +135,11 @@ class Issue(github.GithubObject.CompletableGithubObject):
         :type: :class:`github.Repository.Repository`
         """
         self._completeIfNotSet(self._repository)
-        return self._NoneIfNotSet(self._repository)
+        if self._repository is github.GithubObject.NotSet:
+            # The repository was not set automatically, so it must be looked up by url.
+            repo_url = "/".join(self.url.split("/")[:-2])
+            self._repository = github.Repository.Repository(self._requester, {'url': repo_url}, False)
+        return self._repository
 
     @property
     def state(self):

--- a/github/tests/Issue.py
+++ b/github/tests/Issue.py
@@ -45,6 +45,7 @@ class Issue(Framework.TestCase):
         self.assertEqual(self.issue.updated_at, datetime.datetime(2012, 5, 26, 14, 59, 33))
         self.assertEqual(self.issue.url, "https://api.github.com/repos/jacquev6/PyGithub/issues/28")
         self.assertEqual(self.issue.user.login, "jacquev6")
+        self.assertEqual(self.issue.repository.name, "PyGithub")
 
     def testEditWithoutParameters(self):
         self.issue.edit()

--- a/github/tests/ReplayData/Issue.testAttributes.txt
+++ b/github/tests/ReplayData/Issue.testAttributes.txt
@@ -1,0 +1,11 @@
+https
+GET
+api.github.com
+None
+/repos/jacquev6/PyGithub
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+null
+200
+[('status', '200 OK'), ('x-ratelimit-remaining', '4992'), ('content-length', '1129'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"5dc65a168cf4d957347ea04221cd5102"'), ('date', 'Sat, 26 May 2012 14:59:39 GMT'), ('content-type', 'application/json; charset=utf-8')]
+{"clone_url":"https://github.com/jacquev6/PyGithub.git","has_downloads":true,"watchers":13,"updated_at":"2012-05-26T11:25:48Z","permissions":{"pull":true,"admin":true,"push":true},"homepage":"http://vincent-jacques.net/PyGithub","url":"https://api.github.com/repos/jacquev6/PyGithub","mirror_url":null,"has_wiki":false,"has_issues":true,"fork":false,"forks":2,"size":412,"private":false,"open_issues":15,"svn_url":"https://github.com/jacquev6/PyGithub","owner":{"url":"https://api.github.com/users/jacquev6","gravatar_id":"b68de5ae38616c296fa345d2b9df2225","login":"jacquev6","id":327146,"avatar_url":"https://secure.gravatar.com/avatar/b68de5ae38616c296fa345d2b9df2225?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-140.png"},"name":"PyGithub","language":"Python","description":"Python library implementing the full Github API v3","ssh_url":"git@github.com:jacquev6/PyGithub.git","pushed_at":"2012-05-26T11:25:48Z","created_at":"2012-02-25T12:53:47Z","id":3544490,"git_url":"git://github.com/jacquev6/PyGithub.git","html_url":"https://github.com/jacquev6/PyGithub","full_name":"jacquev6/PyGithub"}
+


### PR DESCRIPTION
Issues created from `Repository.get_issue()` have their `repository` field set to None.  This pull request manually sets the Issue's repository using the Issue's URL, when the repository has not already been set.

I've also modified the test in `tests.Issue.Issue.testAttributes` to verify that the repository is correctly set.  The modified test does fail if I remove my changes to the library.
