### PR TITLE
Changed default laziness of get_repo() to False

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -190,7 +190,7 @@ class Github(object):
         )
         return github.Organization.Organization(self.__requester, headers, data, completed=True)
 
-    def get_repo(self, full_name_or_id, lazy=True):
+    def get_repo(self, full_name_or_id, lazy=False):
         """
         :calls: `GET /repos/:owner/:repo <http://developer.github.com/v3/repos>`_ or `GET /repositories/:id <http://developer.github.com/v3/repos>`_
         :rtype: :class:`github.Repository.Repository`


### PR DESCRIPTION
A potential fix for #353 

The optional argument "lazy" in the function determines whether it actually checks for the existence of the repo. Users can get around this by simply including "False" as a second argument when calling it. 

Alternatively, this fix makes the default behavior of the function to check for the repo and return 404 if it doesn't exist, as it used to be. 
