### PR TITLE
Fix GithubIntegration in Python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@
 ################################################################################
 
 *.pyc
+.eggs/
+.python-version
 
 /GithubCredentials.py
 /scripts/TwitterCredentials.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: python
 python:
-- '2.7'
 - '2.6'
+- '2.7'
 - '3.2'
 - '3.3'
 - '3.4'
 - '3.5'
+- '3.6'
 sudo: false
 script:
 - python setup.py test

--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -633,11 +633,16 @@ class GithubIntegration(object):
             "exp": now + 60,
             "iss": self.integration_id
         }
-        return jwt.encode(
+        encrypted = jwt.encode(
             payload,
             key=self.private_key,
             algorithm="RS256"
         )
+
+        if atLeastPython3:
+            encrypted = encrypted.decode('utf-8')
+
+        return encrypted
 
     def get_access_token(self, installation_id, user_id=None):
         """


### PR DESCRIPTION
In Python2, `jwt.encode()` returns a `str` object, and in python3 it returns a `bytes` object.

This fix simply performs a `.decode('utf-8')` on the bytes object in Python3 (as described in https://github.com/PyGithub/PyGithub/issues/588). This should also address https://github.com/PyGithub/PyGithub/issues/627.