### PR TITLE
Added support to consider No proxy settings

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -51,6 +51,7 @@ else:  # pragma no cover (Covered by all tests with Python 2.5)
     import simplejson as json  # pragma no cover (Covered by all tests with Python 2.5)
 
 import GithubException
+from Utils import should_bypass_proxies
 
 
 class Requester:
@@ -327,7 +328,7 @@ class Requester:
         ## http_proxy: http://user:password@proxy_host:proxy_port
         ##
         proxy_uri = os.getenv('http_proxy') or os.getenv('HTTP_PROXY')
-        if proxy_uri is not None:
+        if not should_bypass_proxies(self.__base_url) and proxy_uri is not None:
             url = urlparse.urlparse(proxy_uri)
             conn = self.__connectionClass(url.hostname, url.port, **kwds)
             headers = {}

--- a/github/Utils.py
+++ b/github/Utils.py
@@ -1,0 +1,93 @@
+import os
+import socket
+import struct
+
+from urlparse import urlparse
+
+
+def is_ipv4_address(string_ip):
+    """ Check if the IP is an IPV4 address """
+    try:
+        socket.inet_aton(string_ip)
+    except socket.error:
+        return False
+
+    return True
+
+
+def is_valid_cidr(string_network):
+    """Very simple check of the cidr format in no_proxy variable"""
+    if string_network.count('/') == 1:
+        try:
+            mask = int(string_network.split('/')[1])
+        except ValueError:
+            return False
+
+        if mask < 1 or mask > 32:
+            return False
+
+        try:
+            socket.inet_aton(string_network.split('/')[0])
+        except socket.error:
+            return False
+    else:
+        return False
+    return True
+
+
+def dotted_netmask(mask):
+    """
+    Converts mask from /xx format to xxx.xxx.xxx.xxx
+    Example: if mask is 24 function returns 255.255.255.0
+    """
+    bits = 0xffffffff ^ (1 << 32 - mask) - 1
+    return socket.inet_ntoa(struct.pack('>I', bits))
+
+
+def address_in_network(ip, net):
+    """
+    This function allows you to check if on IP belongs to a network subnet
+    Example: returns True if ip = 192.168.1.1 and net = 192.168.1.0/24
+             returns False if ip = 192.168.1.1 and net = 192.168.100.0/24
+    """
+    ipaddr = struct.unpack('=L', socket.inet_aton(ip))[0]
+    netaddr, bits = net.split('/')
+    netmask = struct.unpack('=L', socket.inet_aton(dotted_netmask(int(bits))))[0]
+    network = struct.unpack('=L', socket.inet_aton(netaddr))[0] & netmask
+    return (ipaddr & netmask) == (network & netmask)
+
+
+def should_bypass_proxies(url):
+    """
+    Returns whether we should bypass proxies or not.
+    """
+    get_proxy = lambda k: os.environ.get(k) or os.environ.get(k.upper())
+
+    # First check whether no_proxy is defined. If it is, check that the URL
+    # we're getting isn't in the no_proxy list.
+    no_proxy = get_proxy('no_proxy')
+    netloc = urlparse(url).netloc
+
+    if no_proxy:
+        # We need to check whether we match here. We need to see if we match
+        # the end of the netloc, both with and without the port.
+        no_proxy = (
+            host for host in no_proxy.replace(' ', '').split(',') if host
+        )
+
+        ip = netloc.split(':')[0]
+        if is_ipv4_address(ip):
+            for proxy_ip in no_proxy:
+                if is_valid_cidr(proxy_ip):
+                    if address_in_network(ip, proxy_ip):
+                        return True
+                elif ip == proxy_ip:
+                    # Plain ip notations are handled here
+                    return True
+        else:
+            for host in no_proxy:
+                if netloc.endswith(host) or netloc.split(':')[0].endswith(host):
+                    # The URL does match something in no_proxy, so we don't want
+                    # to apply the proxies on this URL.
+                    return True
+    return False

--- a/github/tests/Utils.py
+++ b/github/tests/Utils.py
@@ -1,0 +1,73 @@
+import mock
+import sys
+import unittest
+
+from github.Utils import *
+
+atLeastPython3 = sys.hexversion >= 0x03000000
+TESTING_MODULE = "github.Utils"
+
+
+class Utils(unittest.TestCase):
+
+    def test_is_ipv4_address(self):
+        """ Test case to test is_ipv4_address """
+        ip = "198.168.1.1"
+        self.assertTrue(is_ipv4_address(ip))
+
+    def test_is_ipv4_address_with_invalid(self):
+        """ Test case to test is_ipv4_address with invalid IP """
+        ip = "github.com"
+        self.assertFalse(is_ipv4_address(ip))
+
+    def test_is_valid_cidr(self):
+        """ Test case to test is_valid_cidr """
+        data = (
+            ("192.168.1.1/32", True),
+            ("192.168.1.1", False),
+            ("192.168.1.1:5000", False),
+            ("192.168.1.1/0", False),
+            ("192.168.1.1/44", False),
+        )
+        for ip, expected in data:
+            self.assertEqual(is_valid_cidr(ip), expected, "IP {}, must return {}".format(ip, expected))
+
+    def test_address_in_network(self):
+        """ Test case to test address_in_network """
+        data = (
+            ("192.168.1.1", "192.168.1.0/24", True),
+            ("192.168.1.1", "192.168.100.0/24", False),
+        )
+        for ip, net, expected in data:
+            self.assertEqual(address_in_network(ip, net), expected, "IP {}, NET {}, must return {}".format(ip, net, expected))
+
+    @mock.patch(TESTING_MODULE + ".os")
+    def test_should_bypass_proxies(self, mock_os):
+        """ Test case to test address_in_network """
+        mock_os.environ = mock.MagicMock(spec=dict)
+        environ = {
+            'no_proxy': "192.168.1.1,192.168.1.3,.github.com",
+            "http_proxy": "http://user:pass@192.168.1.100:8080",
+            "https_proxy": "http://user:pass@192.168.1.100:8080",
+        }
+
+        def getitem(name):
+            return environ[name]
+
+        def setitem(name, val):
+            environ[name] = val
+
+        mock_os.environ.__getitem__.side_effect = getitem
+        mock_os.environ.get.side_effect = getitem
+        mock_os.environ.__setitem__.side_effect = setitem
+
+        data = (
+            ("http://192.168.1.1:8080", True),
+            ("http://dev.github.com", True),
+            ("http://google.com", False),
+            ("http://google.com:5000", False),
+            ("http://192.168.1.25", False),
+            ("http://192.168.1.25:8000", False),
+        )
+        for ip, expected in data:
+            self.assertEqual(should_bypass_proxies(ip), expected, "IP {}, must return {} to bypass proxy".format(ip, expected))


### PR DESCRIPTION
This change is to add support to no_proxy settings. 

Currently all requests are routed to proxy is a proxy is specified in `http_proxy` or `https_proxy`. But for Github enterprise servers such as ours we have dedicated servers on intranet hence the request should bypass proxy.
