### PR TITLE
Properly handle HTTP Proxy authentication with Python 3

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -338,7 +338,7 @@ class Requester:
             headers = {}
             if url.username and url.password:
                 auth = '%s:%s' % (url.username, url.password)
-                if atLeastPython3 and isinstance(auth,str):
+                if atLeastPython3 and isinstance(auth, str):
                     headers['Proxy-Authorization'] = 'Basic ' + base64.b64encode(auth.encode()).decode()
                 else:
                     headers['Proxy-Authorization'] = 'Basic ' + base64.b64encode(auth)

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -338,7 +338,10 @@ class Requester:
             headers = {}
             if url.username and url.password:
                 auth = '%s:%s' % (url.username, url.password)
-                headers['Proxy-Authorization'] = 'Basic ' + base64.b64encode(auth)
+                if atLeastPython3 and isinstance(auth,str):
+                    headers['Proxy-Authorization'] = 'Basic ' + base64.b64encode(auth.encode()).decode()
+                else:
+                    headers['Proxy-Authorization'] = 'Basic ' + base64.b64encode(auth)
             conn.set_tunnel(self.__hostname, self.__port, headers)
         else:
             conn = self.__connectionClass(self.__hostname, self.__port, **kwds)


### PR DESCRIPTION
PyGithub doesn't properly handle HTTP Proxy authentication under Python 3, as it tries to pass a string to base64.b64encode(), when under Python 3 it needs to be a byte-like object.

Simple test case:

- Set your HTTP_PROXY environment variable to point at a valid HTTP proxy that requires authentication.
- Try to run the simple reproducer code below:
```
#!/usr/bin/env python3
from github import Github
gh=Github("jaredsmith","obviouslynotmyrealpassword")
org_object=gh.get_organization("PyGithub")
```
- Notice that it throws the following error:
```
TypeError: a bytes-like object is required, not 'str'
```