### PR TITLE
Added missing parameters for repo creation

### DIFF
--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -500,7 +500,12 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         )
         return github.UserKey.UserKey(self._requester, headers, data, completed=True)
 
-    def create_repo(self, name, description=github.GithubObject.NotSet, homepage=github.GithubObject.NotSet, private=github.GithubObject.NotSet, has_issues=github.GithubObject.NotSet, has_wiki=github.GithubObject.NotSet, has_downloads=github.GithubObject.NotSet, auto_init=github.GithubObject.NotSet, gitignore_template=github.GithubObject.NotSet):
+    def create_repo(self, name, description=github.GithubObject.NotSet,homepage=github.GithubObject.NotSet,
+                    private=github.GithubObject.NotSet, has_issues=github.GithubObject.NotSet,
+                    has_wiki=github.GithubObject.NotSet, has_downloads=github.GithubObject.NotSet,
+                    has_projects=github.GithubObject.NotSet, auto_init=github.GithubObject.NotSet, license_template=github.GithubObject.NotSet,
+                    gitignore_template=github.GithubObject.NotSet, allow_squash_merge=github.GithubObject.NotSet,
+                    allow_merge_commit=github.GithubObject.NotSet, allow_rebase_merge=github.GithubObject.NotSet):
         """
         :calls: `POST /user/repos <http://developer.github.com/v3/repos>`_
         :param name: string
@@ -510,8 +515,13 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         :param has_issues: bool
         :param has_wiki: bool
         :param has_downloads: bool
+        :param has_projects: bool
         :param auto_init: bool
+        :param license_template: string
         :param gitignore_template: string
+        :param allow_squash_merge: bool
+        :param allow_merge_commit: bool
+        :param allow_rebase_merge: bool
         :rtype: :class:`github.Repository.Repository`
         """
         assert isinstance(name, (str, unicode)), name
@@ -521,8 +531,13 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         assert has_issues is github.GithubObject.NotSet or isinstance(has_issues, bool), has_issues
         assert has_wiki is github.GithubObject.NotSet or isinstance(has_wiki, bool), has_wiki
         assert has_downloads is github.GithubObject.NotSet or isinstance(has_downloads, bool), has_downloads
+        assert has_projects is github.GithubObject.NotSet or isinstance(has_projects, bool), has_projects
         assert auto_init is github.GithubObject.NotSet or isinstance(auto_init, bool), auto_init
+        assert license_template is github.GithubObject.NotSet or isinstance(license_template, (str, unicode)), license_template
         assert gitignore_template is github.GithubObject.NotSet or isinstance(gitignore_template, (str, unicode)), gitignore_template
+        assert allow_squash_merge is github.GithubObject.NotSet or isinstance(allow_squash_merge, bool), allow_squash_merge
+        assert allow_merge_commit is github.GithubObject.NotSet or isinstance(allow_merge_commit, bool), allow_merge_commit
+        assert allow_rebase_merge is github.GithubObject.NotSet or isinstance(allow_rebase_merge, bool), allow_rebase_merge
         post_parameters = {
             "name": name,
         }
@@ -538,10 +553,20 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
             post_parameters["has_wiki"] = has_wiki
         if has_downloads is not github.GithubObject.NotSet:
             post_parameters["has_downloads"] = has_downloads
+        if has_projects is not github.GithubObject.NotSet:
+            post_parameters["has_projects"] = has_projects
         if auto_init is not github.GithubObject.NotSet:
             post_parameters["auto_init"] = auto_init
+        if license_template is not github.GithubObject.NotSet:
+            post_parameters["license_template"] = license_template
         if gitignore_template is not github.GithubObject.NotSet:
             post_parameters["gitignore_template"] = gitignore_template
+        if allow_squash_merge is not github.GithubObject.NotSet:
+            post_parameters["allow_squash_merge"] = allow_squash_merge
+        if allow_merge_commit is not github.GithubObject.NotSet:
+            post_parameters["allow_merge_commit"] = allow_merge_commit
+        if allow_rebase_merge is not github.GithubObject.NotSet:
+            post_parameters["allow_rebase_merge"] = allow_rebase_merge
         headers, data = self._requester.requestJsonAndCheck(
             "POST",
             "/user/repos",

--- a/github/Organization.py
+++ b/github/Organization.py
@@ -325,7 +325,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
         :param has_wiki: bool
         :param has_downloads: bool
         :param has_projects: bool
-        :param team_id: :class:`github.Team.Team`
+        :param team_id: : int
         :param auto_init: bool
         :param license_template: string
         :param gitignore_template: string

--- a/github/Organization.py
+++ b/github/Organization.py
@@ -342,7 +342,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
         assert has_wiki is github.GithubObject.NotSet or isinstance(has_wiki, bool), has_wiki
         assert has_downloads is github.GithubObject.NotSet or isinstance(has_downloads, bool), has_downloads
         assert has_projects is github.GithubObject.NotSet or isinstance(has_projects, bool), has_projects
-        assert team_id is github.GithubObject.NotSet or isinstance(team_id, github.Team.Team), team_id
+        assert team_id is github.GithubObject.NotSet or isinstance(team_id, (int, long)), team_id
         assert auto_init is github.GithubObject.NotSet or isinstance(auto_init, bool), auto_init
         assert license_template is github.GithubObject.NotSet or isinstance(license_template, (str, unicode)), license_template
         assert gitignore_template is github.GithubObject.NotSet or isinstance(gitignore_template, (str, unicode)), gitignore_template

--- a/github/Organization.py
+++ b/github/Organization.py
@@ -367,7 +367,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
         if has_projects is not github.GithubObject.NotSet:
             post_parameters["has_projects"] = has_projects
         if team_id is not github.GithubObject.NotSet:
-            post_parameters["team_id"] = team_id._identity
+            post_parameters["team_id"] = team_id
         if auto_init is not github.GithubObject.NotSet:
             post_parameters["auto_init"] = auto_init
         if license_template is not github.GithubObject.NotSet:

--- a/github/Organization.py
+++ b/github/Organization.py
@@ -308,7 +308,13 @@ class Organization(github.GithubObject.CompletableGithubObject):
         )
         return github.Repository.Repository(self._requester, headers, data, completed=True)
 
-    def create_repo(self, name, description=github.GithubObject.NotSet, homepage=github.GithubObject.NotSet, private=github.GithubObject.NotSet, has_issues=github.GithubObject.NotSet, has_wiki=github.GithubObject.NotSet, has_downloads=github.GithubObject.NotSet, team_id=github.GithubObject.NotSet, auto_init=github.GithubObject.NotSet, gitignore_template=github.GithubObject.NotSet):
+    def create_repo(self, name, description=github.GithubObject.NotSet, homepage=github.GithubObject.NotSet,
+                    private=github.GithubObject.NotSet, has_issues=github.GithubObject.NotSet,
+                    has_wiki=github.GithubObject.NotSet, has_downloads=github.GithubObject.NotSet,
+                    has_projects=github.GithubObject.NotSet, team_id=github.GithubObject.NotSet,
+                    auto_init=github.GithubObject.NotSet, license_template=github.GithubObject.NotSet,
+                    gitignore_template=github.GithubObject.NotSet, allow_squash_merge=github.GithubObject.NotSet,
+                    allow_merge_commit=github.GithubObject.NotSet, allow_rebase_merge=github.GithubObject.NotSet):
         """
         :calls: `POST /orgs/:org/repos <http://developer.github.com/v3/repos>`_
         :param name: string
@@ -318,9 +324,14 @@ class Organization(github.GithubObject.CompletableGithubObject):
         :param has_issues: bool
         :param has_wiki: bool
         :param has_downloads: bool
+        :param has_projects: bool
         :param team_id: :class:`github.Team.Team`
         :param auto_init: bool
+        :param license_template: string
         :param gitignore_template: string
+        :param allow_squash_merge: bool
+        :param allow_merge_commit: bool
+        :param allow_rebase_merge: bool
         :rtype: :class:`github.Repository.Repository`
         """
         assert isinstance(name, (str, unicode)), name
@@ -330,9 +341,14 @@ class Organization(github.GithubObject.CompletableGithubObject):
         assert has_issues is github.GithubObject.NotSet or isinstance(has_issues, bool), has_issues
         assert has_wiki is github.GithubObject.NotSet or isinstance(has_wiki, bool), has_wiki
         assert has_downloads is github.GithubObject.NotSet or isinstance(has_downloads, bool), has_downloads
+        assert has_projects is github.GithubObject.NotSet or isinstance(has_projects, bool), has_projects
         assert team_id is github.GithubObject.NotSet or isinstance(team_id, github.Team.Team), team_id
         assert auto_init is github.GithubObject.NotSet or isinstance(auto_init, bool), auto_init
+        assert license_template is github.GithubObject.NotSet or isinstance(license_template, (str, unicode)), license_template
         assert gitignore_template is github.GithubObject.NotSet or isinstance(gitignore_template, (str, unicode)), gitignore_template
+        assert allow_squash_merge is github.GithubObject.NotSet or isinstance(allow_squash_merge, bool), allow_squash_merge
+        assert allow_merge_commit is github.GithubObject.NotSet or isinstance(allow_merge_commit, bool), allow_merge_commit
+        assert allow_rebase_merge is github.GithubObject.NotSet or isinstance(allow_rebase_merge, bool), allow_rebase_merge
         post_parameters = {
             "name": name,
         }
@@ -348,12 +364,22 @@ class Organization(github.GithubObject.CompletableGithubObject):
             post_parameters["has_wiki"] = has_wiki
         if has_downloads is not github.GithubObject.NotSet:
             post_parameters["has_downloads"] = has_downloads
+        if has_projects is not github.GithubObject.NotSet:
+            post_parameters["has_projects"] = has_projects
         if team_id is not github.GithubObject.NotSet:
             post_parameters["team_id"] = team_id._identity
         if auto_init is not github.GithubObject.NotSet:
             post_parameters["auto_init"] = auto_init
+        if license_template is not github.GithubObject.NotSet:
+            post_parameters["license_template"] = license_template
         if gitignore_template is not github.GithubObject.NotSet:
             post_parameters["gitignore_template"] = gitignore_template
+        if allow_squash_merge is not github.GithubObject.NotSet:
+            post_parameters["allow_squash_merge"] = allow_squash_merge
+        if allow_merge_commit is not github.GithubObject.NotSet:
+            post_parameters["allow_merge_commit"] = allow_merge_commit
+        if allow_rebase_merge is not github.GithubObject.NotSet:
+            post_parameters["allow_rebase_merge"] = allow_rebase_merge
         headers, data = self._requester.requestJsonAndCheck(
             "POST",
             self.url + "/repos",

--- a/github/tests/AuthenticatedUser.py
+++ b/github/tests/AuthenticatedUser.py
@@ -129,15 +129,16 @@ class AuthenticatedUser(Framework.TestCase):
         self.assertListKeyEqual(self.user.get_authorizations(), lambda a: a.id, [372294])
 
     def testCreateRepository(self):
-        repo = self.user.create_repo("TestPyGithub")
+        repo = self.user.create_repo(name="TestPyGithub")
         self.assertEqual(repo.url, "https://api.github.com/repos/jacquev6/TestPyGithub")
 
     def testCreateRepositoryWithAllArguments(self):
-        repo = self.user.create_repo("TestPyGithub", "Repo created by PyGithub", "http://foobar.com", private=False, has_issues=False, has_wiki=False, has_downloads=False)
+        repo = self.user.create_repo(name="TestPyGithub", description="Repo created by PyGithub", homepage="http://foobar.com",
+                                     private=False, has_issues=False, has_wiki=False, has_downloads=False)
         self.assertEqual(repo.url, "https://api.github.com/repos/jacquev6/TestPyGithub")
 
     def testCreateRepositoryWithAutoInit(self):
-        repo = self.user.create_repo("TestPyGithub", auto_init=True, gitignore_template="Python")
+        repo = self.user.create_repo(name="TestPyGithub", auto_init=True, gitignore_template="Python")
         self.assertEqual(repo.url, "https://api.github.com/repos/jacquev6/TestPyGithub")
 
     def testCreateAuthorizationWithoutArguments(self):

--- a/github/tests/Organization.py
+++ b/github/tests/Organization.py
@@ -137,7 +137,7 @@ class Organization(Framework.TestCase):
         self.assertEqual(repo.url, "https://api.github.com/repos/BeaverSoftware/TestPyGithub2")
 
     def testCreateRepositoryWithAutoInit(self):
-        repo = self.org.create_repo("TestPyGithub", auto_init=True, gitignore_template="Python")
+        repo = self.org.create_repo(name="TestPyGithub", auto_init=True, gitignore_template="Python")
         self.assertEqual(repo.url, "https://api.github.com/repos/BeaverSoftware/TestPyGithub")
 
     def testCreateFork(self):

--- a/github/tests/Organization.py
+++ b/github/tests/Organization.py
@@ -127,12 +127,13 @@ class Organization(Framework.TestCase):
         self.assertListKeyEqual(self.org.get_teams(), lambda t: t.name, ["Members", "Owners"])
 
     def testCreateRepoWithMinimalArguments(self):
-        repo = self.org.create_repo("TestPyGithub")
+        repo = self.org.create_repo(name="TestPyGithub")
         self.assertEqual(repo.url, "https://api.github.com/repos/BeaverSoftware/TestPyGithub")
 
     def testCreateRepoWithAllArguments(self):
         team = self.org.get_team(141496)
-        repo = self.org.create_repo("TestPyGithub2", "Repo created by PyGithub", "http://foobar.com", False, False, False, False, team)
+        repo = self.org.create_repo(name="TestPyGithub2", description="Repo created by PyGithub", homepage="http://foobar.com",
+                                    private=False, has_issues=False, has_wiki=False, has_downloads=False, team_id=team.id)
         self.assertEqual(repo.url, "https://api.github.com/repos/BeaverSoftware/TestPyGithub2")
 
     def testCreateRepositoryWithAutoInit(self):


### PR DESCRIPTION
There were some missing parameters from the repo_create method

The missing ones are the following:

- has_projects
- license_template
- allow_squash_merge
- allow_merge_commit
- allow_rebase_merge

Also the team_id parameter should be an id not a Team object.