### PR TITLE
make created_at/published_at attrs available for Release objects

### DIFF
--- a/github/GitRelease.py
+++ b/github/GitRelease.py
@@ -77,6 +77,22 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
         return self._author.value
 
     @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._created_at)
+        return self._created_at.value
+
+    @property
+    def published_at(self):
+        """
+        :type: datetime.datetime
+        """
+        self._completeIfNotSet(self._published_at)
+        return self._published_at.value
+
+    @property
     def url(self):
         """
         :type: string
@@ -163,6 +179,8 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
         self._url = github.GithubObject.NotSet
         self._upload_url = github.GithubObject.NotSet
         self._html_url = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._published_at = github.GithubObject.NotSet
 
     def _useAttributes(self, attributes):
         if "id" in attributes:
@@ -181,3 +199,7 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
             self._upload_url = self._makeStringAttribute(attributes["upload_url"])
         if "html_url" in attributes:
             self._html_url = self._makeStringAttribute(attributes["html_url"])
+        if "created_at" in attributes:
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "published_at" in attributes:
+            self._published_at = self._makeDatetimeAttribute(attributes["published_at"])

--- a/github/tests/GitRelease.py
+++ b/github/tests/GitRelease.py
@@ -24,6 +24,7 @@
 
 import os
 import zipfile
+import datetime
 import Framework
 from pprint import pprint
 
@@ -58,6 +59,8 @@ class Release(Framework.TestCase):
         self.assertEqual(self.release.url, "https://api.github.com/repos/edhollandAL/PyGithub/releases/1210814")
         self.assertEqual(self.release.author._rawData['login'], "edhollandAL")
         self.assertEqual(self.release.html_url, "https://github.com/edhollandAL/PyGithub/releases/tag/v1.25.2")
+        self.assertEqual(self.release.created_at, datetime.datetime(2014, 10, 8, 1, 54))
+        self.assertEqual(self.release.published_at, datetime.datetime(2015, 4, 24, 8, 36, 51))
 
         # test __repr__() based on this attributes
         self.assertEqual(self.release.__repr__(), 'GitRelease(title="Test")')


### PR DESCRIPTION
The github releases api returns `created_at` and `published_at` timestamps, similar to the `updated_at` timestamps in issues, comments, etc.  I'd like to be able to access these attributes as `datetime` objects as well.

Eg:
```
>>> github.Github().get_organization(org).get_repo(repo).get_latest_release().published_at
datetime.datetime(2017, 10, 26, 1, 6, 28)
```

I added the `created_at` and `published_at` properties, following the style of the surrounding code and `Issue.py`'s `updated_at` property.