### PR TITLE
Add users/starred (GET)

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -217,22 +217,22 @@ class Github(object):
             url_parameters
         )
         
-    def get_starred(self, login=github.GithubObject.NotSet):
+    def get_starred(self, since=github.GithubObject.NotSet):
         """
-        :calls: `GET /users/:user/starred <http://developer.github.com/v3/activity/starring/#list-repositories-being-starred>`_
-        :param: string
-        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
+        :calls: `GET /user/starred <http://developer.github.com/v3/activity/starring>`_
+        :param since: integer
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
         """
-        assert login is github.GithubObject.NotSet or isinstance(login, (str, unicode)), login
-        if login is github.GithubObject.NotSet:
-            return AuthenticatedUser.AuthenticatedUser(self.__requester, {}, {"url": "/user"}, completed=False)
-        else:
-            headers, data = self.__requester.request.requestJsonAndCheck(
-                "GET",
-                "/users/" + login,
-                "/starred"
-            )
-            return github.NamedUser.NamedUser(self.__requester,headers,data,completed=True)
+        assert since is github.GithubObject.NotSet or isinstance(since, (int, long)), since
+        url_parameters = dict()
+        if since is not github.GithubObject.NotSet:
+            url_parameters["since"] = since
+        return github.PaginatedList.PaginatedList(
+            github.Repository.Repository,
+            self.__requester,
+            "/user/starred",
+            url_parameters
+        )
             
     def get_gist(self, id):
         """


### PR DESCRIPTION
Maybe I have missed the way to get the repos starred by a user, nevertheless with this you can do it. Example:

for repo in g.get_user().get_starred():
    data.append((repo.name,repo.stargazers_count,repo.html_url))
data = sorted(data,key=lambda data: data[1],reverse=True)
pprint.pprint(data,width=255)

Should I add here the rest of http://developer.github.com/v3/activity/starring or in another file?
