### PR TITLE
Support recording tests when using an OAuth token

### DIFF
--- a/Contributing.rst
+++ b/Contributing.rst
@@ -30,6 +30,8 @@ If you add a new test, for example ``Issue139.testCompletion``, you must add an 
 	password = "my_password"
 	oauth_token = "my_token"  # Can be left empty if not used
 
+If you use 2 factor authentication on your Github account, tests that require a login/password authentication will fail. You can use ``python -m github.tests Issue139.testCompletion --record --auth_with_token`` to use the oauth_token when recording a unit test interaction.
+
 Coding conventions
 ~~~~~~~~~~~~~~~~~~
 

--- a/github/tests/Framework.py
+++ b/github/tests/Framework.py
@@ -185,6 +185,7 @@ def ReplayingHttpsConnection(testCase, file, *args, **kwds):
 
 class BasicTestCase(unittest.TestCase):
     recordMode = False
+    tokenAuthMode = False
 
     def setUp(self):
         unittest.TestCase.setUp(self)
@@ -263,8 +264,15 @@ class TestCase(BasicTestCase):
         github.Requester.Requester.setDebugFlag(True)
         github.Requester.Requester.setOnCheckMe(self.getFrameChecker())
 
-        self.g = github.Github(self.login, self.password)
+        if self.tokenAuthMode:
+            self.g = github.Github(self.oauth_token)
+        else:
+            self.g = github.Github(self.login, self.password)
 
 
 def activateRecordMode():  # pragma no cover (Function useful only when recording new tests, not used during automated tests)
     BasicTestCase.recordMode = True
+
+
+def activateTokenAuthMode():  # pragma no cover (Function useful only when recording new tests, not used during automated tests)
+    BasicTestCase.tokenAuthMode = True

--- a/github/tests/__main__.py
+++ b/github/tests/__main__.py
@@ -35,6 +35,10 @@ def main(argv):
         github.tests.Framework.activateRecordMode()
         argv = [arg for arg in argv if arg != "--record"]
 
+    if "--auth_with_token" in argv:
+        github.tests.Framework.activateTokenAuthMode()
+        argv = [arg for arg in argv if arg != "--auth_with_token"]
+
     unittest.main(module=github.tests.AllTests, argv=argv)
 
 


### PR DESCRIPTION
This is how I solved #306. It is probably an incomplete solution as I didn't address the issue of tests that rely on a specific authentication mechanism (I have no idea what that would entail).

It worked for me, at least.