### PR TITLE
Teams API: support description & privacy fields

### DIFF
--- a/github/Organization.py
+++ b/github/Organization.py
@@ -361,17 +361,19 @@ class Organization(github.GithubObject.CompletableGithubObject):
         )
         return github.Repository.Repository(self._requester, headers, data, completed=True)
 
-    def create_team(self, name, repo_names=github.GithubObject.NotSet, permission=github.GithubObject.NotSet):
+    def create_team(self, name, repo_names=github.GithubObject.NotSet, permission=github.GithubObject.NotSet, description=github.GithubObject.NotSet):
         """
         :calls: `POST /orgs/:org/teams <http://developer.github.com/v3/orgs/teams>`_
         :param name: string
         :param repo_names: list of :class:`github.Repository.Repository`
         :param permission: string
+        :param description: string
         :rtype: :class:`github.Team.Team`
         """
         assert isinstance(name, (str, unicode)), name
         assert repo_names is github.GithubObject.NotSet or all(isinstance(element, github.Repository.Repository) for element in repo_names), repo_names
         assert permission is github.GithubObject.NotSet or isinstance(permission, (str, unicode)), permission
+        assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
         post_parameters = {
             "name": name,
         }
@@ -379,6 +381,8 @@ class Organization(github.GithubObject.CompletableGithubObject):
             post_parameters["repo_names"] = [element._identity for element in repo_names]
         if permission is not github.GithubObject.NotSet:
             post_parameters["permission"] = permission
+        if description is not github.GithubObject.NotSet:
+            post_parameters["description"] = description
         headers, data = self._requester.requestJsonAndCheck(
             "POST",
             self.url + "/teams",

--- a/github/Organization.py
+++ b/github/Organization.py
@@ -361,19 +361,21 @@ class Organization(github.GithubObject.CompletableGithubObject):
         )
         return github.Repository.Repository(self._requester, headers, data, completed=True)
 
-    def create_team(self, name, repo_names=github.GithubObject.NotSet, permission=github.GithubObject.NotSet, description=github.GithubObject.NotSet):
+    def create_team(self, name, repo_names=github.GithubObject.NotSet, permission=github.GithubObject.NotSet, description=github.GithubObject.NotSet, privacy=github.GithubObject.NotSet):
         """
         :calls: `POST /orgs/:org/teams <http://developer.github.com/v3/orgs/teams>`_
         :param name: string
         :param repo_names: list of :class:`github.Repository.Repository`
         :param permission: string
         :param description: string
+        :param privacy: string
         :rtype: :class:`github.Team.Team`
         """
         assert isinstance(name, (str, unicode)), name
         assert repo_names is github.GithubObject.NotSet or all(isinstance(element, github.Repository.Repository) for element in repo_names), repo_names
         assert permission is github.GithubObject.NotSet or isinstance(permission, (str, unicode)), permission
         assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
+        assert privacy is github.GithubObject.NotSet or isinstance(privacy, (str, unicode)), privacy
         post_parameters = {
             "name": name,
         }
@@ -383,6 +385,8 @@ class Organization(github.GithubObject.CompletableGithubObject):
             post_parameters["permission"] = permission
         if description is not github.GithubObject.NotSet:
             post_parameters["description"] = description
+        if privacy is not github.GithubObject.NotSet:
+            post_parameters["privacy"] = privacy
         headers, data = self._requester.requestJsonAndCheck(
             "POST",
             self.url + "/teams",

--- a/github/Team.py
+++ b/github/Team.py
@@ -90,6 +90,14 @@ class Team(github.GithubObject.CompletableGithubObject):
         return self._permission.value
 
     @property
+    def privacy(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._privacy)
+        return self._privacy.value
+
+    @property
     def repos_count(self):
         """
         :type: integer
@@ -184,17 +192,19 @@ class Team(github.GithubObject.CompletableGithubObject):
             self.url
         )
 
-    def edit(self, name, permission=github.GithubObject.NotSet, description=github.GithubObject.NotSet):
+    def edit(self, name, permission=github.GithubObject.NotSet, description=github.GithubObject.NotSet, privacy=github.GithubObject.NotSet):
         """
         :calls: `PATCH /teams/:id <http://developer.github.com/v3/orgs/teams>`_
         :param name: string
         :param permission: string
         :param description: string
+        :param privacy: string
         :rtype: None
         """
         assert isinstance(name, (str, unicode)), name
         assert permission is github.GithubObject.NotSet or isinstance(permission, (str, unicode)), permission
         assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
+        assert privacy is github.GithubObject.NotSet or isinstance(privacy, (str, unicode)), privacy
         post_parameters = {
             "name": name,
         }
@@ -202,6 +212,8 @@ class Team(github.GithubObject.CompletableGithubObject):
             post_parameters["permission"] = permission
         if description is not github.GithubObject.NotSet:
             post_parameters["description"] = description
+        if privacy is not github.GithubObject.NotSet:
+            post_parameters["privacy"] = privacy
         headers, data = self._requester.requestJsonAndCheck(
             "PATCH",
             self.url,
@@ -294,6 +306,7 @@ class Team(github.GithubObject.CompletableGithubObject):
         self._members_url = github.GithubObject.NotSet
         self._name = github.GithubObject.NotSet
         self._permission = github.GithubObject.NotSet
+        self._privacy = github.GithubObject.NotSet
         self._repos_count = github.GithubObject.NotSet
         self._repositories_url = github.GithubObject.NotSet
         self._slug = github.GithubObject.NotSet
@@ -312,6 +325,8 @@ class Team(github.GithubObject.CompletableGithubObject):
             self._name = self._makeStringAttribute(attributes["name"])
         if "permission" in attributes:  # pragma no branch
             self._permission = self._makeStringAttribute(attributes["permission"])
+        if "privacy" in attributes:  # pragma no branch
+            self._privacy = self._makeStringAttribute(attributes["privacy"])
         if "repos_count" in attributes:  # pragma no branch
             self._repos_count = self._makeIntAttribute(attributes["repos_count"])
         if "repositories_url" in attributes:  # pragma no branch

--- a/github/Team.py
+++ b/github/Team.py
@@ -42,6 +42,14 @@ class Team(github.GithubObject.CompletableGithubObject):
         return self.get__repr__({"id": self._id.value, "name": self._name.value})
 
     @property
+    def description(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._description)
+        return self._description.value
+
+    @property
     def id(self):
         """
         :type: integer
@@ -176,20 +184,24 @@ class Team(github.GithubObject.CompletableGithubObject):
             self.url
         )
 
-    def edit(self, name, permission=github.GithubObject.NotSet):
+    def edit(self, name, permission=github.GithubObject.NotSet, description=github.GithubObject.NotSet):
         """
         :calls: `PATCH /teams/:id <http://developer.github.com/v3/orgs/teams>`_
         :param name: string
         :param permission: string
+        :param description: string
         :rtype: None
         """
         assert isinstance(name, (str, unicode)), name
         assert permission is github.GithubObject.NotSet or isinstance(permission, (str, unicode)), permission
+        assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
         post_parameters = {
             "name": name,
         }
         if permission is not github.GithubObject.NotSet:
             post_parameters["permission"] = permission
+        if description is not github.GithubObject.NotSet:
+            post_parameters["description"] = description
         headers, data = self._requester.requestJsonAndCheck(
             "PATCH",
             self.url,
@@ -276,6 +288,7 @@ class Team(github.GithubObject.CompletableGithubObject):
         return self.id
 
     def _initAttributes(self):
+        self._description = github.GithubObject.NotSet
         self._id = github.GithubObject.NotSet
         self._members_count = github.GithubObject.NotSet
         self._members_url = github.GithubObject.NotSet
@@ -287,6 +300,8 @@ class Team(github.GithubObject.CompletableGithubObject):
         self._url = github.GithubObject.NotSet
 
     def _useAttributes(self, attributes):
+        if "description" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["description"])
         if "id" in attributes:  # pragma no branch
             self._id = self._makeIntAttribute(attributes["id"])
         if "members_count" in attributes:  # pragma no branch


### PR DESCRIPTION
Per https://developer.github.com/v3/orgs/teams add support for the description & privacy properties of teams. The former is quite useful, and the latter is pretty much required these days since teams are secret by default.

I'm sorry but I can't figure out how to add tests properly.