### PR TITLE
Add read-only Releases API with Assets

### DIFF
--- a/github/Release.py
+++ b/github/Release.py
@@ -25,6 +25,8 @@
 #                                                                              #
 # ##############################################################################
 
+#import uritemplate
+
 import github.GithubObject
 
 import github.NamedUser
@@ -172,6 +174,63 @@ class Release(github.GithubObject.CompletableGithubObject):
         self._completeIfNotSet(self._assets)
         return self._assets.value
 
+    def delete(self):
+        """
+        :calls: `DELETE /repos/:owner/:repo/releases/:id <http://developer.github.com/v3/repos/releases>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url
+        )
+
+    def edit(self, name, message, draft=False, prerelease=False):
+        """
+        :calls: `PATCH /repos/:owner/:repo/releases/:id <http://developer.github.com/v3/repos/releases>`_
+        :param name: string
+        :param body: string
+        :param draft: bool 
+        :param prerelease: bool 
+        :rtype: None
+        """
+        assert isinstance(name, (str, unicode)), name
+        assert isinstance(message, (str, unicode)), message
+        assert isinstance(draft, bool), draft
+        assert isinstance(prerelease, bool), prerelease
+        post_parameters = {
+            "tag_name": self.tag_name,
+            "target_commitish": self.target_commitish,
+            "name": name,
+            "body": message,
+            "draft": draft,
+            "prerelease": prerelease,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
+#    def upload_asset(self, binary_data, name, label=github.GithubObject.NotSet):
+#        """
+#        :calls: `POST https://<upload_url>/repos/:owner/:repo/releases/:id/assets{?name,label} <http://developer.github.com/v3/repos/releases>`_
+#        :param binary_data: string 
+#        :param name: string
+#        :param label: string 
+#        :rtype: :class:`github.ReleaseAsset.ReleaseAsset`
+#        """
+#        assert isinstance(binary_data, str), binary_data 
+#        assert isinstance(name, (str, unicode)), name
+#        assert label is github.GithubObject.NotSet or isinstance(label, (str, unicode)), label
+#
+#        headers, data = self._requester.requestJsonAndCheck(
+#            "POST",
+#            uritemplate.expand(self.upload_url, {'name': name, 'label': label}),
+#            input=binary_data
+#        )
+#        return github.ReleaseAsset.ReleaseAsset(self._requester, headers, data, completed=True)
+
     def _initAttributes(self):
         self._url = github.GithubObject.NotSet
         self._html_url = github.GithubObject.NotSet
@@ -226,4 +285,3 @@ class Release(github.GithubObject.CompletableGithubObject):
             self._author = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["author"])
         if "assets" in attributes:  # pragma no branch
             self._assets = self._makeListOfClassesAttribute(github.ReleaseAsset.ReleaseAsset, attributes["assets"])
-

--- a/github/Release.py
+++ b/github/Release.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2015 Brett Weir <brett@lamestation.com>                            #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.NamedUser
+import github.ReleaseAsset
+
+
+class Release(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents Releases as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._html_url)
+        return self._html_url.value
+
+    @property
+    def assets_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._assets_url)
+        return self._assets_url.value
+
+    @property
+    def upload_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._upload_url)
+        return self._upload_url.value
+
+    @property
+    def tarball_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._tarball_url)
+        return self._tarball_url.value
+
+    @property
+    def zipball_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._zipball_url)
+        return self._zipball_url.value
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def tag_name(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._tag_name)
+        return self._tag_name.value
+
+    @property
+    def target_commitish(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._target_commitish)
+        return self._target_commitish.value
+
+    @property
+    def name(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._name)
+        return self._name.value
+
+    @property
+    def body(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._body)
+        return self._body.value
+
+    @property
+    def draft(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._draft)
+        return self._draft.value
+
+    @property
+    def prerelease(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._prerelease)
+        return self._prerelease.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def published_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._published_at)
+        return self._published_at.value
+
+    @property
+    def author(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._author)
+        return self._author.value
+
+    @property
+    def assets(self):
+        """
+        :type: :class:`github.PaginatedList.PaginatedList` of :class:`github.ReleaseAsset.ReleaseAsset`
+        """
+        self._completeIfNotSet(self._assets)
+        return self._assets.value
+
+    def _initAttributes(self):
+        self._url = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
+        self._assets_url = github.GithubObject.NotSet
+        self._upload_url = github.GithubObject.NotSet
+        self._tarball_url = github.GithubObject.NotSet
+        self._zipball_url = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._tag_name = github.GithubObject.NotSet
+        self._target_commitish = github.GithubObject.NotSet
+        self._name = github.GithubObject.NotSet
+        self._body = github.GithubObject.NotSet
+        self._draft = github.GithubObject.NotSet
+        self._prerelease = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._published_at = github.GithubObject.NotSet
+        self._author = github.GithubObject.NotSet
+        self._assets = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])  # pragma no cover
+        if "html_url" in attributes:  # pragma no branch
+            self._html_url = self._makeStringAttribute(attributes["html_url"])  # pragma no cover
+        if "assets_url" in attributes:  # pragma no branch
+            self._assets_url = self._makeStringAttribute(attributes["assets_url"])  # pragma no cover
+        if "upload_url" in attributes:  # pragma no branch
+            self._upload_url = self._makeStringAttribute(attributes["upload_url"])
+        if "tarball_url" in attributes:  # pragma no branch
+            self._tarball_url = self._makeStringAttribute(attributes["tarball_url"])
+        if "zipball_url" in attributes:  # pragma no branch
+            self._zipball_url = self._makeStringAttribute(attributes["zipball_url"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "tag_name" in attributes:  # pragma no branch
+            self._tag_name = self._makeStringAttribute(attributes["tag_name"])
+        if "target_commitish" in attributes:  # pragma no branch
+            self._target_commitish = self._makeStringAttribute(attributes["target_commitish"])
+        if "name" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["name"])
+        if "body" in attributes:  # pragma no branch
+            self._body = self._makeStringAttribute(attributes["body"])
+        if "draft" in attributes:  # pragma no branch
+            self._draft = self._makeBoolAttribute(attributes["draft"])
+        if "prerelease" in attributes:  # pragma no branch
+            self._prerelease = self._makeBoolAttribute(attributes["prerelease"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "published_at" in attributes:  # pragma no branch
+            self._published_at = self._makeDatetimeAttribute(attributes["published_at"])
+        if "author" in attributes:  # pragma no branch
+            self._author = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["author"])
+        if "assets" in attributes:  # pragma no branch
+            self._assets = self._makeListOfClassesAttribute(github.ReleaseAsset.ReleaseAsset, attributes["assets"])
+

--- a/github/ReleaseAsset.py
+++ b/github/ReleaseAsset.py
@@ -131,6 +131,37 @@ class ReleaseAsset(github.GithubObject.CompletableGithubObject):
         self._completeIfNotSet(self._uploader)
         return self._uploader.value
 
+    def delete(self):
+        """
+        :calls: `DELETE /repos/:owner/:repo/releases/assets/:id <http://developer.github.com/v3/repos/releases>`_
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url
+        )
+
+    def edit(self, name, label=github.GithubObject.NotSet):
+        """
+        :calls: `PATCH /repos/:owner/:repo/releases/assets/:id <http://developer.github.com/v3/repos/releases>`_
+        :param name: string
+        :param label: string
+        :rtype: None
+        """
+        assert isinstance(name, (str, unicode)), name
+        assert description is github.GithubObject.NotSet or isinstance(label, (str, unicode)), label 
+        post_parameters = {
+            "name": name,
+        }
+        if label is not github.GithubObject.NotSet:
+            post_parameters["label"] = label
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+            input=post_parameters
+        )
+        self._useAttributes(data)
+
     def _initAttributes(self):
         self._url = github.GithubObject.NotSet
         self._browser_download_url = github.GithubObject.NotSet
@@ -138,7 +169,7 @@ class ReleaseAsset(github.GithubObject.CompletableGithubObject):
         self._name = github.GithubObject.NotSet
         self._label = github.GithubObject.NotSet
         self._state = github.GithubObject.NotSet
-        self._content_type= github.GithubObject.NotSet
+        self._content_type = github.GithubObject.NotSet
         self._size = github.GithubObject.NotSet
         self._download_count = github.GithubObject.NotSet
         self._created_at = github.GithubObject.NotSet
@@ -170,4 +201,3 @@ class ReleaseAsset(github.GithubObject.CompletableGithubObject):
             self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
         if "uploader" in attributes:  # pragma no branch
             self._uploader = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["uploader"])
-

--- a/github/ReleaseAsset.py
+++ b/github/ReleaseAsset.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2012 Zearin <zearin@gonk.net>                                      #
+# Copyright 2013 AKFish <akfish@gmail.com>                                     #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2015 Brett Weir <brett@lamestation.com>                            #
+#                                                                              #
+# This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+
+import github.NamedUser
+
+
+class ReleaseAsset(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents Release Assets as returned for example by http://developer.github.com/v3/todo
+    """
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._url)
+        return self._url.value
+
+    @property
+    def browser_download_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._browser_download_url)
+        return self._browser_download_url.value
+
+    @property
+    def id(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._id)
+        return self._id.value
+
+    @property
+    def name(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._name)
+        return self._name.value
+
+    @property
+    def label(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._label)
+        return self._label.value
+
+    @property
+    def state(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._state)
+        return self._state.value
+
+    @property
+    def content_type(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._content_type)
+        return self._content_type.value
+
+    @property
+    def size(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._size)
+        return self._size.value
+
+    @property
+    def download_count(self):
+        """
+        :type: integer
+        """
+        self._completeIfNotSet(self._download_count)
+        return self._download_count.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def updated_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._updated_at)
+        return self._updated_at.value
+
+    @property
+    def uploader(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._uploader)
+        return self._uploader.value
+
+    def _initAttributes(self):
+        self._url = github.GithubObject.NotSet
+        self._browser_download_url = github.GithubObject.NotSet
+        self._id = github.GithubObject.NotSet
+        self._name = github.GithubObject.NotSet
+        self._label = github.GithubObject.NotSet
+        self._state = github.GithubObject.NotSet
+        self._content_type= github.GithubObject.NotSet
+        self._size = github.GithubObject.NotSet
+        self._download_count = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._updated_at = github.GithubObject.NotSet
+        self._uploader = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])
+        if "browser_download_url" in attributes:  # pragma no branch
+            self._browser_download_url = self._makeStringAttribute(attributes["browser_download_url"])
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])
+        if "name" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["name"])
+        if "label" in attributes:  # pragma no branch
+            self._label = self._makeStringAttribute(attributes["label"])
+        if "state" in attributes:  # pragma no branch
+            self._state = self._makeStringAttribute(attributes["state"])
+        if "content_type" in attributes:  # pragma no branch
+            self._content_type = self._makeStringAttribute(attributes["content_type"])
+        if "size" in attributes:  # pragma no branch
+            self._size = self._makeIntAttribute(attributes["size"])
+        if "download_count" in attributes:  # pragma no branch
+            self._download_count = self._makeIntAttribute(attributes["download_count"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "updated_at" in attributes:  # pragma no branch
+            self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
+        if "uploader" in attributes:  # pragma no branch
+            self._uploader = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["uploader"])
+

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1783,7 +1783,6 @@ class Repository(github.GithubObject.CompletableGithubObject):
         )
         return github.Release.Release(self._requester, headers, data, completed=True)
 
-
     def get_release_by_tag(self, name):
         """
         :calls: `GET /repos/:owner/:repo/releases/:tag <http://developer.github.com/v3/repos/releases>`_
@@ -1795,7 +1794,6 @@ class Repository(github.GithubObject.CompletableGithubObject):
             self.url + "/releases/tags/" + str(name)
         )
         return github.Release.Release(self._requester, headers, data, completed=True)
-
 
     def get_stargazers(self):
         """

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -12,6 +12,7 @@
 # Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
 # Copyright 2013 martinqt <m.ki2@laposte.net>                                  #
 # Copyright 2015 Jannis Gebauer <ja.geb@me.com>                                #
+# Copyright 2015 Brett Weir <brett@lamestation.com>                            #
 #                                                                              #
 # This file is part of PyGithub. http://jacquev6.github.com/PyGithub/          #
 #                                                                              #
@@ -60,6 +61,7 @@ import github.Hook
 import github.Tag
 import github.GitTag
 import github.Download
+import github.Release
 import github.Permissions
 import github.Event
 import github.Legacy
@@ -1745,6 +1747,56 @@ class Repository(github.GithubObject.CompletableGithubObject):
         )
         return github.ContentFile.ContentFile(self._requester, headers, data, completed=True)
 
+    def get_release(self, id):
+        """
+        :calls: `GET /repos/:owner/:repo/releases/:id <http://developer.github.com/v3/repos/releases>`_
+        :param id: integer
+        :rtype: :class:`github.Release.Release`
+        """
+        assert isinstance(id, (int, long)), id
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/releases/" + str(id)
+        )
+        return github.Release.Release(self._requester, headers, data, completed=True)
+
+    def get_releases(self):
+        """
+        :calls: `GET /repos/:owner/:repo/releases <http://developer.github.com/v3/repos/releases>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Release.Release`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Release.Release,
+            self._requester,
+            self.url + "/releases",
+            None
+        )
+
+    def get_release_latest(self):
+        """
+        :calls: `GET /repos/:owner/:repo/releases/latest <http://developer.github.com/v3/repos/releases>`_
+        :rtype: :class:`github.Release.Release`
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/releases/latest"
+        )
+        return github.Release.Release(self._requester, headers, data, completed=True)
+
+
+    def get_release_by_tag(self, name):
+        """
+        :calls: `GET /repos/:owner/:repo/releases/:tag <http://developer.github.com/v3/repos/releases>`_
+        :rtype: :class:`github.Release.Release`
+        """
+        assert isinstance(name, (str, unicode)), name
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/releases/tags/" + str(name)
+        )
+        return github.Release.Release(self._requester, headers, data, completed=True)
+
+
     def get_stargazers(self):
         """
         :calls: `GET /repos/:owner/:repo/stargazers <http://developer.github.com/v3/activity/starring>`_
@@ -1872,37 +1924,6 @@ class Repository(github.GithubObject.CompletableGithubObject):
             self.url + "/tags",
             None
         )
-
-    def get_releases(self):
-        """
-        :calls: `GET /repos/:owner/:repo/releases <http://developer.github.com/v3/repos>`_
-        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Tag.Tag`
-        """
-        return github.PaginatedList.PaginatedList(
-            github.GitRelease.GitRelease,
-            self._requester,
-            self.url + "/releases",
-            None
-        )
-
-    def get_release(self, id):
-        """
-        :calls: `GET /repos/:owner/:repo/releases/:id https://developer.github.com/v3/repos/releases/#get-a-single-release
-        :param id: int (release id), str (tag name)
-        :rtype: None or :class:`github.GitRelease.GitRelease`
-        """
-        if isinstance(id, int):
-            headers, data = self._requester.requestJsonAndCheck(
-                "GET",
-                self.url + "/releases/" + str(id)
-            )
-            return github.GitRelease.GitRelease(self._requester, headers, data, completed=True)
-        elif isinstance(id, str):
-            headers, data = self._requester.requestJsonAndCheck(
-                "GET",
-                self.url + "/releases/tags/" + id
-            )
-            return github.GitRelease.GitRelease(self._requester, headers, data, completed=True)
 
     def get_teams(self):
         """

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -321,11 +321,11 @@ class Requester:
         if atLeastPython26:  # pragma no branch (Branch useful only with Python 2.5)
             kwds["timeout"] = self.__timeout  # Did not exist before Python2.6
 
-        ##
-        ## Connect through a proxy server with authentication, if http_proxy
-        ## set.
-        ## http_proxy: http://user:password@proxy_host:proxy_port
-        ##
+        #
+        # Connect through a proxy server with authentication, if http_proxy
+        # set.
+        # http_proxy: http://user:password@proxy_host:proxy_port
+        #
         proxy_uri = os.getenv('http_proxy') or os.getenv('HTTP_PROXY')
         if proxy_uri is not None:
             url = urlparse.urlparse(proxy_uri)


### PR DESCRIPTION
Hi guys,

I was using PyGithub to build a website yesterday, and found it was missing the release API, so I added it.

I later noticed that there seemed to already be an in-progress release API but it looked incomplete and didn't match the current API, so I kept going with it.

I also started on the Upload Asset function and discovered that the main API URL is hard-coded into Requester.py, so it'd take a lot more to get that feature to work.

Oh, I would have added to the development branch but there isn't one. >.>

Anyway, lemme know what you think.
