### PR TITLE
Add Repository.archived property

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -85,6 +85,14 @@ class Repository(github.GithubObject.CompletableGithubObject):
         return self.get__repr__({"full_name": self._full_name.value})
 
     @property
+    def archived(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._archived)
+        return self._archived.value
+
+    @property
     def archive_url(self):
         """
         :type: string
@@ -2300,6 +2308,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         return self.owner.login + "/" + self.name
 
     def _initAttributes(self):
+        self._archived = github.GithubObject.NotSet
         self._archive_url = github.GithubObject.NotSet
         self._assignees_url = github.GithubObject.NotSet
         self._blobs_url = github.GithubObject.NotSet
@@ -2374,6 +2383,8 @@ class Repository(github.GithubObject.CompletableGithubObject):
         self._watchers_count = github.GithubObject.NotSet
 
     def _useAttributes(self, attributes):
+        if "archived" in attributes:  # pragma no branch
+            self._archived = self._makeBoolAttribute(attributes["archived"])
         if "archive_url" in attributes:  # pragma no branch
             self._archive_url = self._makeStringAttribute(attributes["archive_url"])
         if "assignees_url" in attributes:  # pragma no branch


### PR DESCRIPTION
Archiving repositories was added recently. I'd like to filter out archived repos in some of my scripts, so I added an `archived` property to the `Repository` class.