### PR TITLE
Fix README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ g = Github("user", "password")
 # Then play with your Github objects:
 for repo in g.get_user().get_repos():
     print repo.name
-    repo.edit(has_wiki=False)
 ```
 
 ## Development


### PR DESCRIPTION
repo.edit takes a mandatory first argument "name". Thus, it currently results in:
```
$ python github_mechanize_forkers.py 
Axelrod
Traceback (most recent call last):
  File "github_mechanize_forkers.py", line 11, in <module>
    repo.edit(has_wiki=False)
TypeError: edit() takes at least 2 arguments (2 given)
```

Fix the instructions by removing the "edit" call entirely -- basic instructions like this should prefer read-only operations