### PR TITLE
fix repository

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1009,7 +1009,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
             self.url
         )
 
-    def edit(self, name, description=github.GithubObject.NotSet, homepage=github.GithubObject.NotSet, private=github.GithubObject.NotSet, has_issues=github.GithubObject.NotSet, has_wiki=github.GithubObject.NotSet, has_downloads=github.GithubObject.NotSet, default_branch=github.GithubObject.NotSet):
+    def edit(self, name=None, description=github.GithubObject.NotSet, homepage=github.GithubObject.NotSet, private=github.GithubObject.NotSet, has_issues=github.GithubObject.NotSet, has_wiki=github.GithubObject.NotSet, has_downloads=github.GithubObject.NotSet, default_branch=github.GithubObject.NotSet):
         """
         :calls: `PATCH /repos/:owner/:repo <http://developer.github.com/v3/repos>`_
         :param name: string
@@ -1022,6 +1022,8 @@ class Repository(github.GithubObject.CompletableGithubObject):
         :param default_branch: string
         :rtype: None
         """
+        if name is None:
+            name = self.name
         assert isinstance(name, (str, unicode)), name
         assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
         assert homepage is github.GithubObject.NotSet or isinstance(homepage, (str, unicode)), homepage


### PR DESCRIPTION
I found Readme demo the following doesn't work.

``` python
from github import Github

# First create a Github instance:
g = Github("user", "password")

# Then play with your Github objects:
for repo in g.get_user().get_repos():
    print repo.name
    repo.edit(has_wiki=False)
```

Raised: `TypeError: edit() takes at least 2 arguments (2 given)`
Because Repository.edit needs `name` argument, but not used in demo.

In many cases, I think name equals self.name, so I set it as default value.
