### PR TITLE
Sort the Github Objects

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -267,7 +267,7 @@ autoclass_content = "both"
 
 githubClasses = [
     fileName[10:-3]
-    for fileName in glob.glob("../github/*.py")
+    for fileName in sorted(glob.glob("../github/*.py"))
     if fileName not in [
         "../github/GithubException.py",
         "../github/GithubObject.py",


### PR DESCRIPTION
It's difficult to follow the API docs when the order isn't alphabetical. This seems like the simplest fix, and worked well locally.