### PR TITLE
Handle github api response that isn't valid json

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -122,7 +122,10 @@ class Requester:
         else:
             if atLeastPython3 and isinstance(data, bytes):  # pragma no branch (Covered by Issue142.testDecodeJson with Python 3)
                 data = data.decode("utf-8")  # pragma no cover (Covered by Issue142.testDecodeJson with Python 3)
-            return json.loads(data)
+            try:
+                return json.loads(data)
+            except ValueError, e:
+                return {'data': data}
 
     def requestJson(self, verb, url, parameters, input):
         def encode(input):


### PR DESCRIPTION
For some reason the Github api started returning a 503 + an html fragment on a the repository comparison call for me today, and the html seems to have tripped up error handling.  Here is the stack trace I saw:

```
Module github.Repository:327 in compare
>>  None
Module github.Requester:95 in requestJsonAndCheck
>>  return self.__check(*self.requestJson(verb, url, parameters, input))
Module github.Requester:101 in __check
>>  output = self.__structuredFromJson(output)
Module github.Requester:125 in __structuredFromJson
>>  return json.loads(data)
Module json:326 in loads
>>  return _default_decoder.decode(s)
Module json.decoder:366 in decode
>>  obj, end = self.raw_decode(s, idx=_w(s, 0).end())
Module json.decoder:384 in raw_decode          view
>>  raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```

This pull request catches the json parser error and returns the text of the data so that the HTTP code error handle up the stack trace can handle the errror properly.  This is the new stack trace:

```
Module github.Repository:327 in compare
>>  None
Module github.Requester:95 in requestJsonAndCheck
>>  return self.__check(*self.requestJson(verb, url, parameters, input))
Module github.Requester:103 in __check
>>  raise self.__createException(status, output)
GithubException: 503 {'data': '<html><body><h1>503 Service Unavailable</h1>\nNo server is available to handle this request.\n</body></html>\n'}
```
