### PR TITLE
Implement support for getting repo by id

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -188,15 +188,16 @@ class Github(object):
         )
         return github.Organization.Organization(self.__requester, headers, data, completed=True)
 
-    def get_repo(self, full_name):
+    def get_repo(self, full_name_or_id):
         """
-        :calls: `GET /repos/:owner/:repo <http://developer.github.com/v3/repos>`_
+        :calls: `GET /repos/:owner/:repo <http://developer.github.com/v3/repos>`_ or `GET /repositories/:id <http://developer.github.com/v3/repos>`_
         :rtype: :class:`github.Repository.Repository`
         """
-        assert isinstance(full_name, (str, unicode)), full_name
+        assert isinstance(full_name_or_id, (str, unicode, int)), full_name_or_id
+        url_base = "/repositories/" if isinstance(full_name_or_id, int) else "/repos/"
         headers, data = self.__requester.requestJsonAndCheck(
             "GET",
-            "/repos/" + full_name
+            "%s%s" % (url_base, full_name_or_id)
         )
         return Repository.Repository(self.__requester, headers, data, completed=True)
 

--- a/github/tests/Github_.py
+++ b/github/tests/Github_.py
@@ -120,6 +120,9 @@ class Github(Framework.TestCase):
     def testGetRepoFromFullName(self):
         self.assertEqual(self.g.get_repo("jacquev6/PyGithub").description, "Python library implementing the full Github API v3")
 
+    def testGetRepoFromId(self):
+        self.assertEqual(self.g.get_repo(3544490).description, "Python library implementing the full Github API v3")
+
     def testGetGitignoreTemplates(self):
         self.assertEqual(self.g.get_gitignore_templates(), ["Actionscript", "Android", "AppceleratorTitanium", "Autotools", "Bancha", "C", "C++", "CFWheels", "CMake", "CSharp", "CakePHP", "Clojure", "CodeIgniter", "Compass", "Concrete5", "Coq", "Delphi", "Django", "Drupal", "Erlang", "ExpressionEngine", "Finale", "ForceDotCom", "FuelPHP", "GWT", "Go", "Grails", "Haskell", "Java", "Jboss", "Jekyll", "Joomla", "Jython", "Kohana", "LaTeX", "Leiningen", "LemonStand", "Lilypond", "Lithium", "Magento", "Maven", "Node", "OCaml", "Objective-C", "Opa", "OracleForms", "Perl", "PlayFramework", "Python", "Qooxdoo", "Qt", "R", "Rails", "RhodesRhomobile", "Ruby", "Scala", "Sdcc", "SeamGen", "SketchUp", "SugarCRM", "Symfony", "Symfony2", "SymphonyCMS", "Target3001", "Tasm", "Textpattern", "TurboGears2", "Unity", "VB.Net", "Waf", "Wordpress", "Yii", "ZendFramework", "gcov", "nanoc", "opencart"])
 

--- a/github/tests/ReplayData/Github.testGetRepoFromId.txt
+++ b/github/tests/ReplayData/Github.testGetRepoFromId.txt
@@ -1,0 +1,11 @@
+https
+GET
+api.github.com
+None
+/repositories/3544490
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+null
+200
+[('status', '200 OK'), ('x-ratelimit-remaining', '4939'), ('content-length', '1097'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"922c0519f2733063a899619ae95ce892"'), ('date', 'Sun, 20 May 2012 12:33:27 GMT'), ('content-type', 'application/json; charset=utf-8')]
+{"svn_url":"https://github.com/jacquev6/PyGithub","has_wiki":false,"has_issues":true,"updated_at":"2012-05-19T10:50:39Z","forks":2,"homepage":"http://vincent-jacques.net/PyGithub","git_url":"git://github.com/jacquev6/PyGithub.git","url":"https://api.github.com/repos/jacquev6/PyGithub","clone_url":"https://github.com/jacquev6/PyGithub.git","open_issues":18,"fork":false,"ssh_url":"git@github.com:jacquev6/PyGithub.git","pushed_at":"2012-05-19T10:50:39Z","size":304,"private":false,"has_downloads":true,"watchers":13,"html_url":"https://github.com/jacquev6/PyGithub","owner":{"avatar_url":"https://secure.gravatar.com/avatar/b68de5ae38616c296fa345d2b9df2225?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-140.png","url":"https://api.github.com/users/jacquev6","gravatar_id":"b68de5ae38616c296fa345d2b9df2225","login":"jacquev6","id":327146},"name":"PyGithub","permissions":{"pull":true,"admin":true,"push":true},"language":"Python","description":"Python library implementing the full Github API v3","created_at":"2012-02-25T12:53:47Z","id":3544490,"mirror_url":null}
+


### PR DESCRIPTION
This allows the Github class to retrieve repos by either their full name
or id. If the user passes in an id for a repo which doesn't exist or in which
they don't have sufficient permissions, an UnknownObjectException will
be raised. This addresses issue #245.
