### PR TITLE
Capitalization of the 2FA OTP request header

### DIFF
--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -426,7 +426,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         if client_secret is not github.GithubObject.NotSet:
             post_parameters["client_secret"] = client_secret
         if onetime_password is not None:
-            request_header = {'x-github-otp': onetime_password}  # pragma no cover (Should be covered)
+            request_header = {'X-GitHub-OTP': onetime_password}  # pragma no cover (Should be covered)
         else:
             request_header = None
         headers, data = self._requester.requestJsonAndCheck(


### PR DESCRIPTION
Running

``` python
from github import Github
user = Github(login_or_token='username', password='password').get_user()
try:                                                                               
    auth = user.create_authorization(scopes=['repo'], note='test')
except GithubException:                                                         
    password = input()                                                             
    auth = user.create_authorization(scopes=['repo'], note='test', onetime_password=password)
```

yields a `TwoFactorException` with the following traceback:

```
Traceback (most recent call last):
  File "./mygithub.py", line 9, in <module>
    auth = user.create_authorization(scopes=['repo'], note='test')
  File "/home/tradej/.local/lib/python3.3/site-packages/github/AuthenticatedUser.py", line 436, in create_authorization
    headers=request_header,
  File "/home/tradej/.local/lib/python3.3/site-packages/github/Requester.py", line 169, in requestJsonAndCheck
    return self.__check(*self.requestJson(verb, url, parameters, headers, input, cnx))
  File "/home/tradej/.local/lib/python3.3/site-packages/github/Requester.py", line 177, in __check
    raise self.__createException(status, responseHeaders, output)
github.GithubException.TwoFactorException: 401 {'documentation_url': 'https://developer.github.com/v3/auth#working-with-two-factor-authentication', 'message': 'Must specify two-factor authentication OTP code.'}
```

This is caused by the OTP header string being all lowercase. If it is properly uppercased as in this pull request, the authentication process finishes correctly.
