### PR TITLE
Updating doc link for Github Commit Statuses

### DIFF
--- a/github/CommitStatus.py
+++ b/github/CommitStatus.py
@@ -31,7 +31,7 @@ import github.NamedUser
 
 class CommitStatus(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents CommitStatuss as returned for example by http://developer.github.com/v3/todo
+    This class represents CommitStatuss as returned for example by https://developer.github.com/v3/repos/statuses/
     """
 
     @property


### PR DESCRIPTION
It seems that this new link should be the appropriate link to docs for Commit Statuses. The old one just seemed to be a place holder "todo"