### PR TITLE
Added MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include COPYING*
+include README.rst

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
             "github.tests",
         ],
         package_data={
-            "github": ["ReadMe.rst", "COPYING*", "tests/ReplayData/*.txt"]
+            "github": ["tests/ReplayData/*.txt"]
         },
         classifiers=[
             "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Hi. (Not only) In the latest version, the COPYING and COPYING.LESSER files are missing when `setup.py sdist` is run. This commit rectifies that through the usage of MANIFEST.in.
