### PR TITLE
Follow redirects in the case of a 301 status code

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -263,6 +263,7 @@ class Requester:
         return status, responseHeaders, output
 
     def __requestRaw(self, cnx, verb, url, requestHeaders, input):
+        original_cnx = cnx
         if cnx is None:
             cnx = self.__createConnection()
         else:
@@ -283,6 +284,9 @@ class Requester:
         cnx.close()
 
         self.__log(verb, url, requestHeaders, input, status, responseHeaders, output)
+
+        if status is 301 and 'location' in responseHeaders:
+            return self.__requestRaw(original_cnx, verb, responseHeaders['location'], requestHeaders, input)
 
         return status, responseHeaders, output
 


### PR DESCRIPTION
PyGithub does not follow HTTP redirects. This issue is visible when a repository is moved on GitHub. GitHub returns a proper 301 with a new location for the resource, but httplib does not follow redirects on it's own.

This PR ensures it follow redirects when a 301 is returned and a location header is provided in the response.

I was unable to add a test case for it as it does not seem possible to have multiple exchanges while using ReplayingConnection.

Here is an example curl (test_redirect was renamed to test_redirect_new_name)
```
~$ curl -v https://api.github.com/repos/mat128/test_redirect
* Adding handle: conn: 0x7fb7a9804000
* Adding handle: send: 0
* Adding handle: recv: 0
* Curl_addHandleToPipeline: length: 1
* - Conn 0 (0x7fb7a9804000) send_pipe: 1, recv_pipe: 0
* About to connect() to api.github.com port 443 (#0)
*   Trying 192.30.252.126...
* Connected to api.github.com (192.30.252.126) port 443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
* Server certificate: *.github.com
* Server certificate: DigiCert SHA2 High Assurance Server CA
* Server certificate: DigiCert High Assurance EV Root CA
> GET /repos/mat128/test_redirect HTTP/1.1
> User-Agent: curl/7.30.0
> Host: api.github.com
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
* Server GitHub.com is not blacklisted
< Server: GitHub.com
< Date: Fri, 27 May 2016 13:28:20 GMT
< Content-Type: application/json; charset=utf-8
< Content-Length: 168
< Status: 301 Moved Permanently
< X-RateLimit-Limit: 60
< X-RateLimit-Remaining: 55
< X-RateLimit-Reset: 1464359212
< Location: https://api.github.com/repositories/59836255
< X-GitHub-Media-Type: github.v3
< Access-Control-Expose-Headers: ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
< Access-Control-Allow-Origin: *
< Content-Security-Policy: default-src 'none'
< Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
< X-Content-Type-Options: nosniff
< X-Frame-Options: deny
< X-XSS-Protection: 1; mode=block
< Vary: Accept-Encoding
< X-Served-By: 2811da37fbdda4367181b328b22b2499
< X-GitHub-Request-Id: 6CA39808:1C0C2:B6973CA:57484B74
<
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/59836255",
  "documentation_url": "https://developer.github.com/v3/#http-redirects"
}
* Connection #0 to host api.github.com left intact
```

Using curl's --location parameter, it correctly follows the redirect:

```
~$ curl -v --location https://api.github.com/repos/mat128/test_redirect
* Adding handle: conn: 0x7ffdc2804000
* Adding handle: send: 0
* Adding handle: recv: 0
* Curl_addHandleToPipeline: length: 1
* - Conn 0 (0x7ffdc2804000) send_pipe: 1, recv_pipe: 0
* About to connect() to api.github.com port 443 (#0)
*   Trying 192.30.252.125...
* Connected to api.github.com (192.30.252.125) port 443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
* Server certificate: *.github.com
* Server certificate: DigiCert SHA2 High Assurance Server CA
* Server certificate: DigiCert High Assurance EV Root CA
> GET /repos/mat128/test_redirect HTTP/1.1
> User-Agent: curl/7.30.0
> Host: api.github.com
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
* Server GitHub.com is not blacklisted
< Server: GitHub.com
< Date: Fri, 27 May 2016 13:29:26 GMT
< Content-Type: application/json; charset=utf-8
< Content-Length: 168
< Status: 301 Moved Permanently
< X-RateLimit-Limit: 60
< X-RateLimit-Remaining: 54
< X-RateLimit-Reset: 1464359212
< Location: https://api.github.com/repositories/59836255
< X-GitHub-Media-Type: github.v3
< Access-Control-Expose-Headers: ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
< Access-Control-Allow-Origin: *
< Content-Security-Policy: default-src 'none'
< Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
< X-Content-Type-Options: nosniff
< X-Frame-Options: deny
< X-XSS-Protection: 1; mode=block
< Vary: Accept-Encoding
< X-Served-By: bd82876e9bf04990f289ba22f246ee9b
< X-GitHub-Request-Id: 6CA39808:12715:602129C:57484BB6
<
* Ignoring the response-body
* Connection #0 to host api.github.com left intact
* Issue another request to this URL: 'https://api.github.com/repositories/59836255'
* Found bundle for host api.github.com: 0x7ffdc2415340
* Re-using existing connection! (#0) with host api.github.com
* Connected to api.github.com (192.30.252.125) port 443 (#0)
* Adding handle: conn: 0x7ffdc2804000
* Adding handle: send: 0
* Adding handle: recv: 0
* Curl_addHandleToPipeline: length: 1
* - Conn 0 (0x7ffdc2804000) send_pipe: 1, recv_pipe: 0
> GET /repositories/59836255 HTTP/1.1
> User-Agent: curl/7.30.0
> Host: api.github.com
> Accept: */*
>
< HTTP/1.1 200 OK
* Server GitHub.com is not blacklisted
< Server: GitHub.com
< Date: Fri, 27 May 2016 13:29:26 GMT
< Content-Type: application/json; charset=utf-8
< Content-Length: 5478
< Status: 200 OK
< X-RateLimit-Limit: 60
< X-RateLimit-Remaining: 53
< X-RateLimit-Reset: 1464359212
< Cache-Control: public, max-age=60, s-maxage=60
< Vary: Accept
< ETag: "b05d4f4a2ac7c32e1fed5e1ee2ef40ac"
< Last-Modified: Fri, 27 May 2016 13:27:48 GMT
< X-GitHub-Media-Type: github.v3
< Access-Control-Expose-Headers: ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
< Access-Control-Allow-Origin: *
< Content-Security-Policy: default-src 'none'
< Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
< X-Content-Type-Options: nosniff
< X-Frame-Options: deny
< X-XSS-Protection: 1; mode=block
< Vary: Accept-Encoding
< X-Served-By: 2d7a5e35115884240089368322196939
< X-GitHub-Request-Id: 6CA39808:12715:60212AE:57484BB6
<
{
  "id": 59836255,
  "name": "test_redirect_new_name",
  "full_name": "mat128/test_redirect_new_name",
  "owner": {
    "login": "mat128",
    "id": 234168,
    "avatar_url": "https://avatars.githubusercontent.com/u/234168?v=3",
    "gravatar_id": "",
    "url": "https://api.github.com/users/mat128",
    "html_url": "https://github.com/mat128",
    "followers_url": "https://api.github.com/users/mat128/followers",
    "following_url": "https://api.github.com/users/mat128/following{/other_user}",
    "gists_url": "https://api.github.com/users/mat128/gists{/gist_id}",
    "starred_url": "https://api.github.com/users/mat128/starred{/owner}{/repo}",
    "subscriptions_url": "https://api.github.com/users/mat128/subscriptions",
    "organizations_url": "https://api.github.com/users/mat128/orgs",
    "repos_url": "https://api.github.com/users/mat128/repos",
    "events_url": "https://api.github.com/users/mat128/events{/privacy}",
    "received_events_url": "https://api.github.com/users/mat128/received_events",
    "type": "User",
    "site_admin": false
  },
  "private": false,
  "html_url": "https://github.com/mat128/test_redirect_new_name",
  "description": "",
  "fork": false,
  "url": "https://api.github.com/repos/mat128/test_redirect_new_name",
  "forks_url": "https://api.github.com/repos/mat128/test_redirect_new_name/forks",
  "keys_url": "https://api.github.com/repos/mat128/test_redirect_new_name/keys{/key_id}",
  "collaborators_url": "https://api.github.com/repos/mat128/test_redirect_new_name/collaborators{/collaborator}",
  "teams_url": "https://api.github.com/repos/mat128/test_redirect_new_name/teams",
  "hooks_url": "https://api.github.com/repos/mat128/test_redirect_new_name/hooks",
  "issue_events_url": "https://api.github.com/repos/mat128/test_redirect_new_name/issues/events{/number}",
  "events_url": "https://api.github.com/repos/mat128/test_redirect_new_name/events",
  "assignees_url": "https://api.github.com/repos/mat128/test_redirect_new_name/assignees{/user}",
  "branches_url": "https://api.github.com/repos/mat128/test_redirect_new_name/branches{/branch}",
  "tags_url": "https://api.github.com/repos/mat128/test_redirect_new_name/tags",
  "blobs_url": "https://api.github.com/repos/mat128/test_redirect_new_name/git/blobs{/sha}",
  "git_tags_url": "https://api.github.com/repos/mat128/test_redirect_new_name/git/tags{/sha}",
  "git_refs_url": "https://api.github.com/repos/mat128/test_redirect_new_name/git/refs{/sha}",
  "trees_url": "https://api.github.com/repos/mat128/test_redirect_new_name/git/trees{/sha}",
  "statuses_url": "https://api.github.com/repos/mat128/test_redirect_new_name/statuses/{sha}",
  "languages_url": "https://api.github.com/repos/mat128/test_redirect_new_name/languages",
  "stargazers_url": "https://api.github.com/repos/mat128/test_redirect_new_name/stargazers",
  "contributors_url": "https://api.github.com/repos/mat128/test_redirect_new_name/contributors",
  "subscribers_url": "https://api.github.com/repos/mat128/test_redirect_new_name/subscribers",
  "subscription_url": "https://api.github.com/repos/mat128/test_redirect_new_name/subscription",
  "commits_url": "https://api.github.com/repos/mat128/test_redirect_new_name/commits{/sha}",
  "git_commits_url": "https://api.github.com/repos/mat128/test_redirect_new_name/git/commits{/sha}",
  "comments_url": "https://api.github.com/repos/mat128/test_redirect_new_name/comments{/number}",
  "issue_comment_url": "https://api.github.com/repos/mat128/test_redirect_new_name/issues/comments{/number}",
  "contents_url": "https://api.github.com/repos/mat128/test_redirect_new_name/contents/{+path}",
  "compare_url": "https://api.github.com/repos/mat128/test_redirect_new_name/compare/{base}...{head}",
  "merges_url": "https://api.github.com/repos/mat128/test_redirect_new_name/merges",
  "archive_url": "https://api.github.com/repos/mat128/test_redirect_new_name/{archive_format}{/ref}",
  "downloads_url": "https://api.github.com/repos/mat128/test_redirect_new_name/downloads",
  "issues_url": "https://api.github.com/repos/mat128/test_redirect_new_name/issues{/number}",
  "pulls_url": "https://api.github.com/repos/mat128/test_redirect_new_name/pulls{/number}",
  "milestones_url": "https://api.github.com/repos/mat128/test_redirect_new_name/milestones{/number}",
  "notifications_url": "https://api.github.com/repos/mat128/test_redirect_new_name/notifications{?since,all,participating}",
  "labels_url": "https://api.github.com/repos/mat128/test_redirect_new_name/labels{/name}",
  "releases_url": "https://api.github.com/repos/mat128/test_redirect_new_name/releases{/id}",
  "deployments_url": "https://api.github.com/repos/mat128/test_redirect_new_name/deployments",
  "created_at": "2016-05-27T13:27:40Z",
  "updated_at": "2016-05-27T13:27:48Z",
  "pushed_at": "2016-05-27T13:27:41Z",
  "git_url": "git://github.com/mat128/test_redirect_new_name.git",
  "ssh_url": "git@github.com:mat128/test_redirect_new_name.git",
  "clone_url": "https://github.com/mat128/test_redirect_new_name.git",
  "svn_url": "https://github.com/mat128/test_redirect_new_name",
  "homepage": null,
  "size": 0,
  "stargazers_count": 0,
  "watchers_count": 0,
  "language": null,
  "has_issues": true,
  "has_downloads": true,
  "has_wiki": true,
  "has_pages": false,
  "forks_count": 0,
  "mirror_url": null,
  "open_issues_count": 0,
  "forks": 0,
  "open_issues": 0,
  "watchers": 0,
  "default_branch": "master",
  "network_count": 0,
  "subscribers_count": 1
}
* Connection #0 to host api.github.com left intact
```

I have manually tested the code included in the PR with success.