### PR TITLE
add "integration" install option with minimal docs

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -31,6 +31,9 @@ This package is in the `Python Package Index
 be enough.  You can also clone it on `Github
 <http://github.com/PyGithub/PyGithub>`__.
 
+If you wish to use GitHub Integrations, you'll want to be sure to install the
+'integrations' option: ``pip install PyGithub['integrations']``
+
 Licensing
 ---------
 

--- a/setup.py
+++ b/setup.py
@@ -96,5 +96,8 @@ if __name__ == "__main__":
         use_2to3=True,
         install_requires=[
             "pyjwt"
-        ]
+        ],
+        extras_require = {
+            "integrations": ["cryptography"]
+        }
     )


### PR DESCRIPTION
Would close #554 

Tested PyGithub installation locally in a blank virtualenvs (both 2.7 and 3.6) by `pip install -e .['integrations']`  and it successfully builds and installs the cryptography package as expected.