### PR TITLE
[Documentation] Create instance from token

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ This library enables you to manage [GitHub] resources such as repositories, user
 from github import Github
 
 # First create a Github instance:
+
+# using username and password
 g = Github("user", "password")
+
+# or using an access token
+g = Github("access_token")
 
 # Then play with your Github objects:
 for repo in g.get_user().get_repos():

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -14,8 +14,12 @@ please `open an issue <https://github.com/PyGithub/PyGithub/issues>`__.
 First create a Github instance::
 
     from github import Github
-
+    
+    # using username and password
     g = Github("user", "password")
+    
+    # or using an access token
+    g = Github(token)
 
 Then play with your Github objects::
 

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -19,7 +19,7 @@ First create a Github instance::
     g = Github("user", "password")
     
     # or using an access token
-    g = Github(token)
+    g = Github("access_token")
 
 Then play with your Github objects::
 


### PR DESCRIPTION
This PR provides the user with more options to create the Github instance, aka from access_token, for people who are unwilling to put their username and password in the code. 