### PR TITLE
Add optional context when creating a status for a commit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ What's new?
 Version 1.25.2 (October 7th, 2014)
 ----------------------------------
 
-* `Work around <https://github.com/jacquev6/PyGithub/issues/278>`__ the API v3 returning `null`s in some paginated responses, `erichaase <https://github.com/erichaase>`__ for the bug report
+* `Work around <https://github.com/jacquev6/PyGithub/issues/278>`__ the API v3 returning ``null`` in some paginated responses, thanks `erichaase <https://github.com/erichaase>`__ for the bug report
 
 Version 1.25.1 (September 28th, 2014)
 -------------------------------------

--- a/github/Commit.py
+++ b/github/Commit.py
@@ -150,17 +150,19 @@ class Commit(github.GithubObject.CompletableGithubObject):
         )
         return github.CommitComment.CommitComment(self._requester, headers, data, completed=True)
 
-    def create_status(self, state, target_url=github.GithubObject.NotSet, description=github.GithubObject.NotSet):
+    def create_status(self, state, target_url=github.GithubObject.NotSet, description=github.GithubObject.NotSet, context=github.GithubObject.NotSet):
         """
         :calls: `POST /repos/:owner/:repo/statuses/:sha <http://developer.github.com/v3/repos/statuses>`_
         :param state: string
         :param target_url: string
         :param description: string
+        :param context: string
         :rtype: :class:`github.CommitStatus.CommitStatus`
         """
         assert isinstance(state, (str, unicode)), state
         assert target_url is github.GithubObject.NotSet or isinstance(target_url, (str, unicode)), target_url
         assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
+        assert context is github.GithubObject.NotSet or isinstance(context, (str, unicode)), context
         post_parameters = {
             "state": state,
         }
@@ -168,6 +170,8 @@ class Commit(github.GithubObject.CompletableGithubObject):
             post_parameters["target_url"] = target_url
         if description is not github.GithubObject.NotSet:
             post_parameters["description"] = description
+        if context is not github.GithubObject.NotSet:
+            post_parameters["context"] = context
         headers, data = self._requester.requestJsonAndCheck(
             "POST",
             self._parentUrl(self._parentUrl(self.url)) + "/statuses/" + self.sha,


### PR DESCRIPTION
Hi,

This pull request allows optional context to be given when creating a status for a commit.

From https://developer.github.com/v3/repos/statuses/#create-a-status the ``context`` is a string label to differentiate the current status from the status of other systems. The default is "default", which means any status created through ``v1.x`` will always have a context of "default". Even though the API specifies the default context to be "default", I have matched the code based for existing optional arguments by using ``github.GithubObject.NotSet``.

Cheers,
Andy