### PR TITLE
Allow access to preview versions of the server-side API

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -54,7 +54,7 @@ class Github(object):
     This is the main class you instanciate to access the Github API v3. Optional parameters allow different authentication methods.
     """
 
-    def __init__(self, login_or_token=None, password=None, base_url=DEFAULT_BASE_URL, timeout=DEFAULT_TIMEOUT, client_id=None, client_secret=None, user_agent='PyGithub/Python', per_page=DEFAULT_PER_PAGE):
+    def __init__(self, login_or_token=None, password=None, base_url=DEFAULT_BASE_URL, timeout=DEFAULT_TIMEOUT, client_id=None, client_secret=None, user_agent='PyGithub/Python', per_page=DEFAULT_PER_PAGE, api_preview=False):
         """
         :param login_or_token: string
         :param password: string
@@ -73,7 +73,8 @@ class Github(object):
         assert client_id is None or isinstance(client_id, (str, unicode)), client_id
         assert client_secret is None or isinstance(client_secret, (str, unicode)), client_secret
         assert user_agent is None or isinstance(user_agent, (str, unicode)), user_agent
-        self.__requester = Requester(login_or_token, password, base_url, timeout, client_id, client_secret, user_agent, per_page)
+        assert isinstance(api_preview, (bool))
+        self.__requester = Requester(login_or_token, password, base_url, timeout, client_id, client_secret, user_agent, per_page, api_preview)
 
     def __get_FIX_REPO_GET_GIT_REF(self):
         """

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -123,7 +123,7 @@ class Requester:
 
     #############################################################
 
-    def __init__(self, login_or_token, password, base_url, timeout, client_id, client_secret, user_agent, per_page):
+    def __init__(self, login_or_token, password, base_url, timeout, client_id, client_secret, user_agent, per_page, api_preview):
         self._initializeDebugFeature()
 
         if password is not None:
@@ -164,6 +164,7 @@ class Requester:
         assert user_agent is not None, 'github now requires a user-agent. ' \
             'See http://developer.github.com/v3/#user-agent-required'
         self.__userAgent = user_agent
+        self.__apiPreview = api_preview
 
     def requestJsonAndCheck(self, verb, url, parameters=None, headers=None, input=None, cnx=None):
         return self.__check(*self.requestJson(verb, url, parameters, headers, input, cnx))
@@ -234,6 +235,8 @@ class Requester:
 
         self.__authenticate(url, requestHeaders, parameters)
         requestHeaders["User-Agent"] = self.__userAgent
+        if self.__apiPreview:
+            requestHeaders["Accept"] = "application/vnd.github.moondragon+json"
 
         url = self.__makeAbsoluteUrl(url)
         url = self.__addParametersToUrl(url, parameters)


### PR DESCRIPTION

Developers can preview / test their code against new versions of the Github APIs by setting an Accept header

https://developer.github.com/changes/2014-12-08-organization-permissions-api-preview/

This change allows PyGithub users to try the new APIs by setting api_preview=True when constructing the Github object

