### PR TITLE
add html_url to GitRelease

### DIFF
--- a/github/GitRelease.py
+++ b/github/GitRelease.py
@@ -82,6 +82,14 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
         self._completeIfNotSet(self._upload_url)
         return self._upload_url.value
 
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._html_url)
+        return self._html_url.value
+
     def delete_release(self):
         headers, data = self._requester.requestJsonAndCheck(
             "DELETE",
@@ -115,6 +123,7 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
         self._author = github.GithubObject.NotSet
         self._url = github.GithubObject.NotSet
         self._upload_url = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
 
     def _useAttributes(self, attributes):
         if "body" in attributes:
@@ -129,3 +138,5 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
             self._url = self._makeStringAttribute(attributes["url"])
         if "upload_url" in attributes:
             self._upload_url = self._makeStringAttribute(attributes["upload_url"])
+        if "html_url" in attributes:
+            self._html_url = self._makeStringAttribute(attributes["html_url"])

--- a/github/tests/GitRelease.py
+++ b/github/tests/GitRelease.py
@@ -39,6 +39,7 @@ class Release(Framework.TestCase):
         self.assertEqual(self.release.title, "Test")
         self.assertEqual(self.release.url, "https://api.github.com/repos/edhollandAL/PyGithub/releases/1210814")
         self.assertEqual(self.release.author._rawData['login'], "edhollandAL")
+        self.assertEqual(self.release.html_url, "https://github.com/edhollandAL/PyGithub/releases/tag/v1.25.2")
 
         # test __repr__() based on this attributes
         self.assertEqual(self.release.__repr__(), 'GitRelease(title="Test")')
@@ -66,3 +67,4 @@ class Release(Framework.TestCase):
         self.assertEqual(self.release.body, "release message")
         self.assertEqual(self.release.title, "release title")
         self.assertEqual(self.release.author._rawData['login'], "edhollandAL")
+        self.assertEqual(self.release.html_url, "https://github.com/edhollandAL/PyGithub/releases/tag/v3.0.0")


### PR DESCRIPTION
Adding html_url to GitRelease as its available in the json return but currently not available.  Updating an existing test to account for this addition as well.