### PR TITLE
Handle rate limit: retry after requested delay

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -41,6 +41,7 @@ import sys
 import Consts
 import re
 import os
+import time
 
 atLeastPython26 = sys.hexversion >= 0x02060000
 atLeastPython3 = sys.hexversion >= 0x03000000
@@ -168,7 +169,16 @@ class Requester:
         self.__apiPreview = api_preview
 
     def requestJsonAndCheck(self, verb, url, parameters=None, headers=None, input=None, cnx=None):
-        return self.__check(*self.requestJson(verb, url, parameters, headers, input, cnx))
+        for i in range(3):
+            try:
+                (status, responseHeaders, output) = self.requestJson(verb, url, parameters, headers, input, cnx)
+                return self.__check(status, responseHeaders, output)
+            except GithubException.RateLimitExceededException:
+                delay = int(responseHeaders['x-ratelimit-reset']) - int(time.time())
+                logger = logging.getLogger(__name__)
+                logger.warning("rate limit reached, sleeping for %d seconds" % delay)
+                time.sleep(delay+1)
+        raise # couldn't get an answer after 3 attempts
 
     def requestMultipartAndCheck(self, verb, url, parameters=None, headers=None, input=None):
         return self.__check(*self.requestMultipart(verb, url, parameters, headers, input))

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -186,7 +186,7 @@ class Requester:
             cls = GithubException.TwoFactorException  # pragma no cover (Should be covered)
         elif status == 403 and output.get("message").startswith("Missing or invalid User Agent string"):
             cls = GithubException.BadUserAgentException
-        elif status == 403 and output.get("message").startswith("API Rate Limit Exceeded"):
+        elif status == 403 and output.get("message").startswith("API rate limit exceeded"):
             cls = GithubException.RateLimitExceededException
         elif status == 404 and output.get("message") == "Not Found":
             cls = GithubException.UnknownObjectException


### PR DESCRIPTION
This suggestion requires to update tests/RateLimiting.py, as the call doesn't fail anymore (that's the whole point of this PR).
