### PR TITLE
Document how one gets an AuthenticatedUser object

### DIFF
--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -45,6 +45,8 @@ import github.Notification
 class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
     """
     This class represents AuthenticatedUsers as returned for example by http://developer.github.com/v3/todo
+    
+    An AuthenticatedUser object can be created by calling ``get_user()`` on a Github object.
     """
 
     @property


### PR DESCRIPTION
I just spent an embarrassing number of minutes trying to figure out why calling `get_user('edunham')` was returning a `NamedUser` object and how I was supposed to get an `AuthenticatedUser` instead. 

It seems that I'm also [not the first](http://stackoverflow.com/questions/28675121/how-to-create-a-new-repository-with-pygithub/38212843) to run into the issue of "where does an AuthenticatedUser object come from?". 

The docs for AuthenticatedUser were the first place I looked for the solution, so they seem like a sensible place to leave hints for future people encountering the same frustrations.