### PR TITLE
added role parameter to add_membership function

### DIFF
--- a/github/Team.py
+++ b/github/Team.py
@@ -125,16 +125,21 @@ class Team(github.GithubObject.CompletableGithubObject):
             self.url + "/members/" + member._identity
         )
 
-    def add_membership(self, member):
+    def add_membership(self, member, role=github.GithubObject.NotSet):
         """
         :calls: `PUT /teams/:id/memberships/:user <http://developer.github.com/v3/orgs/teams>`_
         :param member: :class:`github.Nameduser.NamedUser`
+        :param role: string, (optional), The role that this user should have in the team.
         :rtype: None
         """
         assert isinstance(member, github.NamedUser.NamedUser), member
+        put_parameters = dict()
+        if role is not github.GithubObject.NotSet:
+            put_parameters["role"] = role
         headers, data = self._requester.requestJsonAndCheck(
             "PUT",
-            self.url + "/memberships/" + member._identity
+            self.url + "/memberships/" + member._identity,
+            input=put_parameters
         )
 
     def add_to_repos(self, repo):


### PR DESCRIPTION
The add_membership function did not accept the optional role parameter, to add a member as a team maintainer.  I added a keyword parameter called "role" that will optionally accept a string value for the desired role.  