### PR TITLE
adding support for the integrations installation endpoint

### DIFF
--- a/github/Installation.py
+++ b/github/Installation.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+
+# ########################## Copyrights and license ############################
+#                                                                              #
+# Copyright 2017 Jannis Gebauer <ja.geb@me.com>                                #
+#                                                                              #
+# This file is part of PyGithub.                                               #
+# http://pygithub.github.io/PyGithub/v1/index.html                             #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+# ##############################################################################
+
+import github.GithubObject
+import github.PaginatedList
+
+import github.Gist
+import github.Repository
+import github.NamedUser
+import github.Plan
+import github.Organization
+import github.UserKey
+import github.Issue
+import github.Event
+import github.Authorization
+import github.Notification
+
+INTEGRATION_PREVIEW_HEADERS = {"Accept": "application/vnd.github.machine-man-preview+json"}
+
+
+class Installation(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents Installations as in https://developer.github.com/v3/integrations/installations
+    """
+
+    def __repr__(self):
+        return self.get__repr__({"id": self._id.value})
+
+    @property
+    def id(self):
+        return self._id
+
+    def get_repos(self):
+        """
+        :calls: `GET /installation/repositories <https://developer.github.com/v3/integrations/installations/#list-repositories>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
+        """
+        url_parameters = dict()
+
+        return github.PaginatedList.PaginatedList(
+            contentClass=github.Repository.Repository,
+            requester=self._requester,
+            firstUrl="/installation/repositories",
+            firstParams=url_parameters,
+            headers=INTEGRATION_PREVIEW_HEADERS,
+            list_item='repositories'
+        )
+
+    def _initAttributes(self):
+        self._id = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "id" in attributes:  # pragma no branch
+            self._id = self._makeIntAttribute(attributes["id"])

--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -29,6 +29,7 @@
 import urllib
 import pickle
 import time
+import sys
 from httplib import HTTPSConnection
 from jose import jwt
 
@@ -39,6 +40,7 @@ import Organization
 import Gist
 import github.PaginatedList
 import Repository
+import Installation
 import Legacy
 import github.GithubObject
 import HookDescription
@@ -49,6 +51,7 @@ import RateLimit
 import InstallationAuthorization
 import GithubException
 
+atLeastPython3 = sys.hexversion >= 0x03000000
 
 DEFAULT_BASE_URL = "https://api.github.com"
 DEFAULT_TIMEOUT = 10
@@ -596,6 +599,14 @@ class Github(object):
         )
         return [StatusMessage.StatusMessage(self.__requester, headers, attributes, completed=True) for attributes in data]
 
+    def get_installation(self, id):
+        """
+
+        :param id:
+        :return:
+        """
+        return Installation.Installation(self.__requester, headers={}, attributes={"id": id}, completed=True)
+
 
 class GithubIntegration(object):
     """
@@ -651,6 +662,10 @@ class GithubIntegration(object):
         )
         response = conn.getresponse()
         response_text = response.read()
+
+        if atLeastPython3:
+            response_text = response_text.decode('utf-8')
+
         conn.close()
         if response.status == 201:
             data = json.loads(response_text)
@@ -674,5 +689,3 @@ class GithubIntegration(object):
             status=response.status,
             data=response_text
         )
-
-

--- a/github/PaginatedList.py
+++ b/github/PaginatedList.py
@@ -107,7 +107,7 @@ class PaginatedList(PaginatedListBase):
         some_other_repos = user.get_repos().get_page(3)
     """
 
-    def __init__(self, contentClass, requester, firstUrl, firstParams, headers=None):
+    def __init__(self, contentClass, requester, firstUrl, firstParams, headers=None, list_item="items"):
         PaginatedListBase.__init__(self)
         self.__requester = requester
         self.__contentClass = contentClass
@@ -116,6 +116,7 @@ class PaginatedList(PaginatedListBase):
         self.__nextUrl = firstUrl
         self.__nextParams = firstParams or {}
         self.__headers = headers
+        self.__list_item = list_item
         if self.__requester.per_page != 30:
             self.__nextParams["per_page"] = self.__requester.per_page
         self._reversed = False
@@ -173,9 +174,9 @@ class PaginatedList(PaginatedListBase):
                 self.__nextUrl = links["next"]
         self.__nextParams = None
 
-        if 'items' in data:
+        if self.__list_item in data:
             self.__totalCount = data['total_count']
-            data = data["items"]
+            data = data[self.__list_item]
 
         content = [
             self.__contentClass(self.__requester, headers, element, completed=False)
@@ -209,9 +210,9 @@ class PaginatedList(PaginatedListBase):
             headers=self.__headers
         )
 
-        if 'items' in data:
+        if self.__list_item in data:
             self.__totalCount = data['total_count']
-            data = data["items"]
+            data = data[self.__list_item]
 
         return [
             self.__contentClass(self.__requester, headers, element, completed=False)


### PR DESCRIPTION
This is a continuation of https://github.com/PyGithub/PyGithub/pull/449 which adds support for installations.

Given a valid installation, you can now get all repos an installation has access to:

```
from github import Github

installation_id = 123

gh = GitHub('some-integration-token')

installation = gh.get_installation(installation_id)

for repo in installation.get_repos():
    print(repo.full_name)
```

The new integrations API is still in early access, so it's likely that some things will change along the way. Once the API has settled down, I'll add proper tests for all endpoints.