### PR TITLE
Add details of repo type for get_repos documentation

### DIFF
--- a/github/Organization.py
+++ b/github/Organization.py
@@ -526,7 +526,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
     def get_repos(self, type=github.GithubObject.NotSet):
         """
         :calls: `GET /orgs/:org/repos <http://developer.github.com/v3/repos>`_
-        :param type: string
+        :param type: string ('all', 'public', 'private', 'forks', 'sources', 'member')
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
         """
         assert type is github.GithubObject.NotSet or isinstance(type, (str, unicode)), type


### PR DESCRIPTION
Taken from https://developer.github.com/v3/repos/#list-organization-repositories, it would save the trip to the github API for whoever is reading the documentation.