### PR TITLE
GitHub integrations support

### DIFF
--- a/github/InstallationAuthorization.py
+++ b/github/InstallationAuthorization.py
@@ -2,9 +2,7 @@
 
 # ########################## Copyrights and license ############################
 #                                                                              #
-# Copyright 2012 Vincent Jacques <vincent@vincent-jacques.net>                 #
-# Copyright 2012 Zearin <zearin@gonk.net>                                      #
-# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2016 Jannis gebauier <ja.geb@me.com>                               #
 #                                                                              #
 # This file is part of PyGithub.                                               #
 # http://pygithub.github.io/PyGithub/v1/index.html                             #
@@ -24,28 +22,51 @@
 #                                                                              #
 # ##############################################################################
 
-"""
-The primary class you will instanciate is :class:`github.MainClass.Github`.
-From its ``get_``, ``create_`` methods, you will obtain instances of all Github objects
-like :class:`github.NamedUser.NamedUser` or :class:`github.Repository.Repository`.
+import datetime
 
-All classes inherit from :class:`github.GithubObject.GithubObject`.
-"""
-
-import logging
-
-from MainClass import Github, GithubIntegration
-from GithubException import GithubException, BadCredentialsException, UnknownObjectException, BadUserAgentException, RateLimitExceededException, BadAttributeException
-from InputFileContent import InputFileContent
-from InputGitAuthor import InputGitAuthor
-from InputGitTreeElement import InputGitTreeElement
+import github.GithubObject
+import github.PaginatedList
+import github.NamedUser
 
 
-def enable_console_debug_logging():  # pragma no cover (Function useful only outside test environment)
+class InstallationAuthorization(github.GithubObject.NonCompletableGithubObject):
     """
-    This function sets up a very simple logging configuration (log everything on standard output) that is useful for troubleshooting.
+    InstallationAuthorization as obtained from a GitHub integration.
     """
 
-    logger = logging.getLogger("github")
-    logger.setLevel(logging.DEBUG)
-    logger.addHandler(logging.StreamHandler())
+    def __repr__(self):
+        return self.get__repr__({"expires_at": self._expires_at.value})
+
+    @property
+    def token(self):
+        """
+        :type: string
+        """
+        return self._token.value
+
+    @property
+    def expires_at(self):
+        """
+        :type: datetime
+        """
+        return self._expires_at.value
+
+    @property
+    def on_behalf_of(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        return self._on_behalf_of.value
+
+    def _initAttributes(self):
+        self._token = github.GithubObject.NotSet
+        self._expires_at = github.GithubObject.NotSet
+        self._on_behalf_of = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "token" in attributes:  # pragma no branch
+            self._token = self._makeStringAttribute(attributes["token"])
+        if "expires_at" in attributes:  # pragma no branch
+            self._expires_at = self._makeDatetimeAttribute(attributes["expires_at"])
+        if "on_behalf_of" in attributes:  # pragma no branch
+            self._on_behalf_of = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["on_behalf_of"])

--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -28,8 +28,11 @@
 
 import urllib
 import pickle
+import time
+from httplib import HTTPSConnection
+from jose import jwt
 
-from Requester import Requester
+from Requester import Requester, json
 import AuthenticatedUser
 import NamedUser
 import Organization
@@ -43,6 +46,8 @@ import GitignoreTemplate
 import Status
 import StatusMessage
 import RateLimit
+import InstallationAuthorization
+import GithubException
 
 
 DEFAULT_BASE_URL = "https://api.github.com"
@@ -590,3 +595,84 @@ class Github(object):
             cnx="status"
         )
         return [StatusMessage.StatusMessage(self.__requester, headers, attributes, completed=True) for attributes in data]
+
+
+class GithubIntegration(object):
+    """
+    Main class to obtain tokens for a GitHub integration.
+    """
+
+    def __init__(self, integration_id, private_key):
+        """
+        :param integration_id: int
+        :param private_key: string
+        """
+        self.integration_id = integration_id
+        self.private_key = private_key
+
+    def create_jwt(self):
+        """
+        Creates a signed JWT, valid for 60 seconds.
+        :return:
+        """
+        now = int(time.time())
+        payload = {
+            "iat": now,
+            "exp": now + 60,
+            "iss": self.integration_id
+        }
+        return jwt.encode(
+            payload,
+            key=self.private_key,
+            algorithm="RS256"
+        )
+
+    def get_access_token(self, installation_id, user_id=None):
+        """
+        Get an access token for the given installation id.
+        POSTs https://api.github.com/installations/<installation_id>/access_tokens
+        :param user_id: int
+        :param installation_id: int
+        :return: :class:`github.InstallationAuthorization.InstallationAuthorization`
+        """
+        body = None
+        if user_id:
+            body = json.dumps({"user_id": user_id})
+        conn = HTTPSConnection("api.github.com")
+        conn.request(
+            method="POST",
+            url="/installations/{}/access_tokens".format(installation_id),
+            headers={
+                "Authorization": "Bearer {}".format(self.create_jwt()),
+                "Accept": "application/vnd.github.machine-man-preview+json",
+                "User-Agent": "PyGithub/Python"
+            },
+            body=body
+        )
+        response = conn.getresponse()
+        response_text = response.read()
+        conn.close()
+        if response.status == 201:
+            data = json.loads(response_text)
+            return InstallationAuthorization.InstallationAuthorization(
+                requester=None,  # not required, this is a NonCompletableGithubObject
+                headers={},  # not required, this is a NonCompletableGithubObject
+                attributes=data,
+                completed=True
+            )
+        elif response.status == 403:
+            raise GithubException.BadCredentialsException(
+                status=response.status,
+                data=response_text
+            )
+        elif response.status == 404:
+            raise GithubException.UnknownObjectException(
+                status=response.status,
+                data=response_text
+            )
+        raise GithubException.GithubException(
+            status=response.status,
+            data=response_text
+        )
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-jose

--- a/setup.py
+++ b/setup.py
@@ -94,5 +94,8 @@ if __name__ == "__main__":
             "Topic :: Software Development",
         ],
         test_suite="github.tests.AllTests",
-        use_2to3=True
+        use_2to3=True,
+        install_requires=[
+            "python-jose"
+        ]
     )


### PR DESCRIPTION
This PR adds support for the all new [GitHub Integrations](https://developer.github.com/early-access/integrations/authentication/).

Since the `GithubIntegration` is the main entrypoint to obtain access tokens, I've created it alongside the `Github` main class.

I wasn't able to recycle much of the functionality in `Requester` because the integration is to coupled with the `Github` main class. Instead, I've used the _wonderful_ httplib.
### Usage

``` python
from github import GithubIntegration, Github

# obtained during integration creation
private_key = "some private key"
integration_id = 123

# obtained when a user installs the integration (webhook)
installation_id = 456

# get a token
integration = GithubIntegration(integration_id, private_key)
auth = integration.get_access_token(installation_id)

gh = GitHub(auth.token)
repo = gh.get_repo("user/whatever")
```
### Tests

None, yet. Integrations are in early access right now. I think it's safe to add tests once the API is stable.
### Added dependencies

In order to create the JSON web token, this PR adds [python-jose](https://github.com/mpdavis/python-jose). Another candidate is [pyjwt](https://github.com/jpadilla/pyjwt), but that isn't installable on Google Compute Engine.
