### PR TITLE
Don't modify original requestHeaders in Requester.__log()

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -352,6 +352,8 @@ class Requester:
         logger = logging.getLogger(__name__)
         if logger.isEnabledFor(logging.DEBUG):
             if "Authorization" in requestHeaders:
+                # don't modify original requestHeaders
+                requestHeaders = requestHeaders.copy()
                 if requestHeaders["Authorization"].startswith("Basic"):
                     requestHeaders["Authorization"] = "Basic (login and password removed)"
                 elif requestHeaders["Authorization"].startswith("token"):


### PR DESCRIPTION
It's a problem when we need to use the `requestHeaders` later.

Like in case of `__requestRaw()` where we send a request + get response,
then `__log()` it and if the response contains status `301 (redirected)`
send another request (with same requestHeaders) to redirected url.

If the `__log()` erases the `'Authorization'` field, the subsequent
request fails.

Fixes #470
