### PR TITLE
Fix typo in a constant

### DIFF
--- a/github/Consts.py
+++ b/github/Consts.py
@@ -42,4 +42,4 @@ REQ_IF_MODIFIED_SINCE = "If-Modified-Since"
 # (Lower Case)                                                                 #
 # ##############################################################################
 RES_ETAG = "etag"
-RES_LAST_MODIFED = "last-modified"
+RES_LAST_MODIFIED = "last-modified"

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -208,7 +208,7 @@ class GithubObject(object):
         '''
         :type: str
         '''
-        return self._headers.get(Consts.RES_LAST_MODIFED)
+        return self._headers.get(Consts.RES_LAST_MODIFIED)
 
     def get__repr__(self, params):
         """


### PR DESCRIPTION
This is technically an API breakage, but I couldn't find any users of this constant except PyGithub itself, so I think it should be fine.

Found using [mwic](http://jwilk.net/software/mwic).