### PR TITLE
Fixes #339 by allowing strings in the labels list.

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -861,7 +861,8 @@ class Repository(github.GithubObject.CompletableGithubObject):
         assert body is github.GithubObject.NotSet or isinstance(body, (str, unicode)), body
         assert assignee is github.GithubObject.NotSet or isinstance(assignee, github.NamedUser.NamedUser) or isinstance(assignee, (str, unicode)), assignee
         assert milestone is github.GithubObject.NotSet or isinstance(milestone, github.Milestone.Milestone), milestone
-        assert labels is github.GithubObject.NotSet or all(isinstance(element, github.Label.Label) for element in labels), labels
+        assert labels is github.GithubObject.NotSet or all(isinstance(element, github.Label.Label) or isinstance(element, str) for element in labels), labels
+
         post_parameters = {
             "title": title,
         }
@@ -875,7 +876,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         if milestone is not github.GithubObject.NotSet:
             post_parameters["milestone"] = milestone._identity
         if labels is not github.GithubObject.NotSet:
-            post_parameters["labels"] = [element.name for element in labels]
+            post_parameters["labels"] = [element.name if isinstance(element, github.Label.Label) else element for element in labels]
         headers, data = self._requester.requestJsonAndCheck(
             "POST",
             self.url + "/issues",

--- a/github/tests/ReplayData/Repository.testCreateIssueWithAllArgumentsStringLabel.txt
+++ b/github/tests/ReplayData/Repository.testCreateIssueWithAllArgumentsStringLabel.txt
@@ -1,0 +1,33 @@
+https
+GET
+api.github.com
+None
+/users/jacquev6
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+null
+200
+[('status', '200 OK'), ('x-ratelimit-remaining', '4991'), ('content-length', '801'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"0c1724d7560338bc2f2579af6e8ec545"'), ('date', 'Fri, 01 Jun 2012 20:09:23 GMT'), ('content-type', 'application/json; charset=utf-8')]
+{"owned_private_repos":5,"type":"User","company":"Criteo","gravatar_id":"b68de5ae38616c296fa345d2b9df2225","avatar_url":"https://secure.gravatar.com/avatar/b68de5ae38616c296fa345d2b9df2225?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-140.png","login":"jacquev6","email":"vincent@vincent-jacques.net","hireable":false,"public_gists":3,"created_at":"2010-07-09T06:10:06Z","location":"Paris, France","bio":"","url":"https://api.github.com/users/jacquev6","following":24,"private_gists":5,"public_repos":10,"blog":"http://vincent-jacques.net","disk_usage":16900,"name":"Vincent Jacques","total_private_repos":5,"collaborators":0,"followers":13,"html_url":"https://github.com/jacquev6","id":327146,"plan":{"private_repos":5,"space":614400,"name":"micro","collaborators":1}}
+
+https
+GET
+api.github.com
+None
+/repos/jacquev6/PyGithub/milestones/2
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+null
+200
+[('status', '200 OK'), ('x-ratelimit-remaining', '4990'), ('content-length', '899'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"5fc4dbe5fd444fd2ea9f90c698b432cf"'), ('date', 'Fri, 01 Jun 2012 20:09:24 GMT'), ('content-type', 'application/json; charset=utf-8')]
+{"title":"Version 1.0: coherent public interface","creator":{"gravatar_id":"b68de5ae38616c296fa345d2b9df2225","login":"jacquev6","url":"https://api.github.com/users/jacquev6","id":327146,"avatar_url":"https://secure.gravatar.com/avatar/b68de5ae38616c296fa345d2b9df2225?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-140.png"},"created_at":"2012-03-08T12:22:28Z","state":"open","description":"Heavy rewrite to have:\r\n* a fully coherent public interface\r\n* usable stack-traces in case of exception\r\n* more explicit exceptions\r\n* more readable code (for library exploration, auto-completion in IDEs, etc.)\r\n\r\nSee working branch https://github.com/jacquev6/PyGithub/tree/topic/RewriteWithGeneratedCode","url":"https://api.github.com/repos/jacquev6/PyGithub/milestones/2","closed_issues":13,"due_on":"2012-06-04T07:00:00Z","open_issues":6,"number":2,"id":93547}
+
+https
+POST
+api.github.com
+None
+/repos/jacquev6/PyGithub/issues
+{'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+{"body": "Body created by PyGithub", "assignee": "jacquev6", "labels": ["Question"], "milestone": 2, "title": "Issue also created by PyGithub"}
+201
+[('status', '201 Created'), ('x-ratelimit-remaining', '4943'), ('content-length', '2069'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"d131a11b793937127bf7d0ce56e2805e"'), ('date', 'Sun, 27 May 2012 05:40:15 GMT'), ('content-type', 'application/json; charset=utf-8'), ('location', 'https://api.github.com/repos/jacquev6/PyGithub/issues/30')]
+{"updated_at":"2012-05-27T05:40:15Z","body":"Body created by PyGithub","url":"https://api.github.com/repos/jacquev6/PyGithub/issues/30","comments":0,"milestone":{"creator":{"url":"https://api.github.com/users/jacquev6","gravatar_id":"b68de5ae38616c296fa345d2b9df2225","login":"jacquev6","id":327146,"avatar_url":"https://secure.gravatar.com/avatar/b68de5ae38616c296fa345d2b9df2225?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-140.png"},"url":"https://api.github.com/repos/jacquev6/PyGithub/milestones/2","number":2,"title":"Version 1.0: coherent public interface","due_on":"2012-06-04T07:00:00Z","open_issues":10,"created_at":"2012-03-08T12:22:28Z","state":"open","description":"Heavy rewrite to have:\r\n* a fully coherent public interface\r\n* usable stack-traces in case of exception\r\n* more explicit exceptions\r\n* more readable code (for library exploration, auto-completion in IDEs, etc.)\r\n\r\nSee working branch https://github.com/jacquev6/PyGithub/tree/topic/RewriteWithGeneratedCode","id":93547,"closed_issues":2},"number":30,"closed_by":null,"assignee":{"url":"https://api.github.com/users/jacquev6","gravatar_id":"b68de5ae38616c296fa345d2b9df2225","login":"jacquev6","id":327146,"avatar_url":"https://secure.gravatar.com/avatar/b68de5ae38616c296fa345d2b9df2225?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-140.png"},"closed_at":null,"title":"Issue also created by PyGithub","labels":[{"url":"https://api.github.com/repos/jacquev6/PyGithub/labels/Question","name":"Question","color":"02e10c"}],"created_at":"2012-05-27T05:40:15Z","state":"open","user":{"url":"https://api.github.com/users/jacquev6","gravatar_id":"b68de5ae38616c296fa345d2b9df2225","login":"jacquev6","id":327146,"avatar_url":"https://secure.gravatar.com/avatar/b68de5ae38616c296fa345d2b9df2225?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-140.png"},"id":4769659,"pull_request":{"patch_url":null,"diff_url":null,"html_url":null},"html_url":"https://github.com/jacquev6/PyGithub/issues/30"}
+

--- a/github/tests/Repository.py
+++ b/github/tests/Repository.py
@@ -109,6 +109,12 @@ class Repository(Framework.TestCase):
         issue = self.repo.create_issue("Issue also created by PyGithub", "Body created by PyGithub", user, milestone, [question])
         self.assertEqual(issue.number, 30)
 
+    def testCreateIssueWithAllArgumentsStringLabel(self):
+        user = self.g.get_user("jacquev6")
+        milestone = self.repo.get_milestone(2)
+        issue = self.repo.create_issue("Issue also created by PyGithub", "Body created by PyGithub", user, milestone, ['Question'])
+        self.assertEqual(issue.number, 30)
+
     def testCreateLabel(self):
         label = self.repo.create_label("Label with silly name % * + created by PyGithub", "00ff00")
         self.assertEqual(label.color, "00ff00")


### PR DESCRIPTION
Labels can be added from strings and there is no reason strings can't be allowed in the list for issue creation.  The change requires relaxing the assertion and adding a conditional to the adding of labels to the post.

Currently
```python
repo.create_issue('name', body = "body", labels = [repo.get_label('label')])
```

After the Change
```python
repo.create_issue('name', body = "body", labels = ['label'])
```