### PR TITLE
Nicer __repr__ for GithubObjects

### DIFF
--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -50,6 +50,9 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
     An AuthenticatedUser object can be created by calling ``get_user()`` on a Github object.
     """
 
+    def __repr__(self):
+        return self.get__repr__({"login": self._login.value})
+
     @property
     def avatar_url(self):
         """

--- a/github/Authorization.py
+++ b/github/Authorization.py
@@ -35,6 +35,9 @@ class Authorization(github.GithubObject.CompletableGithubObject):
     This class represents Authorizations as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"scopes": self._scopes.value})
+
     @property
     def app(self):
         """

--- a/github/AuthorizationApplication.py
+++ b/github/AuthorizationApplication.py
@@ -33,6 +33,9 @@ class AuthorizationApplication(github.GithubObject.CompletableGithubObject):
     This class represents AuthorizationApplications as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"name": self._name.value})
+
     @property
     def name(self):
         """

--- a/github/Branch.py
+++ b/github/Branch.py
@@ -36,6 +36,9 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
     This class represents Branchs. The reference can be found here http://developer.github.com/v3/repos/#list-branches
     """
 
+    def __repr__(self):
+        return self.get__repr__({"name": self._name.value})
+
     @property
     def commit(self):
         """

--- a/github/Commit.py
+++ b/github/Commit.py
@@ -43,6 +43,9 @@ class Commit(github.GithubObject.CompletableGithubObject):
     This class represents Commits. The reference can be found here http://developer.github.com/v3/git/commits/
     """
 
+    def __repr__(self):
+        return self.get__repr__({"sha": self._sha.value})
+
     @property
     def author(self):
         """

--- a/github/CommitCombinedStatus.py
+++ b/github/CommitCombinedStatus.py
@@ -36,6 +36,9 @@ class CommitCombinedStatus(github.GithubObject.NonCompletableGithubObject):
     This class represents CommitCombinedStatus as returned for example by https://developer.github.com/v3/repos/statuses/
     """
 
+    def __repr__(self):
+        return self.get__repr__({"sha": self._sha.value, "state": self._state.value})
+
     @property
     def state(self):
         """

--- a/github/CommitComment.py
+++ b/github/CommitComment.py
@@ -35,6 +35,9 @@ class CommitComment(github.GithubObject.CompletableGithubObject):
     This class represents CommitComments as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"id": self._id.value, "user": self.user})
+
     @property
     def body(self):
         """

--- a/github/CommitStatus.py
+++ b/github/CommitStatus.py
@@ -35,6 +35,13 @@ class CommitStatus(github.GithubObject.NonCompletableGithubObject):
     This class represents CommitStatuss as returned for example by https://developer.github.com/v3/repos/statuses/
     """
 
+    def __repr__(self):
+        return self.get__repr__({
+            "id": self._id.value,
+            "state": self._state.value,
+            "context": self._context.value
+        })
+
     @property
     def created_at(self):
         """

--- a/github/ContentFile.py
+++ b/github/ContentFile.py
@@ -40,6 +40,9 @@ class ContentFile(github.GithubObject.CompletableGithubObject):
     This class represents ContentFiles as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"path": self._path.value})
+
     @property
     def content(self):
         """

--- a/github/Download.py
+++ b/github/Download.py
@@ -33,6 +33,9 @@ class Download(github.GithubObject.CompletableGithubObject):
     This class represents Downloads as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"id": self._id.value})
+
     @property
     def accesskeyid(self):
         """

--- a/github/Event.py
+++ b/github/Event.py
@@ -38,6 +38,9 @@ class Event(github.GithubObject.NonCompletableGithubObject):
     This class represents Events. The reference can be found here http://developer.github.com/v3/activity/events/
     """
 
+    def __repr__(self):
+        return self.get__repr__({"id": self._id.value, "type": self._type.value})
+
     @property
     def actor(self):
         """

--- a/github/File.py
+++ b/github/File.py
@@ -33,6 +33,9 @@ class File(github.GithubObject.NonCompletableGithubObject):
     This class represents Files as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"sha": self._sha.value, "filename": self._filename.value})
+
     @property
     def additions(self):
         """

--- a/github/Gist.py
+++ b/github/Gist.py
@@ -40,6 +40,9 @@ class Gist(github.GithubObject.CompletableGithubObject):
     This class represents Gists as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"id": self._id.value})
+
     @property
     def comments(self):
         """

--- a/github/GistComment.py
+++ b/github/GistComment.py
@@ -35,6 +35,9 @@ class GistComment(github.GithubObject.CompletableGithubObject):
     This class represents GistComments as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"id": self._id.value, "user": self._user.value})
+
     @property
     def body(self):
         """

--- a/github/GistFile.py
+++ b/github/GistFile.py
@@ -33,6 +33,9 @@ class GistFile(github.GithubObject.NonCompletableGithubObject):
     This class represents GistFiles as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"filename": self._filename.value})
+
     @property
     def content(self):
         """

--- a/github/GitAuthor.py
+++ b/github/GitAuthor.py
@@ -33,6 +33,9 @@ class GitAuthor(github.GithubObject.NonCompletableGithubObject):
     This class represents GitAuthors as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"name": self._name.value})
+
     @property
     def date(self):
         """

--- a/github/GitBlob.py
+++ b/github/GitBlob.py
@@ -33,6 +33,9 @@ class GitBlob(github.GithubObject.CompletableGithubObject):
     This class represents GitBlobs as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"sha": self._sha.value})
+
     @property
     def content(self):
         """

--- a/github/GitCommit.py
+++ b/github/GitCommit.py
@@ -36,6 +36,9 @@ class GitCommit(github.GithubObject.CompletableGithubObject):
     This class represents GitCommits as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"sha": self._sha.value})
+
     @property
     def author(self):
         """

--- a/github/GitObject.py
+++ b/github/GitObject.py
@@ -33,6 +33,9 @@ class GitObject(github.GithubObject.NonCompletableGithubObject):
     This class represents GitObjects as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"sha": self._sha.value})
+
     @property
     def sha(self):
         """

--- a/github/GitRef.py
+++ b/github/GitRef.py
@@ -35,6 +35,9 @@ class GitRef(github.GithubObject.CompletableGithubObject):
     This class represents GitRefs as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"ref": self._ref.value})
+
     @property
     def object(self):
         """
@@ -89,6 +92,22 @@ class GitRef(github.GithubObject.CompletableGithubObject):
             input=post_parameters
         )
         self._useAttributes(data)
+
+    def get_statuses(self):
+        """
+        https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
+        :calls: `GET /repos/:owner/:repo/commits/:ref/statuses`
+        :return:
+        """
+        pass
+
+    def get_status(self):
+        """
+        https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
+        :calls: `GET /repos/:owner/:repo/commits/:ref/status`
+        :return:
+        """
+        pass
 
     def _initAttributes(self):
         self._object = github.GithubObject.NotSet

--- a/github/GitRelease.py
+++ b/github/GitRelease.py
@@ -31,6 +31,9 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
     This class represents GitRelease as returned for example by https://developer.github.com/v3/repos/releases
     """
 
+    def __repr__(self):
+        return self.get__repr__({"title": self._title.value})
+
     @property
     def body(self):
         """

--- a/github/GitTag.py
+++ b/github/GitTag.py
@@ -36,6 +36,9 @@ class GitTag(github.GithubObject.CompletableGithubObject):
     This class represents GitTags as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"sha": self._sha.value, "tag": self._tag.value})
+
     @property
     def message(self):
         """

--- a/github/GitTree.py
+++ b/github/GitTree.py
@@ -35,6 +35,9 @@ class GitTree(github.GithubObject.CompletableGithubObject):
     This class represents GitTrees as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"sha": self._sha.value})
+
     @property
     def sha(self):
         """

--- a/github/GitTreeElement.py
+++ b/github/GitTreeElement.py
@@ -33,6 +33,9 @@ class GitTreeElement(github.GithubObject.NonCompletableGithubObject):
     This class represents GitTreeElements as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"sha": self._sha.value, "path": self._path.value})
+
     @property
     def mode(self):
         """

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -219,7 +219,7 @@ class GithubObject(object):
                 items = params.items()
             else:
                 items = list(params.items())
-            for k, v in sorted(items, key=itemgetter(1)):
+            for k, v in sorted(items, key=itemgetter(0), reverse=True):
                 yield '{k}="{v}"'.format(k=k, v=v) if isinstance(v, (str, unicode)) else '{k}={v}'.format(k=k, v=v)
         return '{class_name}({params})'.format(
             class_name=self.__class__.__name__,

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -24,11 +24,14 @@
 # along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
 #                                                                              #
 # ##############################################################################
-
+import sys
 import datetime
+from operator import itemgetter
 
 import GithubException
 import Consts
+
+atLeastPython3 = sys.hexversion >= 0x03000000
 
 
 class _NotSetType:
@@ -206,6 +209,22 @@ class GithubObject(object):
         :type: str
         '''
         return self._headers.get(Consts.RES_LAST_MODIFED)
+
+    def get__repr__(self, params):
+        """
+        Converts the object to a nicely printable string.
+        """
+        def format_params(params):
+            if atLeastPython3:
+                items = params.items()
+            else:
+                items = list(params.items())
+            for k, v in sorted(items, key=itemgetter(1)):
+                yield '{k}="{v}"'.format(k=k, v=v) if isinstance(v, (str, unicode)) else '{k}={v}'.format(k=k, v=v)
+        return '{class_name}({params})'.format(
+            class_name=self.__class__.__name__,
+            params=", ".join(list(format_params(params)))
+        )
 
 
 class NonCompletableGithubObject(GithubObject):

--- a/github/GitignoreTemplate.py
+++ b/github/GitignoreTemplate.py
@@ -32,6 +32,9 @@ class GitignoreTemplate(github.GithubObject.NonCompletableGithubObject):
     This class represents GitignoreTemplates as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"name": self._name.value})
+
     @property
     def source(self):
         """

--- a/github/Hook.py
+++ b/github/Hook.py
@@ -35,6 +35,9 @@ class Hook(github.GithubObject.CompletableGithubObject):
     This class represents Hooks as returned for example by http://developer.github.com/v3/repos/hooks
     """
 
+    def __repr__(self):
+        return self.get__repr__({"id": self._id.value, "url": self._url.value})
+
     @property
     def active(self):
         """

--- a/github/HookDescription.py
+++ b/github/HookDescription.py
@@ -33,6 +33,9 @@ class HookDescription(github.GithubObject.NonCompletableGithubObject):
     This class represents HookDescriptions as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"name": self._name.value})
+
     @property
     def events(self):
         """

--- a/github/HookResponse.py
+++ b/github/HookResponse.py
@@ -33,6 +33,9 @@ class HookResponse(github.GithubObject.NonCompletableGithubObject):
     This class represents HookResponses as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"status": self._status.value})
+
     @property
     def code(self):
         """

--- a/github/InputGitAuthor.py
+++ b/github/InputGitAuthor.py
@@ -46,6 +46,9 @@ class InputGitAuthor(object):
         self.__email = email
         self.__date = date
 
+    def __repr__(self):
+        return 'InputGitAuthor(name="{}")'.format(self.__name)
+
     @property
     def _identity(self):
         identity = {

--- a/github/Issue.py
+++ b/github/Issue.py
@@ -47,6 +47,9 @@ class Issue(github.GithubObject.CompletableGithubObject):
     This class represents Issues as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"number": self._number.value, "title": self._title.value})
+
     @property
     def assignee(self):
         """

--- a/github/IssueComment.py
+++ b/github/IssueComment.py
@@ -36,6 +36,9 @@ class IssueComment(github.GithubObject.CompletableGithubObject):
     This class represents IssueComments as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"id": self._id.value, "user": self._user.value})
+
     @property
     def body(self):
         """

--- a/github/IssueEvent.py
+++ b/github/IssueEvent.py
@@ -36,6 +36,9 @@ class IssueEvent(github.GithubObject.CompletableGithubObject):
     This class represents IssueEvents as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"id": self._id.value})
+    
     @property
     def actor(self):
         """

--- a/github/Label.py
+++ b/github/Label.py
@@ -36,6 +36,9 @@ class Label(github.GithubObject.CompletableGithubObject):
     This class represents Labels. The reference can be found here http://developer.github.com/v3/issues/labels/
     """
 
+    def __repr__(self):
+        return self.get__repr__({"name": self._name.value})
+
     @property
     def color(self):
         """

--- a/github/Milestone.py
+++ b/github/Milestone.py
@@ -40,6 +40,9 @@ class Milestone(github.GithubObject.CompletableGithubObject):
     This class represents Milestones. The reference can be found here http://developer.github.com/v3/issues/milestones/
     """
 
+    def __repr__(self):
+        return self.get__repr__({"number": self._number.value})
+
     @property
     def closed_issues(self):
         """

--- a/github/NamedUser.py
+++ b/github/NamedUser.py
@@ -42,6 +42,9 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
     This class represents NamedUsers as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"login": self._login.value})
+
     @property
     def avatar_url(self):
         """

--- a/github/Notification.py
+++ b/github/Notification.py
@@ -36,6 +36,9 @@ class Notification(github.GithubObject.CompletableGithubObject):
     This class represents Notifications. The reference can be found here http://developer.github.com/v3/activity/notifications/
     """
 
+    def __repr__(self):
+        return self.get__repr__({"id": self._id.value, "subject": self._subject.value})
+
     @property
     def id(self):
         """

--- a/github/NotificationSubject.py
+++ b/github/NotificationSubject.py
@@ -31,6 +31,9 @@ class NotificationSubject(github.GithubObject.NonCompletableGithubObject):
     This class represents Subjects of Notifications as returned for example by http://developer.github.com/v3/activity/notifications/#list-your-notifications
     """
 
+    def __repr__(self):
+        return self.get__repr__({"title": self._title.value})
+
     @property
     def title(self):
         """

--- a/github/Organization.py
+++ b/github/Organization.py
@@ -44,6 +44,9 @@ class Organization(github.GithubObject.CompletableGithubObject):
     This class represents Organizations. The reference can be found here http://developer.github.com/v3/orgs/
     """
 
+    def __repr__(self):
+        return self.get__repr__({"id": self._id.value, "name": self._name.value})
+
     @property
     def avatar_url(self):
         """

--- a/github/Permissions.py
+++ b/github/Permissions.py
@@ -33,6 +33,13 @@ class Permissions(github.GithubObject.NonCompletableGithubObject):
     This class represents Permissionss as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({
+            "admin": self._admin.value,
+            "pull": self._pull.value,
+            "push": self._push.value
+        })
+
     @property
     def admin(self):
         """

--- a/github/Plan.py
+++ b/github/Plan.py
@@ -33,6 +33,9 @@ class Plan(github.GithubObject.NonCompletableGithubObject):
     This class represents Plans as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"name": self._name.value})
+
     @property
     def collaborators(self):
         """

--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -44,6 +44,9 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
     This class represents PullRequests. The reference can be found here http://developer.github.com/v3/pulls/
     """
 
+    def __repr__(self):
+        return self.get__repr__({"number": self._number.value, "title": self._title.value})
+
     @property
     def additions(self):
         """

--- a/github/PullRequestComment.py
+++ b/github/PullRequestComment.py
@@ -37,6 +37,9 @@ class PullRequestComment(github.GithubObject.CompletableGithubObject):
     This class represents PullRequestComments. The reference can be found here http://developer.github.com/v3/pulls/comments/
     """
 
+    def __repr__(self):
+        return self.get__repr__({"id": self._id.value, "user": self._user.value})
+
     @property
     def body(self):
         """

--- a/github/PullRequestMergeStatus.py
+++ b/github/PullRequestMergeStatus.py
@@ -34,6 +34,9 @@ class PullRequestMergeStatus(github.GithubObject.NonCompletableGithubObject):
     This class represents PullRequestMergeStatuss. The reference can be found here http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged
     """
 
+    def __repr__(self):
+        return self.get__repr__({"sha": self._sha.value, "merged": self._merged.value})
+
     @property
     def merged(self):
         """

--- a/github/PullRequestPart.py
+++ b/github/PullRequestPart.py
@@ -36,6 +36,9 @@ class PullRequestPart(github.GithubObject.NonCompletableGithubObject):
     This class represents PullRequestParts as returned for example by http://developer.github.com/v3/todo
     """
 
+    def __repr__(self):
+        return self.get__repr__({"sha": self._sha.value})
+
     @property
     def label(self):
         """

--- a/github/Rate.py
+++ b/github/Rate.py
@@ -31,6 +31,9 @@ class Rate(github.GithubObject.NonCompletableGithubObject):
     This class represents rate limits as defined in http://developer.github.com/v3/rate_limit
     """
 
+    def __repr__(self):
+        return self.get__repr__({"limit": self._limit.value, "remaining": self._remaining.value})
+
     @property
     def limit(self):
         """

--- a/github/RateLimit.py
+++ b/github/RateLimit.py
@@ -31,6 +31,9 @@ class RateLimit(github.GithubObject.NonCompletableGithubObject):
     This class represents rate limits as defined in http://developer.github.com/v3/rate_limit
     """
 
+    def __repr__(self):
+        return self.get__repr__({"rate": self._rate.value})
+
     @property
     def rate(self):
         """

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -80,6 +80,9 @@ class Repository(github.GithubObject.CompletableGithubObject):
     This class represents Repositories. The reference can be found here http://developer.github.com/v3/repos/
     """
 
+    def __repr__(self):
+        return self.get__repr__({"full_name": self._full_name.value})
+
     @property
     def archive_url(self):
         """

--- a/github/RepositoryKey.py
+++ b/github/RepositoryKey.py
@@ -39,6 +39,9 @@ class RepositoryKey(github.GithubObject.CompletableGithubObject):
         github.GithubObject.CompletableGithubObject.__init__(self, requester, headers, attributes, completed)
         self.__repoUrl = repoUrl
 
+    def __repr__(self):
+        return self.get__repr__({"id": self._id.value})
+
     @property
     def __customUrl(self):
         return self.__repoUrl + "/keys/" + str(self.id)

--- a/github/Stargazer.py
+++ b/github/Stargazer.py
@@ -39,6 +39,10 @@ class Stargazer(github.GithubObject.NonCompletableGithubObject):
     This class represents Stargazers with the date of starring as returned by
     https://developer.github.com/v3/activity/starring/#alternative-response-with-star-creation-timestamps
     """
+
+    def __repr__(self):
+        return self.get__repr__({"user": self._user.value._login.value})
+
     @property
     def starred_at(self):
         """

--- a/github/Status.py
+++ b/github/Status.py
@@ -30,6 +30,9 @@ class Status(github.GithubObject.NonCompletableGithubObject):
     This class represents status as defined in https://status.github.com/api
     """
 
+    def __repr__(self):
+        return self.get__repr__({"status": self._status.value})
+
     @property
     def status(self):
         """

--- a/github/StatusMessage.py
+++ b/github/StatusMessage.py
@@ -30,6 +30,9 @@ class StatusMessage(github.GithubObject.NonCompletableGithubObject):
     This class represents status messages as defined in https://status.github.com/api
     """
 
+    def __repr__(self):
+        return self.get__repr__({"body": self._body.value})
+
     @property
     def body(self):
         """

--- a/github/Tag.py
+++ b/github/Tag.py
@@ -36,6 +36,12 @@ class Tag(github.GithubObject.NonCompletableGithubObject):
     This class represents Tags. The reference can be found here http://developer.github.com/v3/git/tags/
     """
 
+    def __repr__(self):
+        return self.get__repr__({
+            "name": self._name.value,
+            "commit": self._commit.value
+        })
+
     @property
     def commit(self):
         """

--- a/github/Team.py
+++ b/github/Team.py
@@ -38,6 +38,9 @@ class Team(github.GithubObject.CompletableGithubObject):
     This class represents Teams. The reference can be found here http://developer.github.com/v3/orgs/teams/
     """
 
+    def __repr__(self):
+        return self.get__repr__({"id": self._id.value, "name": self._name.value})
+
     @property
     def id(self):
         """

--- a/github/UserKey.py
+++ b/github/UserKey.py
@@ -34,6 +34,9 @@ class UserKey(github.GithubObject.CompletableGithubObject):
     This class represents UserKeys. The reference can be found here http://developer.github.com/v3/users/keys/
     """
 
+    def __repr__(self):
+        return self.get__repr__({"id": self._id.value, "title": self._title.value})
+
     @property
     def id(self):
         """

--- a/github/tests/AuthenticatedUser.py
+++ b/github/tests/AuthenticatedUser.py
@@ -65,6 +65,9 @@ class AuthenticatedUser(Framework.TestCase):
         self.assertEqual(self.user.type, "User")
         self.assertEqual(self.user.url, "https://api.github.com/users/jacquev6")
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.user.__repr__(), 'AuthenticatedUser(login="jacquev6")')
+
     def testEditWithoutArguments(self):
         self.user.edit()
 

--- a/github/tests/Branch.py
+++ b/github/tests/Branch.py
@@ -36,6 +36,9 @@ class Branch(Framework.TestCase):
         self.assertEqual(self.branch.name, "topic/RewriteWithGeneratedCode")
         self.assertEqual(self.branch.commit.sha, "1292bf0e22c796e91cc3d6e24b544aece8c21f2a")
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.branch.__repr__(), 'Branch(name="topic/RewriteWithGeneratedCode")')
+
     def testProtectedAttributes(self):
         self.branch = self.g.get_user().get_repo("PyGithub").get_protected_branch("master")
         self.assertEqual(self.branch.name, "master")

--- a/github/tests/Commit.py
+++ b/github/tests/Commit.py
@@ -55,6 +55,9 @@ class Commit(Framework.TestCase):
         self.assertEqual(self.commit.stats.total, 20)
         self.assertEqual(self.commit.url, "https://api.github.com/repos/jacquev6/PyGithub/commits/1292bf0e22c796e91cc3d6e24b544aece8c21f2a")
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.commit.__repr__(), 'Commit(sha="1292bf0e22c796e91cc3d6e24b544aece8c21f2a")')
+
     def testGetComments(self):
         self.assertListKeyEqual(self.commit.get_comments(), lambda c: c.id, [1347033, 1347083, 1347397, 1349654])
 

--- a/github/tests/CommitCombinedStatus.py
+++ b/github/tests/CommitCombinedStatus.py
@@ -52,4 +52,4 @@ class CommitCombinedStatus(Framework.TestCase):
 
         # test __repr__() based on this attributes
         self.assertEqual(self.combined_status.__repr__(),
-                         'CommitCombinedStatus(sha="74e70119a23fa3ffb3db19d4590eccfebd72b659", state="success")')
+                         'CommitCombinedStatus(state="success", sha="74e70119a23fa3ffb3db19d4590eccfebd72b659")')

--- a/github/tests/CommitCombinedStatus.py
+++ b/github/tests/CommitCombinedStatus.py
@@ -49,3 +49,7 @@ class CommitCombinedStatus(Framework.TestCase):
         self.assertEqual(self.combined_status.repository.full_name, "edx/edx-platform")
         self.assertEqual(self.combined_status.commit_url, "https://api.github.com/repos/edx/edx-platform/commits/74e70119a23fa3ffb3db19d4590eccfebd72b659")
         self.assertEqual(self.combined_status.url, "https://api.github.com/repos/edx/edx-platform/commits/74e70119a23fa3ffb3db19d4590eccfebd72b659/status")
+
+        # test __repr__() based on this attributes
+        self.assertEqual(self.combined_status.__repr__(),
+                         'CommitCombinedStatus(sha="74e70119a23fa3ffb3db19d4590eccfebd72b659", state="success")')

--- a/github/tests/CommitComment.py
+++ b/github/tests/CommitComment.py
@@ -49,7 +49,7 @@ class CommitComment(Framework.TestCase):
 
         # test __repr__() based on this attributes
         self.assertEqual(self.comment.__repr__(),
-                         'CommitComment(id=1361949, user=NamedUser(login="jacquev6"))')
+                         'CommitComment(user=NamedUser(login="jacquev6"), id=1361949)')
 
     def testEdit(self):
         self.comment.edit("Comment edited by PyGithub")

--- a/github/tests/CommitComment.py
+++ b/github/tests/CommitComment.py
@@ -47,6 +47,10 @@ class CommitComment(Framework.TestCase):
         self.assertEqual(self.comment.url, "https://api.github.com/repos/jacquev6/PyGithub/comments/1361949")
         self.assertEqual(self.comment.user.login, "jacquev6")
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.comment.__repr__(),
+                         'CommitComment(id=1361949, user=NamedUser(login="jacquev6"))')
+
     def testEdit(self):
         self.comment.edit("Comment edited by PyGithub")
 

--- a/github/tests/CommitStatus.py
+++ b/github/tests/CommitStatus.py
@@ -50,4 +50,4 @@ class CommitStatus(Framework.TestCase):
 
         # test __repr__() based on this attributes
         self.assertEqual(self.statuses[0].__repr__(),
-                         'CommitStatus(id=277040, context="build", state="success")')
+                         'CommitStatus(state="success", id=277040, context="build")')

--- a/github/tests/CommitStatus.py
+++ b/github/tests/CommitStatus.py
@@ -47,3 +47,7 @@ class CommitStatus(Framework.TestCase):
         self.assertEqual(self.statuses[0].context, "build")
         self.assertEqual(self.statuses[0].target_url, "https://github.com/jacquev6/PyGithub/issues/67")
         self.assertEqual(self.statuses[1].target_url, None)
+
+        # test __repr__() based on this attributes
+        self.assertEqual(self.statuses[0].__repr__(),
+                         'CommitStatus(id=277040, context="build", state="success")')

--- a/github/tests/ContentFile.py
+++ b/github/tests/ContentFile.py
@@ -44,3 +44,6 @@ class ContentFile(Framework.TestCase):
         self.assertEqual(len(self.file.content), 10212)
         self.assertEqual(len(self.file.decoded_content), 7531)
         self.assertEqual(self.file.sha, "5628799a7d517a4aaa0c1a7004d07569cd154df0")
+
+        # test __repr__() based on this attributes
+        self.assertEqual(self.file.__repr__(), 'ContentFile(path="ReadMe.md")')

--- a/github/tests/Download.py
+++ b/github/tests/Download.py
@@ -56,5 +56,8 @@ class Download(Framework.TestCase):
         self.assertEqual(self.download.size, 1024)
         self.assertEqual(self.download.url, "https://api.github.com/repos/jacquev6/PyGithub/downloads/242550")
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.download.__repr__(), 'Download(id=242550)')
+
     def testDelete(self):
         self.download.delete()

--- a/github/tests/Event.py
+++ b/github/tests/Event.py
@@ -43,3 +43,6 @@ class Event(Framework.TestCase):
         self.assertTrue(self.event.public)
         self.assertEqual(self.event.repo.name, "jacquev6/PyGithub")
         self.assertEqual(self.event.type, "PushEvent")
+
+        # test __repr__() based on this attributes
+        self.assertEqual(self.event.__repr__(), 'Event(id="1556114751", type="PushEvent")')

--- a/github/tests/Event.py
+++ b/github/tests/Event.py
@@ -45,4 +45,4 @@ class Event(Framework.TestCase):
         self.assertEqual(self.event.type, "PushEvent")
 
         # test __repr__() based on this attributes
-        self.assertEqual(self.event.__repr__(), 'Event(id="1556114751", type="PushEvent")')
+        self.assertEqual(self.event.__repr__(), 'Event(type="PushEvent", id="1556114751")')

--- a/github/tests/Gist.py
+++ b/github/tests/Gist.py
@@ -66,6 +66,9 @@ class Gist(Framework.TestCase):
         self.assertEqual(gist.html_url, "https://gist.github.com/6296732")
         self.assertEqual(gist.url, "https://api.github.com/gists/6296732")
 
+        # test __repr__() based on this attributes
+        self.assertEqual(gist.__repr__(), 'Gist(id="6296732")')
+
     def testEditWithoutParameters(self):
         gist = self.g.get_gist("2729810")
         gist.edit()

--- a/github/tests/GistComment.py
+++ b/github/tests/GistComment.py
@@ -42,6 +42,9 @@ class GistComment(Framework.TestCase):
         self.assertEqual(self.comment.url, "https://api.github.com/gists/2729810/comments/323629")
         self.assertEqual(self.comment.user.login, "jacquev6")
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.comment.__repr__(), 'GistComment(id=323629, user=NamedUser(login="jacquev6"))')
+
     def testEdit(self):
         self.comment.edit("Comment edited by PyGithub")
         self.assertEqual(self.comment.body, "Comment edited by PyGithub")

--- a/github/tests/GistComment.py
+++ b/github/tests/GistComment.py
@@ -43,7 +43,7 @@ class GistComment(Framework.TestCase):
         self.assertEqual(self.comment.user.login, "jacquev6")
 
         # test __repr__() based on this attributes
-        self.assertEqual(self.comment.__repr__(), 'GistComment(id=323629, user=NamedUser(login="jacquev6"))')
+        self.assertEqual(self.comment.__repr__(), 'GistComment(user=NamedUser(login="jacquev6"), id=323629)')
 
     def testEdit(self):
         self.comment.edit("Comment edited by PyGithub")

--- a/github/tests/GitBlob.py
+++ b/github/tests/GitBlob.py
@@ -40,3 +40,7 @@ class GitBlob(Framework.TestCase):
         self.assertEqual(self.blob.size, 1295)
         self.assertEqual(self.blob.sha, "53bce9fa919b4544e67275089b3ec5b44be20667")
         self.assertEqual(self.blob.url, "https://api.github.com/repos/jacquev6/PyGithub/git/blobs/53bce9fa919b4544e67275089b3ec5b44be20667")
+
+        # test __repr__() based on this attributes
+        self.assertEqual(self.blob.__repr__(),
+                         'GitBlob(sha="53bce9fa919b4544e67275089b3ec5b44be20667")')

--- a/github/tests/GitCommit.py
+++ b/github/tests/GitCommit.py
@@ -48,3 +48,7 @@ class GitCommit(Framework.TestCase):
         self.assertEqual(self.commit.sha, "4303c5b90e2216d927155e9609436ccb8984c495")
         self.assertEqual(self.commit.tree.sha, "f492784d8ca837779650d1fb406a1a3587a764ad")
         self.assertEqual(self.commit.url, "https://api.github.com/repos/jacquev6/PyGithub/git/commits/4303c5b90e2216d927155e9609436ccb8984c495")
+
+        # test __repr__() based on this attributes
+        self.assertEqual(self.commit.__repr__(),
+                         'GitCommit(sha="4303c5b90e2216d927155e9609436ccb8984c495")')

--- a/github/tests/GitRef.py
+++ b/github/tests/GitRef.py
@@ -39,6 +39,10 @@ class GitRef(Framework.TestCase):
         self.assertEqual(self.ref.ref, "refs/heads/BranchCreatedByPyGithub")
         self.assertEqual(self.ref.url, "https://api.github.com/repos/jacquev6/PyGithub/git/refs/heads/BranchCreatedByPyGithub")
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.ref.__repr__(),
+                         'GitRef(ref="refs/heads/BranchCreatedByPyGithub")')
+
     def testEdit(self):
         self.ref.edit("04cde900a0775b51f762735637bd30de392a2793")
 

--- a/github/tests/GitRelease.py
+++ b/github/tests/GitRelease.py
@@ -40,6 +40,10 @@ class Release(Framework.TestCase):
         self.assertEqual(self.release.url, "https://api.github.com/repos/edhollandAL/PyGithub/releases/1210814")
         self.assertEqual(self.release.author._rawData['login'], "edhollandAL")
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.release.__repr__(), 'GitRelease(title="Test")')
+
+
     def testDelete(self):
         self.release = self.g.get_user().get_repo("PyGithub").get_releases()[0]
         self.assertTrue(self.release.delete_release())

--- a/github/tests/GitTag.py
+++ b/github/tests/GitTag.py
@@ -47,4 +47,4 @@ class GitTag(Framework.TestCase):
         self.assertEqual(self.tag.url, "https://api.github.com/repos/jacquev6/PyGithub/git/tags/f5f37322407b02a80de4526ad88d5f188977bc3c")
 
         # test __repr__() based on this attributes
-        self.assertEqual(self.tag.__repr__(), 'GitTag(sha="f5f37322407b02a80de4526ad88d5f188977bc3c", tag="v0.6")')
+        self.assertEqual(self.tag.__repr__(), 'GitTag(tag="v0.6", sha="f5f37322407b02a80de4526ad88d5f188977bc3c")')

--- a/github/tests/GitTag.py
+++ b/github/tests/GitTag.py
@@ -45,3 +45,6 @@ class GitTag(Framework.TestCase):
         self.assertEqual(self.tag.tagger.email, "vincent@vincent-jacques.net")
         self.assertEqual(self.tag.tagger.name, "Vincent Jacques")
         self.assertEqual(self.tag.url, "https://api.github.com/repos/jacquev6/PyGithub/git/tags/f5f37322407b02a80de4526ad88d5f188977bc3c")
+
+        # test __repr__() based on this attributes
+        self.assertEqual(self.tag.__repr__(), 'GitTag(sha="f5f37322407b02a80de4526ad88d5f188977bc3c", tag="v0.6")')

--- a/github/tests/GitTree.py
+++ b/github/tests/GitTree.py
@@ -48,3 +48,6 @@ class GitTree(Framework.TestCase):
         self.assertEqual(self.tree.tree[6].type, "tree")
         self.assertEqual(self.tree.tree[6].url, "https://api.github.com/repos/jacquev6/PyGithub/git/trees/60b4602b2c2070246c5df078fb7a5150b45815eb")
         self.assertEqual(self.tree.url, "https://api.github.com/repos/jacquev6/PyGithub/git/trees/f492784d8ca837779650d1fb406a1a3587a764ad")
+
+        # test __repr__() based on this attributes
+        self.assertEqual(self.tree.__repr__(), 'GitTree(sha="f492784d8ca837779650d1fb406a1a3587a764ad")')

--- a/github/tests/Hook.py
+++ b/github/tests/Hook.py
@@ -48,7 +48,7 @@ class Hook(Framework.TestCase):
         self.assertEqual(self.hook.url, "https://api.github.com/repos/jacquev6/PyGithub/hooks/257993")
 
         # test __repr__() based on this attributes
-        self.assertEqual(self.hook.__repr__(), 'Hook(id=257993, url="https://api.github.com/repos/jacquev6/PyGithub/hooks/257993")')
+        self.assertEqual(self.hook.__repr__(), 'Hook(url="https://api.github.com/repos/jacquev6/PyGithub/hooks/257993", id=257993)')
 
     def testEditWithMinimalParameters(self):
         self.hook.edit("web", {"url": "http://foobar.com/hook"})

--- a/github/tests/Hook.py
+++ b/github/tests/Hook.py
@@ -47,6 +47,9 @@ class Hook(Framework.TestCase):
         self.assertEqual(self.hook.updated_at, datetime.datetime(2012, 5, 29, 18, 49, 47))
         self.assertEqual(self.hook.url, "https://api.github.com/repos/jacquev6/PyGithub/hooks/257993")
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.hook.__repr__(), 'Hook(id=257993, url="https://api.github.com/repos/jacquev6/PyGithub/hooks/257993")')
+
     def testEditWithMinimalParameters(self):
         self.hook.edit("web", {"url": "http://foobar.com/hook"})
         self.assertEqual(self.hook.config, {"url": "http://foobar.com/hook"})

--- a/github/tests/Issue.py
+++ b/github/tests/Issue.py
@@ -59,7 +59,7 @@ class Issue(Framework.TestCase):
         self.assertEqual(self.issue.repository.name, "PyGithub")
 
         # test __repr__() based on this attributes
-        self.assertEqual(self.issue.__repr__(), 'Issue(number=28, title="Issue created by PyGithub")')
+        self.assertEqual(self.issue.__repr__(), 'Issue(title="Issue created by PyGithub", number=28)')
 
     def testEditWithoutParameters(self):
         self.issue.edit()

--- a/github/tests/Issue.py
+++ b/github/tests/Issue.py
@@ -58,6 +58,9 @@ class Issue(Framework.TestCase):
         self.assertEqual(self.issue.user.login, "jacquev6")
         self.assertEqual(self.issue.repository.name, "PyGithub")
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.issue.__repr__(), 'Issue(number=28, title="Issue created by PyGithub")')
+
     def testEditWithoutParameters(self):
         self.issue.edit()
 

--- a/github/tests/IssueComment.py
+++ b/github/tests/IssueComment.py
@@ -43,6 +43,9 @@ class IssueComment(Framework.TestCase):
         self.assertEqual(self.comment.user.login, "jacquev6")
         self.assertEqual(self.comment.html_url, "https://github.com/jacquev6/PyGithub/issues/28#issuecomment-5808311")
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.comment.__repr__(), 'IssueComment(id=5808311, user=NamedUser(login="jacquev6"))')
+
     def testEdit(self):
         self.comment.edit("Comment edited by PyGithub")
         self.assertEqual(self.comment.body, "Comment edited by PyGithub")

--- a/github/tests/IssueComment.py
+++ b/github/tests/IssueComment.py
@@ -44,7 +44,7 @@ class IssueComment(Framework.TestCase):
         self.assertEqual(self.comment.html_url, "https://github.com/jacquev6/PyGithub/issues/28#issuecomment-5808311")
 
         # test __repr__() based on this attributes
-        self.assertEqual(self.comment.__repr__(), 'IssueComment(id=5808311, user=NamedUser(login="jacquev6"))')
+        self.assertEqual(self.comment.__repr__(), 'IssueComment(user=NamedUser(login="jacquev6"), id=5808311)')
 
     def testEdit(self):
         self.comment.edit("Comment edited by PyGithub")

--- a/github/tests/IssueEvent.py
+++ b/github/tests/IssueEvent.py
@@ -42,3 +42,6 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event.id, 16348656)
         self.assertEqual(self.event.issue.number, 30)
         self.assertEqual(self.event.url, "https://api.github.com/repos/jacquev6/PyGithub/issues/events/16348656")
+
+        # test __repr__() based on this attributes
+        self.assertEqual(self.event.__repr__(), 'IssueEvent(id=16348656)')

--- a/github/tests/Label.py
+++ b/github/tests/Label.py
@@ -37,6 +37,9 @@ class Label(Framework.TestCase):
         self.assertEqual(self.label.name, "Bug")
         self.assertEqual(self.label.url, "https://api.github.com/repos/jacquev6/PyGithub/labels/Bug")
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.label.__repr__(), 'Label(name="Bug")')
+
     def testEdit(self):
         self.label.edit("LabelEditedByPyGithub", "0000ff")
         self.assertEqual(self.label.color, "0000ff")

--- a/github/tests/Milestone.py
+++ b/github/tests/Milestone.py
@@ -47,6 +47,9 @@ class Milestone(Framework.TestCase):
         self.assertEqual(self.milestone.url, "https://api.github.com/repos/jacquev6/PyGithub/milestones/1")
         self.assertEqual(self.milestone.creator.login, "jacquev6")
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.milestone.__repr__(), 'Milestone(number=1)')
+
     def testEditWithMinimalParameters(self):
         self.milestone.edit("Title edited by PyGithub")
         self.assertEqual(self.milestone.title, "Title edited by PyGithub")

--- a/github/tests/NamedUser.py
+++ b/github/tests/NamedUser.py
@@ -63,6 +63,10 @@ class NamedUser(Framework.TestCase):
         self.assertEqual(self.user.type, "User")
         self.assertEqual(self.user.url, "https://api.github.com/users/nvie")
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.user.__repr__(), 'NamedUser(login="nvie")')
+
+
     def testAttributesOfSelf(self):
         self.assertEqual(self.user.avatar_url, "https://secure.gravatar.com/avatar/b68de5ae38616c296fa345d2b9df2225?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-140.png")
         self.assertEqual(self.user.bio, "")
@@ -92,6 +96,9 @@ class NamedUser(Framework.TestCase):
         self.assertEqual(self.user.total_private_repos, 5)
         self.assertEqual(self.user.type, "User")
         self.assertEqual(self.user.url, "https://api.github.com/users/jacquev6")
+
+        # test __repr__() based on this attributes
+        self.assertEqual(self.user.__repr__(), 'NamedUser(login="jacquev6")')
 
     def testGetGists(self):
         self.assertListKeyEqual(self.user.get_gists(), lambda g: g.description, ["Gist created by PyGithub", "FairThreadPoolPool.cpp", "How to error 500 Github API v3, as requested by Rick (GitHub Staff)", "Cadfael: order of episodes in French DVD edition"])

--- a/github/tests/Organization.py
+++ b/github/tests/Organization.py
@@ -62,6 +62,9 @@ class Organization(Framework.TestCase):
         self.assertEqual(self.org.type, "Organization")
         self.assertEqual(self.org.url, "https://api.github.com/orgs/BeaverSoftware")
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.org.__repr__(), 'Organization(name=None, id=1424031)')
+
     def testEditWithoutArguments(self):
         self.org.edit()
 

--- a/github/tests/PullRequest.py
+++ b/github/tests/PullRequest.py
@@ -69,7 +69,7 @@ class PullRequest(Framework.TestCase):
         self.assertEqual(self.pull.user.login, "jacquev6")
 
         # test __repr__() based on this attributes
-        self.assertEqual(self.pull.__repr__(), 'PullRequest(number=31, title="Title edited by PyGithub")')
+        self.assertEqual(self.pull.__repr__(), 'PullRequest(title="Title edited by PyGithub", number=31)')
 
     def testCreateComment(self):
         commit = self.repo.get_commit("8a4f306d4b223682dd19410d4a9150636ebe4206")

--- a/github/tests/PullRequest.py
+++ b/github/tests/PullRequest.py
@@ -68,6 +68,9 @@ class PullRequest(Framework.TestCase):
         self.assertEqual(self.pull.url, "https://api.github.com/repos/jacquev6/PyGithub/pulls/31")
         self.assertEqual(self.pull.user.login, "jacquev6")
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.pull.__repr__(), 'PullRequest(number=31, title="Title edited by PyGithub")')
+
     def testCreateComment(self):
         commit = self.repo.get_commit("8a4f306d4b223682dd19410d4a9150636ebe4206")
         comment = self.pull.create_comment("Comment created by PyGithub", commit, "src/github/Issue.py", 5)

--- a/github/tests/PullRequestComment.py
+++ b/github/tests/PullRequestComment.py
@@ -49,7 +49,7 @@ class PullRequestComment(Framework.TestCase):
         self.assertEqual(self.comment.html_url, "https://github.com/jacquev6/PyGithub/pull/170#issuecomment-18637907")
 
         # test __repr__() based on this attributes
-        self.assertEqual(self.comment.__repr__(), 'PullRequestComment(id=886298, user=NamedUser(login="jacquev6"))')
+        self.assertEqual(self.comment.__repr__(), 'PullRequestComment(user=NamedUser(login="jacquev6"), id=886298)')
 
 
     def testEdit(self):

--- a/github/tests/PullRequestComment.py
+++ b/github/tests/PullRequestComment.py
@@ -48,6 +48,10 @@ class PullRequestComment(Framework.TestCase):
         self.assertEqual(self.comment.user.login, "jacquev6")
         self.assertEqual(self.comment.html_url, "https://github.com/jacquev6/PyGithub/pull/170#issuecomment-18637907")
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.comment.__repr__(), 'PullRequestComment(id=886298, user=NamedUser(login="jacquev6"))')
+
+
     def testEdit(self):
         self.comment.edit("Comment edited by PyGithub")
         self.assertEqual(self.comment.body, "Comment edited by PyGithub")

--- a/github/tests/PullRequestFile.py
+++ b/github/tests/PullRequestFile.py
@@ -42,3 +42,6 @@ class PullRequestFile(Framework.TestCase):
         self.assertEqual(self.file.raw_url, "https://github.com/jacquev6/PyGithub/raw/8a4f306d4b223682dd19410d4a9150636ebe4206/codegen/templates/GithubObject.py")
         self.assertEqual(self.file.sha, "8a4f306d4b223682dd19410d4a9150636ebe4206")
         self.assertEqual(self.file.status, "modified")
+
+        # test __repr__() based on this attributes
+        self.assertEqual(self.file.__repr__(), 'File(sha="8a4f306d4b223682dd19410d4a9150636ebe4206", filename="codegen/templates/GithubObject.py")')

--- a/github/tests/Repository.py
+++ b/github/tests/Repository.py
@@ -68,6 +68,9 @@ class Repository(Framework.TestCase):
         self.assertEqual(self.repo.url, "https://api.github.com/repos/jacquev6/PyGithub")
         self.assertEqual(self.repo.watchers, 15)
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.repo.__repr__(), 'Repository(full_name="jacquev6/PyGithub")')
+
     def testProtectBranch(self):
         self.repo.protect_branch("master", True, "everyone", ["test"])
         branch = self.repo.get_protected_branch("master")

--- a/github/tests/RepositoryKey.py
+++ b/github/tests/RepositoryKey.py
@@ -39,6 +39,10 @@ class RepositoryKey(Framework.TestCase):
         self.assertEqual(self.key.url, "https://api.github.com/user/keys/2626761")
         self.assertTrue(self.key.verified)
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.key.__repr__(), 'RepositoryKey(id=2626761)')
+
+
     def testEdit(self):
         self.key.edit("Title edited by PyGithub", "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA5Q58YmzZjU64prR5Pk91MfeHezOTgLqDYmepYbv3qjguiHtPai1vSai5WvUv3hgf9DArXsXE5CV6yoBIhAdGtpJKExHuQ2m4XTFCdbrgfQ3ypcSdgzEiQemyTA6TWwhbuwjJ1IqJMYOVLH+FBCkD8pyIpUDO7v3vaR2TCEuNwOS7lbsRsW3OkGYnUKjaPaCTe/inrqb7I3OE8cPhWJ3dM/zzzBj22J4LCNKhjKua8TFS74xGm3lNDZ6/twQl4n4xmrH/3tG+WOJicNO3JohNHqK9T0pILnr3epEyfdkBjcG0qXApqWvH2WipJhaH6of8Gdr0Z/K/7p8QFddmwNgdPQ==")
         self.assertEqual(self.key.key, "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA5Q58YmzZjU64prR5Pk91MfeHezOTgLqDYmepYbv3qjguiHtPai1vSai5WvUv3hgf9DArXsXE5CV6yoBIhAdGtpJKExHuQ2m4XTFCdbrgfQ3ypcSdgzEiQemyTA6TWwhbuwjJ1IqJMYOVLH+FBCkD8pyIpUDO7v3vaR2TCEuNwOS7lbsRsW3OkGYnUKjaPaCTe/inrqb7I3OE8cPhWJ3dM/zzzBj22J4LCNKhjKua8TFS74xGm3lNDZ6/twQl4n4xmrH/3tG+WOJicNO3JohNHqK9T0pILnr3epEyfdkBjcG0qXApqWvH2WipJhaH6of8Gdr0Z/K/7p8QFddmwNgdPQ==")

--- a/github/tests/Tag.py
+++ b/github/tests/Tag.py
@@ -37,3 +37,6 @@ class Tag(Framework.TestCase):
         self.assertEqual(self.tag.name, "v0.3")
         self.assertEqual(self.tag.tarball_url, "https://github.com/jacquev6/PyGithub/tarball/v0.3")
         self.assertEqual(self.tag.zipball_url, "https://github.com/jacquev6/PyGithub/zipball/v0.3")
+
+        # test __repr__() based on this attributes
+        self.assertEqual(self.tag.__repr__(), 'Tag(commit=Commit(sha="636e6112deb72277b3bffcc3303cd7e8a7431a5d"), name="v0.3")')

--- a/github/tests/Tag.py
+++ b/github/tests/Tag.py
@@ -39,4 +39,4 @@ class Tag(Framework.TestCase):
         self.assertEqual(self.tag.zipball_url, "https://github.com/jacquev6/PyGithub/zipball/v0.3")
 
         # test __repr__() based on this attributes
-        self.assertEqual(self.tag.__repr__(), 'Tag(commit=Commit(sha="636e6112deb72277b3bffcc3303cd7e8a7431a5d"), name="v0.3")')
+        self.assertEqual(self.tag.__repr__(), 'Tag(name="v0.3", commit=Commit(sha="636e6112deb72277b3bffcc3303cd7e8a7431a5d"))')

--- a/github/tests/Team.py
+++ b/github/tests/Team.py
@@ -42,7 +42,7 @@ class Team(Framework.TestCase):
         self.assertEqual(self.team.url, "https://api.github.com/teams/189850")
 
         # test __repr__() based on this attributes
-        self.assertEqual(self.team.__repr__(), 'Team(id=189850, name="Team created by PyGithub")')
+        self.assertEqual(self.team.__repr__(), 'Team(name="Team created by PyGithub", id=189850)')
 
     def testMembers(self):
         user = self.g.get_user("jacquev6")

--- a/github/tests/Team.py
+++ b/github/tests/Team.py
@@ -41,6 +41,9 @@ class Team(Framework.TestCase):
         self.assertEqual(self.team.repos_count, 0)
         self.assertEqual(self.team.url, "https://api.github.com/teams/189850")
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.team.__repr__(), 'Team(id=189850, name="Team created by PyGithub")')
+
     def testMembers(self):
         user = self.g.get_user("jacquev6")
         self.assertListKeyEqual(self.team.get_members(), None, [])

--- a/github/tests/UserKey.py
+++ b/github/tests/UserKey.py
@@ -40,7 +40,7 @@ class UserKey(Framework.TestCase):
         self.assertTrue(self.key.verified)
 
         # test __repr__() based on this attributes
-        self.assertEqual(self.key.__repr__(), 'UserKey(id=2626650, title="Key added through PyGithub")')
+        self.assertEqual(self.key.__repr__(), 'UserKey(title="Key added through PyGithub", id=2626650)')
 
     def testEditWithoutArguments(self):
         self.key.edit()

--- a/github/tests/UserKey.py
+++ b/github/tests/UserKey.py
@@ -39,6 +39,9 @@ class UserKey(Framework.TestCase):
         self.assertEqual(self.key.url, "https://api.github.com/user/keys/2626650")
         self.assertTrue(self.key.verified)
 
+        # test __repr__() based on this attributes
+        self.assertEqual(self.key.__repr__(), 'UserKey(id=2626650, title="Key added through PyGithub")')
+
     def testEditWithoutArguments(self):
         self.key.edit()
 


### PR DESCRIPTION
This one got stupidly large, but once you go into that rabbit hole there's no easy way out.

The PR basically just adds a nicer `__repr__` for GithubObjects. That's extremely helpful in logs and when playing around with PyGithub in a shell.

Turns this:

```python
github.NamedUser.NamedUser at 0x7fba7f6fcfd0
github.PullRequest.PullRequest at 0x7fba7f6fcfd0
github.CommitComment.CommitComment at 0x7fba7f6fcfd0
github.ContentFile.ContentFile at 0x7fba7f6fcfd0
github.Tag.Tag at 0x7fba7f6fcfd0
github.GitTree.GitTree at 0x7fba7f6fcfd0
```

into that:
```python
NamedUser(login="nvie")
PullRequest(number=31, title="Title edited by PyGithub")
CommitComment(id=1361949, user=NamedUser(login="jacquev6"))
ContentFile(path="ReadMe.md")
Tag(commit=Commit(sha="636e6112deb72277b3bffcc3303cd7e8a7431a5d"), name="v0.3")
GitTree(sha="f492784d8ca837779650d1fb406a1a3587a764ad")
```
 
