### PR TITLE
Update Team.py to get members with role filter

### DIFF
--- a/github/Team.py
+++ b/github/Team.py
@@ -197,16 +197,22 @@ class Team(github.GithubObject.CompletableGithubObject):
         )
         self._useAttributes(data)
 
-    def get_members(self):
+    def get_members(self, role=github.GithubObject.NotSet):
         """
         :calls: `GET /teams/:id/members <http://developer.github.com/v3/orgs/teams>`_
+        :param role: string
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
+        assert (role is github.GithubObject.NotSet or
+                isinstance(role, (str, unicode))), role
+        url_parameters = {}
+        if role is not github.GithubObject.NotSet:
+            url_parameters["role"] = role
         return github.PaginatedList.PaginatedList(
             github.NamedUser.NamedUser,
             self._requester,
             self.url + "/members",
-            None
+            url_parameters
         )
 
     def get_repos(self):


### PR DESCRIPTION
Hello,

I edited "get_members" function to query with "role" like the following:
 team.get_members(role='maintainer')