### PR TITLE
Support HTTP 302 redirect in Organization.has_in_members

### DIFF
--- a/github/Organization.py
+++ b/github/Organization.py
@@ -576,6 +576,11 @@ class Organization(github.GithubObject.CompletableGithubObject):
             "GET",
             self.url + "/members/" + member._identity
         )
+        if status == 302:
+            status, headers, data = self._requester.requestJson(
+                "GET",
+                headers['location']
+            )
         return status == 204
 
     def has_in_public_members(self, public_member):

--- a/github/tests/AllTests.py
+++ b/github/tests/AllTests.py
@@ -53,6 +53,7 @@ from Label import *
 from Milestone import *
 from NamedUser import *
 from Markdown import *
+from OrganizationHasInMembers import *
 from Organization import *
 from PullRequest import *
 from PullRequestComment import *

--- a/github/tests/OrganizationHasInMembers.py
+++ b/github/tests/OrganizationHasInMembers.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2013 Vincent Jacques <vincent@vincent-jacques.net>                 #
+# Copyright 2016 Sam Corbett <sjcorbett@apache.org>                            #
+#                                                                              #
+# This file is part of PyGithub.                                               #
+# http://pygithub.github.io/PyGithub/v1/index.html                             #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import Framework
+
+
+class OrganizationHasInMembers(Framework.TestCase):
+    def setUp(self):
+        Framework.TestCase.setUp(self)
+        self.user = self.g.get_user("meneal")
+        self.org = self.g.get_organization("RobotWithFeelings")
+        self.has_in_members = self.org.has_in_members(self.user)
+
+    def testHasInMembers(self):
+        self.assertTrue(self.has_in_members)

--- a/github/tests/ReplayData/OrganizationHasInMembers.setUp.txt
+++ b/github/tests/ReplayData/OrganizationHasInMembers.setUp.txt
@@ -1,0 +1,31 @@
+https
+GET
+api.github.com
+None
+/users/meneal
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+null
+200
+[('content-length', '1108'), ('vary', 'Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding'), ('x-served-by', 'bae57931a6fe678a3dffe9be8e7819c8'), ('x-oauth-scopes', 'read:org'), ('x-xss-protection', '1; mode=block'), ('x-content-type-options', 'nosniff'), ('x-accepted-oauth-scopes', ''), ('etag', '"ae36cb79aa9c9620550a90dd1f06225f"'), ('cache-control', 'private, max-age=60, s-maxage=60'), ('status', '200 OK'), ('x-ratelimit-remaining', '4957'), ('x-github-media-type', 'github.v3; format=json'), ('access-control-expose-headers', 'ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval'), ('x-github-request-id', 'D07B:2C92:3D5858:4DFE0B:588022F4'), ('last-modified', 'Sun, 15 Jan 2017 20:57:11 GMT'), ('date', 'Thu, 19 Jan 2017 02:22:44 GMT'), ('access-control-allow-origin', '*'), ('content-security-policy', "default-src 'none'"), ('strict-transport-security', 'max-age=31536000; includeSubdomains; preload'), ('server', 'GitHub.com'), ('x-ratelimit-limit', '5000'), ('x-frame-options', 'deny'), ('content-type', 'application/json; charset=utf-8'), ('x-ratelimit-reset', '1484795009')]
+{"login":"meneal","id":3112188,"avatar_url":"https://avatars.githubusercontent.com/u/3112188?v=3","gravatar_id":"","url":"https://api.github.com/users/meneal","html_url":"https://github.com/meneal","followers_url":"https://api.github.com/users/meneal/followers","following_url":"https://api.github.com/users/meneal/following{/other_user}","gists_url":"https://api.github.com/users/meneal/gists{/gist_id}","starred_url":"https://api.github.com/users/meneal/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/meneal/subscriptions","organizations_url":"https://api.github.com/users/meneal/orgs","repos_url":"https://api.github.com/users/meneal/repos","events_url":"https://api.github.com/users/meneal/events{/privacy}","received_events_url":"https://api.github.com/users/meneal/received_events","type":"User","site_admin":false,"name":"Matthew Neal","company":null,"blog":"www.meneal.com","location":"Durham, NC","email":null,"hireable":null,"bio":null,"public_repos":20,"public_gists":2,"followers":3,"following":0,"created_at":"2012-12-23T22:59:34Z","updated_at":"2017-01-15T20:57:11Z"}
+
+https
+GET
+api.github.com
+None
+/orgs/RobotWithFeelings
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+null
+200
+[('content-length', '1045'), ('vary', 'Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding'), ('x-served-by', '0e17b94a265a427d9cafe798ceea7c02'), ('x-oauth-scopes', 'read:org'), ('x-xss-protection', '1; mode=block'), ('x-content-type-options', 'nosniff'), ('x-accepted-oauth-scopes', 'admin:org, read:org, repo, user, write:org'), ('etag', '"1176a1fa957a3165fd5429709efa0093"'), ('cache-control', 'private, max-age=60, s-maxage=60'), ('status', '200 OK'), ('x-ratelimit-remaining', '4956'), ('x-github-media-type', 'github.v3; format=json'), ('access-control-expose-headers', 'ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval'), ('x-github-request-id', 'D07C:2C92:3D5865:4DFE1C:588022F4'), ('last-modified', 'Tue, 12 Jan 2016 22:38:04 GMT'), ('date', 'Thu, 19 Jan 2017 02:22:44 GMT'), ('access-control-allow-origin', '*'), ('content-security-policy', "default-src 'none'"), ('strict-transport-security', 'max-age=31536000; includeSubdomains; preload'), ('server', 'GitHub.com'), ('x-ratelimit-limit', '5000'), ('x-frame-options', 'deny'), ('content-type', 'application/json; charset=utf-8'), ('x-ratelimit-reset', '1484795009')]
+{"login":"RobotWithFeelings","id":16672883,"url":"https://api.github.com/orgs/RobotWithFeelings","repos_url":"https://api.github.com/orgs/RobotWithFeelings/repos","events_url":"https://api.github.com/orgs/RobotWithFeelings/events","hooks_url":"https://api.github.com/orgs/RobotWithFeelings/hooks","issues_url":"https://api.github.com/orgs/RobotWithFeelings/issues","members_url":"https://api.github.com/orgs/RobotWithFeelings/members{/member}","public_members_url":"https://api.github.com/orgs/RobotWithFeelings/public_members{/member}","avatar_url":"https://avatars.githubusercontent.com/u/16672883?v=3","description":null,"public_repos":3,"public_gists":0,"followers":0,"following":0,"html_url":"https://github.com/RobotWithFeelings","created_at":"2016-01-12T19:23:54Z","updated_at":"2016-01-12T22:38:04Z","type":"Organization","total_private_repos":0,"owned_private_repos":0,"private_gists":null,"disk_usage":null,"collaborators":null,"billing_email":null,"plan":{"name":"free","space":976562499,"private_repos":0,"filled_seats":4,"seats":0}}
+
+https
+GET
+api.github.com
+None
+/orgs/RobotWithFeelings/members/meneal
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+null
+204
+[('status', '204 No Content'), ('x-ratelimit-remaining', '4955'), ('x-github-media-type', 'github.v3; format=json'), ('x-content-type-options', 'nosniff'), ('content-security-policy', "default-src 'none'"), ('access-control-expose-headers', 'ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval'), ('x-github-request-id', 'D07D:2C93:7811EA:988FEE:588022F4'), ('strict-transport-security', 'max-age=31536000; includeSubdomains; preload'), ('vary', 'Accept-Encoding'), ('server', 'GitHub.com'), ('access-control-allow-origin', '*'), ('x-ratelimit-limit', '5000'), ('x-xss-protection', '1; mode=block'), ('x-served-by', 'd0b3c2c33a23690498aa8e70a435a259'), ('date', 'Thu, 19 Jan 2017 02:22:44 GMT'), ('x-frame-options', 'deny'), ('x-oauth-scopes', 'read:org'), ('x-accepted-oauth-scopes', 'read:org, repo, user'), ('x-ratelimit-reset', '1484795009')]


### PR DESCRIPTION
When a request like:

```
curl -iL -u 'meneal:REDACTED' https://api.github.com/orgs/lambdaconglomerate/members/meneal
```

is made, Github responds with a 302 and then a 204, as follows:

```
HTTP/1.1 302 Found
Server: GitHub.com
Date: Thu, 01 Dec 2016 21:57:58 GMT
Content-Type: text/html;charset=utf-8
Content-Length: 0
Status: 302 Found
X-RateLimit-Limit: 5000
X-RateLimit-Remaining: 4991
X-RateLimit-Reset: 1480632278
Location: https://api.github.com/organizations/13904033/public_members/meneal
Access-Control-Expose-Headers: ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
Access-Control-Allow-Origin: *
Content-Security-Policy: default-src 'none'
Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
X-Content-Type-Options: nosniff
X-Frame-Options: deny
X-XSS-Protection: 1; mode=block
Vary: Accept-Encoding
X-Served-By: 4537b68c46a1b65b106078b0a2578ee2
X-GitHub-Request-Id: 812AD0B3:758F:15F5B73A:58409CE6

HTTP/1.1 204 No Content
Server: GitHub.com
Date: Thu, 01 Dec 2016 21:57:58 GMT
Status: 204 No Content
X-RateLimit-Limit: 5000
X-RateLimit-Remaining: 4990
X-RateLimit-Reset: 1480632278
X-OAuth-Scopes:
X-Accepted-OAuth-Scopes:
X-GitHub-Media-Type: github.v3
Access-Control-Expose-Headers: ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
Access-Control-Allow-Origin: *
Content-Security-Policy: default-src 'none'
Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
X-Content-Type-Options: nosniff
X-Frame-Options: deny
X-XSS-Protection: 1; mode=block
Vary: Accept-Encoding
X-Served-By: 52437fedc85beec8da3449496900fb9a
X-GitHub-Request-Id: 812AD0B3:758F:15F5B742:58409CE6
```

The [current implementation of `has_in_members`](https://github.com/PyGithub/PyGithub/blob/master/github/Organization.py#L568) only checks for the 204 without handling the 302 redirect and by doing so it returns a false negative. The occurrence of the redirect is sensitive to the scope of the token, in my testing a token with no scope (public access) receives the 302 then the 204, while a token with `read:org` only gets the 204.