### PR TITLE
Fix for pickling exception when deserializing GithubException.

### DIFF
--- a/github/GithubException.py
+++ b/github/GithubException.py
@@ -36,6 +36,7 @@ class GithubException(Exception):
         Exception.__init__(self)
         self.__status = status
         self.__data = data
+        self.args = [status, data]
 
     @property
     def status(self):

--- a/github/tests/Exceptions.py
+++ b/github/tests/Exceptions.py
@@ -25,6 +25,7 @@
 
 import github
 import sys
+import pickle
 
 import Framework
 
@@ -113,6 +114,10 @@ class Exceptions(Framework.TestCase):  # To stay compatible with Python 2.6, we 
             else:
                 self.assertEqual(str(exception), "401 {'message': 'Bad credentials'}")  # pragma no cover (Covered with Python 3)
         self.assertTrue(raised)
+
+
+    def testExceptionPickling(self):
+        pickle.loads(pickle.dumps(github.GithubException('foo', 'bar')))
 
 
 class SpecificExceptions(Framework.TestCase):


### PR DESCRIPTION
See: https://bugs.python.org/issue9400

"Because CalledProcessError extends PyExc_BaseException, which defines a `__reduce__` method, that special method cause the pickle load to call the exception type's `__init__` method with packed `self.args` as arguments. So if a subclass of "Exception" needs to behave correctly in pickling, it should make `self.args` meet its `__init__` method's function signature. "


**Before:**
``` python
>>> from github import GithubException
>>> import pickle
>>> pickle.loads(pickle.dumps(GithubException('a', 'b')))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/pickle.py", line 1382, in loads
    return Unpickler(file).load()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/pickle.py", line 858, in load
    dispatch[key](self)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/pickle.py", line 1133, in load_reduce
    value = func(*args)
TypeError: __init__() takes exactly 3 arguments (1 given)
```

**After:**
```python
>>> from github import GithubException
>>> import pickle
>>> pickle.loads(pickle.dumps(GithubException('a', 'b')))
GithubException('a', 'b')
```