### PR TITLE
Handle spaces and other special characters in /contents API

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1252,7 +1252,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
             url_parameters["ref"] = ref
         headers, data = self._requester.requestJsonAndCheck(
             "GET",
-            self.url + "/contents" + path,
+            self.url + "/contents" + urllib.quote(path),
             parameters=url_parameters
         )
         if isinstance(data, list):
@@ -1311,7 +1311,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
         headers, data = self._requester.requestJsonAndCheck(
             "PUT",
-            self.url + "/contents" + path,
+            self.url + "/contents" + urllib.quote(path),
             input=put_parameters
         )
 
@@ -1370,7 +1370,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
         headers, data = self._requester.requestJsonAndCheck(
             "PUT",
-            self.url + "/contents" + path,
+            self.url + "/contents" + urllib.quote(path),
             input=put_parameters
         )
 
@@ -1405,7 +1405,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
         headers, data = self._requester.requestJsonAndCheck(
             "DELETE",
-            self.url + "/contents" + path,
+            self.url + "/contents" + urllib.quote(path),
             input=url_parameters
         )
 
@@ -1426,7 +1426,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
             url_parameters["ref"] = ref
         headers, data = self._requester.requestJsonAndCheck(
             "GET",
-            self.url + "/contents" + path,
+            self.url + "/contents" + urllib.quote(path),
             parameters=url_parameters
         )
 


### PR DESCRIPTION
Fixes #613.

The only breakage is if someone is already using `urllib.quote` to work around this bug. In this case, the path will be encoded twice, resulting in an incorrect path.