### PR TITLE
Support getting the Latest release

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -2092,6 +2092,17 @@ class Repository(github.GithubObject.CompletableGithubObject):
             )
             return github.GitRelease.GitRelease(self._requester, headers, data, completed=True)
 
+    def get_latest_release(self):
+        """
+        :calls: `GET /repos/:owner/:repo/releases/latest https://developer.github.com/v3/repos/releases/#get-the-latest-release
+        :rtype: :class:`github.GitRelease.GitRelease`
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/releases/latest"
+        )
+        return github.GitRelease.GitRelease(self._requester, headers, data, completed=True)
+
     def get_teams(self):
         """
         :calls: `GET /repos/:owner/:repo/teams <http://developer.github.com/v3/repos>`_


### PR DESCRIPTION
As per https://developer.github.com/v3/repos/releases/#get-the-latest-release it is possible to get the latest release by issuing a call to `/repos/:owner/:repo/releases/latest`. This PR implements that as a seperate method in the Repository class, returning a GitRelease for the latest release.

This will 404 if the target repository has no releases, and it would appear to just return the most recent release if a repository has not marked a release as the latest.

I was unsure what to test for adding this, if you have any suggestions of tests to accompany this addition I can happily add them to this PR.