### PR TITLE
Replace deprecated "permission" with "privacy" in create_team.

### DIFF
--- a/github/Organization.py
+++ b/github/Organization.py
@@ -361,24 +361,24 @@ class Organization(github.GithubObject.CompletableGithubObject):
         )
         return github.Repository.Repository(self._requester, headers, data, completed=True)
 
-    def create_team(self, name, repo_names=github.GithubObject.NotSet, permission=github.GithubObject.NotSet):
+    def create_team(self, name, repo_names=github.GithubObject.NotSet, privacy=github.GithubObject.NotSet):
         """
         :calls: `POST /orgs/:org/teams <http://developer.github.com/v3/orgs/teams>`_
         :param name: string
         :param repo_names: list of :class:`github.Repository.Repository`
-        :param permission: string
+        :param privacy: string
         :rtype: :class:`github.Team.Team`
         """
         assert isinstance(name, (str, unicode)), name
         assert repo_names is github.GithubObject.NotSet or all(isinstance(element, github.Repository.Repository) for element in repo_names), repo_names
-        assert permission is github.GithubObject.NotSet or isinstance(permission, (str, unicode)), permission
+        assert privacy is github.GithubObject.NotSet or isinstance(privacy, (str, unicode)), privacy
         post_parameters = {
             "name": name,
         }
         if repo_names is not github.GithubObject.NotSet:
             post_parameters["repo_names"] = [element._identity for element in repo_names]
-        if permission is not github.GithubObject.NotSet:
-            post_parameters["permission"] = permission
+        if privacy is not github.GithubObject.NotSet:
+            post_parameters["privacy"] = privacy
         headers, data = self._requester.requestJsonAndCheck(
             "POST",
             self.url + "/teams",

--- a/github/tests/Organization.py
+++ b/github/tests/Organization.py
@@ -83,7 +83,7 @@ class Organization(Framework.TestCase):
 
     def testCreateTeamWithAllArguments(self):
         repo = self.org.get_repo("FatherBeaver")
-        team = self.org.create_team("Team also created by PyGithub", [repo], "push")
+        team = self.org.create_team("Team also created by PyGithub", [repo], "closed")
         self.assertEqual(team.id, 189852)
 
     def testPublicMembers(self):

--- a/github/tests/ReplayData/Organization.testCreateTeamWithAllArguments.txt
+++ b/github/tests/ReplayData/Organization.testCreateTeamWithAllArguments.txt
@@ -15,8 +15,8 @@ api.github.com
 None
 /orgs/BeaverSoftware/teams
 {'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
-{"repo_names": ["BeaverSoftware/FatherBeaver"], "name": "Team also created by PyGithub", "permission": "push"}
+{"repo_names": ["BeaverSoftware/FatherBeaver"], "name": "Team also created by PyGithub", "privacy": "closed"}
 201
 [('status', '201 Created'), ('x-ratelimit-remaining', '4982'), ('content-length', '150'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"6e3fb00de6ca4c112feee3a1438d6f0e"'), ('date', 'Sat, 26 May 2012 21:00:26 GMT'), ('content-type', 'application/json; charset=utf-8'), ('location', 'https://api.github.com/teams/189852')]
-{"repos_count":1,"url":"https://api.github.com/teams/189852","members_count":0,"name":"Team also created by PyGithub","permission":"push","id":189852}
+{"repos_count":1,"url":"https://api.github.com/teams/189852","members_count":0,"name":"Team also created by PyGithub","privacy":"closed","id":189852}
 


### PR DESCRIPTION
The "Create team" endpoint in the teams API allows to specify `privacy ` as a parameter while the `permissions` parameter is deprecated. See https://developer.github.com/v3/orgs/teams/#create-team