### PR TITLE
[docs] warn about using threads

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -8,6 +8,10 @@ Should you have any question, any remark, or if you find a bug,
 or if there is something you can do with the API but not with PyGithub,
 please `open an issue <https://github.com/PyGithub/PyGithub/issues>`__.
 
+.. warning::
+
+   PyGithub is **not** thread-safe, please ensure that you serialize your calls to this API.
+
 (Very short) tutorial
 ---------------------
 


### PR DESCRIPTION
Please make explicit that this library is not thread-safe.

The documentation for this project is excellent, and for the most part I was able to get everything up and running *very* quickly!  However, an unfortunate amount of time was just spent debugging my own program only to realize what the actual problem is.

It makes sense why this library is not thread-safe, and I'm in no way asking for this feature!  But I seem to be [the second person](https://github.com/PyGithub/PyGithub/issues/183) to have done this.  As that user indicates, us expecting PyGithub to be threadsafe was a foolish thing to do.

At the same time, given the nature of the API and what it does, it feels natural to assume that it would be thread-safe.

A simple warning will probably save a lot of other people a lot of time :wink:

Thanks for PyGithub!