### PR TITLE
Expose target_commitish parameter

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -746,11 +746,11 @@ class Repository(github.GithubObject.CompletableGithubObject):
         )
         return github.GitRef.GitRef(self._requester, headers, data, completed=True)
 
-    def create_git_tag_and_release(self, tag, tag_message, release_name, release_message, object, type, tagger=github.GithubObject.NotSet, draft=False, prerelease=False):
+    def create_git_tag_and_release(self, tag, tag_message, release_name, release_message, object, type, tagger=github.GithubObject.NotSet, target_commitish=None, draft=False, prerelease=False):
         self.create_git_tag(tag, tag_message, object, type, tagger)
         return self.create_git_release(tag, release_name, release_message, draft, prerelease)
 
-    def create_git_release(self, tag, name, message, draft=False, prerelease=False):
+    def create_git_release(self, tag, name, message, target_commitish=None, draft=False, prerelease=False):
         assert isinstance(tag, (str, unicode)), tag
         assert isinstance(name, (str, unicode)), name
         assert isinstance(message, (str, unicode)), message
@@ -763,6 +763,8 @@ class Repository(github.GithubObject.CompletableGithubObject):
             "draft": draft,
             "prerelease": prerelease,
         }
+        if target_commitish:
+            post_parameters["target_commitish"] = target_commitish
         headers, data = self._requester.requestJsonAndCheck(
             "POST",
             self.url + "/releases",


### PR DESCRIPTION
In https://developer.github.com/v3/repos/releases/#create-a-release there is a parameter called `target_commitish` which makes it possible to tag objects other than the current head of the default branch of the repository.

Currently we are trying to create GitHub releases with PyGithub but it is in a broken state since all our releases so far are incorrectly tagged.

We've tested and confirmed that using this parameter fixes the problem.

Could we add this please?

Thanks in advance!
