### PR TITLE
README: Remove searching maintainer note

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,12 +7,6 @@ Should you have any question, any remark, or if you find a bug, or if there is s
 
 For further details, please refer to the `reference documentation <http://pygithub.readthedocs.org/en/stable/>`_ at ``readthedocs.org``.
 
-Looking for maintainers (February 22nd, 2015)
-=============================================
-
-My current priorities are not compatible with doing a good job maintaining PyGithub, so I'm looking for volunteers to take over.
-Please see `#297 <https://github.com/jacquev6/PyGithub/issues/297>`__.
-
 What's new?
 ===========
 


### PR DESCRIPTION
There are obviously volunteers maintaining this project and this note is scaring people away.

Fixes https://github.com/PyGithub/PyGithub/issues/297