### PR TITLE
added add_to_members to organization

### DIFF
--- a/github/Organization.py
+++ b/github/Organization.py
@@ -288,6 +288,23 @@ class Organization(github.GithubObject.CompletableGithubObject):
             self.url + "/public_members/" + public_member._identity
         )
 
+    def add_to_members(self, member, role=github.GithubObject.NotSet):
+        """
+        :calls: `PUT /orgs/:org/memberships/:user <http://developer.github.com/v3/orgs/members>`_
+        :param member: :class:`github.NamedUser.NamedUser`
+        :param role: string
+        :rtype: None
+        """
+        assert isinstance(role, (str, unicode)), role
+        assert isinstance(member, github.NamedUser.NamedUser), member
+        url_parameters = {
+            "role": role,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "PUT",
+            self.url + "/memberships/" + member._identity, parameters=url_parameters
+        )
+
     def create_fork(self, repo):
         """
         :calls: `POST /repos/:owner/:repo/forks <http://developer.github.com/v3/repos/forks>`_

--- a/github/tests/Organization.py
+++ b/github/tests/Organization.py
@@ -91,6 +91,14 @@ class Organization(Framework.TestCase):
         self.org.remove_from_public_members(lyloa)
         self.assertFalse(self.org.has_in_public_members(lyloa))
 
+    def testAddMembers(self):
+        lyloa = self.g.get_user("Lyloa")
+        self.assertFalse(self.org.has_in_members(lyloa))
+        self.org.add_to_members(lyloa, role='member')
+        self.assertTrue(self.org.has_in_members(lyloa))
+        self.org.remove_from_members(lyloa)
+        self.assertFalse(self.org.has_in_members(lyloa))
+
     def testGetPublicMembers(self):
         self.assertListKeyEqual(self.org.get_public_members(), lambda u: u.login, ["jacquev6"])
 

--- a/github/tests/Organization.py
+++ b/github/tests/Organization.py
@@ -91,14 +91,6 @@ class Organization(Framework.TestCase):
         self.org.remove_from_public_members(lyloa)
         self.assertFalse(self.org.has_in_public_members(lyloa))
 
-    def testAddMembers(self):
-        lyloa = self.g.get_user("Lyloa")
-        self.assertFalse(self.org.has_in_members(lyloa))
-        self.org.add_to_members(lyloa, role='member')
-        self.assertTrue(self.org.has_in_members(lyloa))
-        self.org.remove_from_members(lyloa)
-        self.assertFalse(self.org.has_in_members(lyloa))
-
     def testGetPublicMembers(self):
         self.assertListKeyEqual(self.org.get_public_members(), lambda u: u.login, ["jacquev6"])
 


### PR DESCRIPTION
#399

Currently, there is no implementation of the add to (nonpublic) members. I copied the add_public_members function and lightly edited it to match the endpoint.
