### PR TITLE
Fix creating/updating binary files on Python 3

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1282,7 +1282,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
             'path must be str/unicode object'
         assert isinstance(message, (str, unicode)),                \
             'message must be str/unicode object'
-        assert isinstance(content, (str, unicode)),                \
+        assert isinstance(content, (str, unicode, bytes)),         \
             'content must be a str/unicode object'
         assert branch is github.GithubObject.NotSet                \
             or isinstance(branch, (str, unicode)),                 \
@@ -1295,7 +1295,9 @@ class Repository(github.GithubObject.CompletableGithubObject):
             'committer must be a github.InputGitAuthor object'
 
         if atLeastPython3:
-            content = b64encode(content.encode('utf-8')).decode('utf-8')
+            if isinstance(content, str):
+                content = content.encode('utf-8')
+            content = b64encode(content).decode('utf-8')
         else:
             if isinstance(content, unicode):
                 content = content.encode('utf-8')
@@ -1337,7 +1339,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
             'path must be str/unicode object'
         assert isinstance(message, (str, unicode)),                \
             'message must be str/unicode object'
-        assert isinstance(content, (str, unicode)),                \
+        assert isinstance(content, (str, unicode, bytes)),         \
             'content must be a str/unicode object'
         assert isinstance(sha, (str, unicode)),                    \
             'sha must be a str/unicode object'
@@ -1352,7 +1354,9 @@ class Repository(github.GithubObject.CompletableGithubObject):
             'committer must be a github.InputGitAuthor object'
 
         if atLeastPython3:
-            content = b64encode(content.encode('utf-8')).decode('utf-8')
+            if isinstance(content, str):
+                content = content.encode('utf-8')
+            content = b64encode(content).decode('utf-8')
         else:
             if isinstance(content, unicode):
                 content = content.encode('utf-8')


### PR DESCRIPTION
There is a bit of logic for Python 2 that detects if you're uploading string or bytes, but this was missing for Python 3.