### PR TITLE
Method create_milestone now uses datetime object

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -968,13 +968,13 @@ class Repository(github.GithubObject.CompletableGithubObject):
         :param title: string
         :param state: string
         :param description: string
-        :param due_on: date
+        :param due_on: datetime
         :rtype: :class:`github.Milestone.Milestone`
         """
         assert isinstance(title, (str, unicode)), title
         assert state is github.GithubObject.NotSet or isinstance(state, (str, unicode)), state
         assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
-        assert due_on is github.GithubObject.NotSet or isinstance(due_on, datetime.date), due_on
+        assert due_on is github.GithubObject.NotSet or isinstance(due_on, datetime.date) or isinstance(due_on, datetime.datetime), due_on
         post_parameters = {
             "title": title,
         }
@@ -983,7 +983,10 @@ class Repository(github.GithubObject.CompletableGithubObject):
         if description is not github.GithubObject.NotSet:
             post_parameters["description"] = description
         if due_on is not github.GithubObject.NotSet:
-            post_parameters["due_on"] = due_on.strftime("%Y-%m-%dT%H:%M:%SZ")
+            if isinstance(due_on, datetime.date):
+                post_parameters["due_on"] = due_on.strftime("%Y-%m-%dT%H:%M:%SZ")
+            else:
+                post_parameters["due_on"] = due_on.isoformat()
         headers, data = self._requester.requestJsonAndCheck(
             "POST",
             self.url + "/milestones",

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -974,7 +974,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         assert isinstance(title, (str, unicode)), title
         assert state is github.GithubObject.NotSet or isinstance(state, (str, unicode)), state
         assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
-        assert due_on is github.GithubObject.NotSet or isinstance(due_on, datetime.date) or isinstance(due_on, datetime.datetime), due_on
+        assert due_on is github.GithubObject.NotSet or isinstance(due_on, (datetime.datetime, datetime.date)), due_on
         post_parameters = {
             "title": title,
         }


### PR DESCRIPTION
This fits better with v3 API which uses ISO8601 date/time format with timezone.

Date object still allowed for backward compatibility

The problem with current implementation is it always passes UTC to the API.  So for example, if you're in the United States and pass a `date` object like `date(2018, 2, 4)`, then GitHub will interpret that as 2018-02-04T00:00:00Z which is actually 2018-02-03 in the United States.  So the due date in the milestone will be the day before the one you passed in.  This is incorrect behavior.

Since GitHub API needs expects a date/time in ISO 8601 format, it would be best to pass in a `datetime` object and call `.isoformat()` on the object, than to bother with `date` objects.  This will also be more compatible with enhanced datetime libraries like [pendulum](https://pendulum.eustace.io/).