### PR TITLE
Add support for permission parameter when adding collaborators

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -660,20 +660,27 @@ class Repository(github.GithubObject.CompletableGithubObject):
         self._completeIfNotSet(self._watchers_count)
         return self._watchers_count.value
 
-    def add_to_collaborators(self, collaborator):
+    def add_to_collaborators(self, collaborator, permission=github.GithubObject.NotSet):
         """
         :calls: `PUT /repos/:owner/:repo/collaborators/:user <http://developer.github.com/v3/repos/collaborators>`_
         :param collaborator: string or :class:`github.NamedUser.NamedUser`
+        :param permission: string 'pull', 'push' or 'admin'
         :rtype: None
         """
         assert isinstance(collaborator, github.NamedUser.NamedUser) or isinstance(collaborator, (str, unicode)), collaborator
+        assert permission is github.GithubObject.NotSet or isinstance(permission, (str, unicode)), permission
 
         if isinstance(collaborator, github.NamedUser.NamedUser):
             collaborator = collaborator._identity
 
+        put_parameters = {}
+        if permission is not github.GithubObject.NotSet:
+            put_parameters['permission'] = permission
+
         headers, data = self._requester.requestJsonAndCheck(
             "PUT",
-            self.url + "/collaborators/" + collaborator
+            self.url + "/collaborators/" + collaborator,
+            input=put_parameters
         )
 
     def compare(self, base, head):


### PR DESCRIPTION
According to the [API](https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator), a permission parameter can be used when adding a collaborator to a repository owned by an organisation.

This PR adds the parameter to the `add_to_collaborators` method from `Repository`.