### PR TITLE
add params to NamedUser.get_starred

### DIFF
--- a/github/NamedUser.py
+++ b/github/NamedUser.py
@@ -467,7 +467,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
             url_parameters
         )
 
-    def get_starred(self):
+    def get_starred(self, params=None):
         """
         :calls: `GET /users/:user/starred <http://developer.github.com/v3/activity/starring>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
@@ -476,10 +476,23 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
             github.Repository.Repository,
             self._requester,
             self.url + "/starred",
-            None
+            params
         )
 
-    def get_subscriptions(self):
+     def get_starred_with_dates(self, params=None):
+        """
+        :calls: `GET /users/:user/starred <http://developer.github.com/v3/activity/starring>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Repository.Repository,
+            self._requester,
+            self.url + "/starred",
+            params,
+            headers={'Accept': 'application/vnd.github.v3.star+json'}
+        )
+
+   def get_subscriptions(self):
         """
         :calls: `GET /users/:user/subscriptions <http://developer.github.com/v3/activity/watching>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`


### PR DESCRIPTION
This adds a way to pass parameters to `NamedUser.get_starred`. Github [accepts](https://developer.github.com/v3/activity/starring/#parameters)) parameters on that endpoint for sorting repositories by created or updated, and for ordering direction. 

This is particularly useful when a user has thousands of starred repos, and you don't want to make API calls on every PaginatedList. Instead, you can pass parameters to decide how to sort and order the returned repos.
