### PR TITLE
Removed unused imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,6 @@
 
 import setuptools
 import textwrap
-import subprocess
-import shutil
-import os.path
 
 version = "1.29"
 


### PR DESCRIPTION
Since 1d9ad14fa918, the setup script no longer uses `subprocess`, `shutil` and `os` modules.