### PR TITLE
Set optional proxy per client object

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -64,7 +64,7 @@ class Github(object):
     This is the main class you instanciate to access the Github API v3. Optional parameters allow different authentication methods.
     """
 
-    def __init__(self, login_or_token=None, password=None, base_url=DEFAULT_BASE_URL, timeout=DEFAULT_TIMEOUT, client_id=None, client_secret=None, user_agent='PyGithub/Python', per_page=DEFAULT_PER_PAGE, api_preview=False):
+    def __init__(self, login_or_token=None, password=None, base_url=DEFAULT_BASE_URL, timeout=DEFAULT_TIMEOUT, client_id=None, client_secret=None, user_agent='PyGithub/Python', per_page=DEFAULT_PER_PAGE, api_preview=False, http_proxy=None):
         """
         :param login_or_token: string
         :param password: string
@@ -74,6 +74,7 @@ class Github(object):
         :param client_secret: string
         :param user_agent: string
         :param per_page: int
+        :param http_proxy: string
         """
 
         assert login_or_token is None or isinstance(login_or_token, (str, unicode)), login_or_token
@@ -84,7 +85,7 @@ class Github(object):
         assert client_secret is None or isinstance(client_secret, (str, unicode)), client_secret
         assert user_agent is None or isinstance(user_agent, (str, unicode)), user_agent
         assert isinstance(api_preview, (bool))
-        self.__requester = Requester(login_or_token, password, base_url, timeout, client_id, client_secret, user_agent, per_page, api_preview)
+        self.__requester = Requester(login_or_token, password, base_url, timeout, client_id, client_secret, user_agent, per_page, api_preview, http_proxy)
 
     def __get_FIX_REPO_GET_GIT_REF(self):
         """

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -123,7 +123,7 @@ class Requester:
 
     #############################################################
 
-    def __init__(self, login_or_token, password, base_url, timeout, client_id, client_secret, user_agent, per_page, api_preview):
+    def __init__(self, login_or_token, password, base_url, timeout, client_id, client_secret, user_agent, per_page, api_preview, http_proxy):
         self._initializeDebugFeature()
 
         if password is not None:
@@ -165,6 +165,7 @@ class Requester:
             'See http://developer.github.com/v3/#user-agent-required'
         self.__userAgent = user_agent
         self.__apiPreview = api_preview
+        self.__httpProxy = http_proxy
 
     def requestJsonAndCheck(self, verb, url, parameters=None, headers=None, input=None, cnx=None):
         return self.__check(*self.requestJson(verb, url, parameters, headers, input, cnx))
@@ -350,7 +351,7 @@ class Requester:
         ## set.
         ## http_proxy: http://user:password@proxy_host:proxy_port
         ##
-        proxy_uri = os.getenv('http_proxy') or os.getenv('HTTP_PROXY')
+        proxy_uri = self.__httpProxy or os.getenv('http_proxy') or os.getenv('HTTP_PROXY')
         if proxy_uri is not None:
             url = urlparse.urlparse(proxy_uri)
             conn = self.__connectionClass(url.hostname, url.port, **kwds)


### PR DESCRIPTION
Currently the only way to set a proxy in PyGithub is via an environment
variable, which means that the only way to use multiple proxies is
running multiple processes.

This patch allows setting an HTTP proxy per `Github` object via an
optional `http_proxy` argument, which will override the proxy set via
environment variables.