### PR TITLE
Fixing https://github.com/PyGithub/PyGithub/issues/335.

### DIFF
--- a/github/Issue.py
+++ b/github/Issue.py
@@ -27,6 +27,7 @@
 #                                                                              #
 # ##############################################################################
 
+import urllib
 import github.GithubObject
 import github.PaginatedList
 
@@ -355,6 +356,8 @@ class Issue(github.GithubObject.CompletableGithubObject):
         assert isinstance(label, (github.Label.Label, str, unicode)), label
         if isinstance(label, github.Label.Label):
             label = label._identity
+        else:
+            label = urllib.quote(label)
         headers, data = self._requester.requestJsonAndCheck(
             "DELETE",
             self.url + "/labels/" + label


### PR DESCRIPTION
Issue.remove_from_labels fails when the label passed is a string with whitespace characters