### PR TITLE
Add permissions parameter to add_to_collaborators

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -659,10 +659,11 @@ class Repository(github.GithubObject.CompletableGithubObject):
         self._completeIfNotSet(self._watchers_count)
         return self._watchers_count.value
 
-    def add_to_collaborators(self, collaborator):
+    def add_to_collaborators(self, collaborator, permission=None):
         """
         :calls: `PUT /repos/:owner/:repo/collaborators/:user <http://developer.github.com/v3/repos/collaborators>`_
         :param collaborator: string or :class:`github.NamedUser.NamedUser`
+        :param permission: string. only supported on organization repositories
         :rtype: None
         """
         assert isinstance(collaborator, github.NamedUser.NamedUser) or isinstance(collaborator, (str, unicode)), collaborator
@@ -670,9 +671,15 @@ class Repository(github.GithubObject.CompletableGithubObject):
         if isinstance(collaborator, github.NamedUser.NamedUser):
             collaborator = collaborator._identity
 
+        put_parameters = None
+        if permission is not None:
+            put_parameters = {
+                "permission": permission,
+            }
         headers, data = self._requester.requestJsonAndCheck(
             "PUT",
-            self.url + "/collaborators/" + collaborator
+            self.url + "/collaborators/" + collaborator,
+            input=put_parameters
         )
 
     def compare(self, base, head):


### PR DESCRIPTION
See the Github API Reference [here](https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator)

This change will only apply if the optional `permissions` parameter is
provided to `add_to_collaborators`. If not, it will behave as before

This is similar to the implementation in #393 but differs as explained above.
Happy to close if the other implementation is preferred, but either way I would very much like to see this feature merged!