### PR TITLE
Fix hashing in python3

### DIFF
--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -240,6 +240,9 @@ class CompletableGithubObject(GithubObject):
         GithubObject.__init__(self, requester, headers, attributes, completed)
         self.__completed = completed
 
+    def __hash__(self):
+        return hash(self._url.value)
+
     def __eq__(self, other):
         return other.__class__ is self.__class__ and other._url.value == self._url.value
 


### PR DESCRIPTION
```python
from github import Github

me = Github(' token ').get_user()

repo = list(me.get_repos())[-1]

print({repo: 'test'})
"""
Traceback (most recent call last):
  File ".../PyGithub/test_hashable.py", line 9, in <module>
    print({repo: 'test'})
TypeError: unhashable type: 'Repository'
"""

user_repos = {}

for user in repo.get_stargazers():
    user_repos[user] = 'test'
    """
    Traceback (most recent call last):
      File ".../PyGithub/test_hashable.py", line 20, in <module>
        user_repos[user] = 'test'
    TypeError: unhashable type: 'NamedUser'
    """
    break

print(user_repos)
```