### PR TITLE
Labels API: support description

### DIFF
--- a/github/Label.py
+++ b/github/Label.py
@@ -52,6 +52,14 @@ class Label(github.GithubObject.CompletableGithubObject):
         return self._color.value
 
     @property
+    def description(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._description)
+        return self._description.value
+
+    @property
     def name(self):
         """
         :type: string
@@ -77,23 +85,28 @@ class Label(github.GithubObject.CompletableGithubObject):
             self.url
         )
 
-    def edit(self, name, color):
+    def edit(self, name, color, description=github.GithubObject.NotSet):
         """
         :calls: `PATCH /repos/:owner/:repo/labels/:name <http://developer.github.com/v3/issues/labels>`_
         :param name: string
         :param color: string
+        :param description: string
         :rtype: None
         """
         assert isinstance(name, (str, unicode)), name
         assert isinstance(color, (str, unicode)), color
+        assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
         post_parameters = {
             "name": name,
             "color": color,
         }
+        if description is not github.GithubObject.NotSet:
+            post_parameters["description"] = description
         headers, data = self._requester.requestJsonAndCheck(
             "PATCH",
             self.url,
-            input=post_parameters
+            input=post_parameters,
+            headers={'Accept': 'application/vnd.github.symmetra-preview+json'}
         )
         self._useAttributes(data)
 
@@ -103,12 +116,15 @@ class Label(github.GithubObject.CompletableGithubObject):
 
     def _initAttributes(self):
         self._color = github.GithubObject.NotSet
+        self._description = github.GithubObject.NotSet
         self._name = github.GithubObject.NotSet
         self._url = github.GithubObject.NotSet
 
     def _useAttributes(self, attributes):
         if "color" in attributes:  # pragma no branch
             self._color = self._makeStringAttribute(attributes["color"])
+        if "description" in attributes:  # pragma no branch
+            self._description = self._makeStringAttribute(attributes["description"])
         if "name" in attributes:  # pragma no branch
             self._name = self._makeStringAttribute(attributes["name"])
         if "url" in attributes:  # pragma no branch

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -999,23 +999,28 @@ class Repository(github.GithubObject.CompletableGithubObject):
         )
         return github.RepositoryKey.RepositoryKey(self._requester, headers, data, completed=True, repoUrl=self.url)
 
-    def create_label(self, name, color):
+    def create_label(self, name, color, description=github.GithubObject.NotSet):
         """
         :calls: `POST /repos/:owner/:repo/labels <http://developer.github.com/v3/issues/labels>`_
         :param name: string
         :param color: string
+        :param description: string
         :rtype: :class:`github.Label.Label`
         """
         assert isinstance(name, (str, unicode)), name
         assert isinstance(color, (str, unicode)), color
+        assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
         post_parameters = {
             "name": name,
             "color": color,
         }
+        if description is not github.GithubObject.NotSet:
+            post_parameters["description"] = description
         headers, data = self._requester.requestJsonAndCheck(
             "POST",
             self.url + "/labels",
-            input=post_parameters
+            input=post_parameters,
+            headers={'Accept': 'application/vnd.github.symmetra-preview+json'}
         )
         return github.Label.Label(self._requester, headers, data, completed=True)
 

--- a/github/tests/Label.py
+++ b/github/tests/Label.py
@@ -39,14 +39,16 @@ class Label(Framework.TestCase):
     def testAttributes(self):
         self.assertEqual(self.label.color, "e10c02")
         self.assertEqual(self.label.name, "Bug")
+        self.assertIsNone(self.label.description)
         self.assertEqual(self.label.url, "https://api.github.com/repos/jacquev6/PyGithub/labels/Bug")
 
         # test __repr__() based on this attributes
         self.assertEqual(self.label.__repr__(), 'Label(name="Bug")')
 
     def testEdit(self):
-        self.label.edit("LabelEditedByPyGithub", "0000ff")
+        self.label.edit("LabelEditedByPyGithub", "0000ff", "Description of LabelEditedByPyGithub")
         self.assertEqual(self.label.color, "0000ff")
+        self.assertEqual(self.label.description, "Description of LabelEditedByPyGithub")
         self.assertEqual(self.label.name, "LabelEditedByPyGithub")
         self.assertEqual(self.label.url, "https://api.github.com/repos/jacquev6/PyGithub/labels/LabelEditedByPyGithub")
 

--- a/github/tests/ReplayData/Issue50.testCreateLabel.txt
+++ b/github/tests/ReplayData/Issue50.testCreateLabel.txt
@@ -3,7 +3,7 @@ POST
 api.github.com
 None
 /repos/jacquev6/PyGithub/labels
-{'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+{'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python', 'Accept': 'application/vnd.github.symmetra-preview+json'}
 {"color": "ffff00", "name": "Label with spaces and strange characters (&*#$)"}
 201
 [('status', '201 Created'), ('content-length', '197'), ('etag', '"99cbb3bf0f7ee7d6278c2ddd3ef42577"'), ('x-ratelimit-remaining', '4968'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('location', 'https://api.github.com/repos/jacquev6/PyGithub/labels/Label+with+spaces+and+strange+characters+%28%26%2A%23%24%29'), ('cache-control', 'max-age=0, private, must-revalidate'), ('date', 'Thu, 28 Jun 2012 19:29:52 GMT'), ('content-type', 'application/json; charset=utf-8')]

--- a/github/tests/ReplayData/Label.testEdit.txt
+++ b/github/tests/ReplayData/Label.testEdit.txt
@@ -3,9 +3,9 @@ PATCH
 api.github.com
 None
 /repos/jacquev6/PyGithub/labels/Bug
-{'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
-{"color": "0000ff", "name": "LabelEditedByPyGithub"}
+{'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python', 'Accept': 'application/vnd.github.symmetra-preview+json'}
+{"color": "0000ff", "name": "LabelEditedByPyGithub", "description": "Description of LabelEditedByPyGithub"}
 200
 [('status', '200 OK'), ('x-ratelimit-remaining', '4965'), ('content-length', '133'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"57435796bd4f14b84ad92105669cfab1"'), ('date', 'Sat, 19 May 2012 10:17:44 GMT'), ('content-type', 'application/json; charset=utf-8')]
-{"url":"https://api.github.com/repos/jacquev6/PyGithub/labels/LabelEditedByPyGithub","name":"LabelEditedByPyGithub","color":"0000ff"}
+{"url":"https://api.github.com/repos/jacquev6/PyGithub/labels/LabelEditedByPyGithub","name":"LabelEditedByPyGithub","color":"0000ff","description":"Description of LabelEditedByPyGithub"}
 

--- a/github/tests/ReplayData/Repository.testCreateLabel.txt
+++ b/github/tests/ReplayData/Repository.testCreateLabel.txt
@@ -3,9 +3,9 @@ POST
 api.github.com
 None
 /repos/jacquev6/PyGithub/labels
-{'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
-{"color": "00ff00", "name": "Label with silly name % * + created by PyGithub"}
+{'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python', 'Accept': 'application/vnd.github.symmetra-preview+json'}
+{"color": "00ff00", "name": "Label with silly name % * + created by PyGithub", "description": "Description of label with silly name"}
 201
 [('status', '201 Created'), ('x-ratelimit-remaining', '4969'), ('content-length', '191'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"92b623552b1bac3f019d03c920305acd"'), ('date', 'Sat, 19 May 2012 10:17:36 GMT'), ('content-type', 'application/json; charset=utf-8'), ('location', 'https://api.github.com/repos/jacquev6/PyGithub/labels/Label+with+silly+name+%25+%2A+%2B+created+by+PyGithub')]
-{"url":"https://api.github.com/repos/jacquev6/PyGithub/labels/Label+with+silly+name+%25+%2A+%2B+created+by+PyGithub","name":"Label with silly name % * + created by PyGithub","color":"00ff00"}
+{"url":"https://api.github.com/repos/jacquev6/PyGithub/labels/Label+with+silly+name+%25+%2A+%2B+created+by+PyGithub","name":"Label with silly name % * + created by PyGithub","color":"00ff00","description":"Description of label with silly name"}
 

--- a/github/tests/Repository.py
+++ b/github/tests/Repository.py
@@ -226,8 +226,9 @@ class Repository(Framework.TestCase):
         self.assertEqual(issue.number, 30)
 
     def testCreateLabel(self):
-        label = self.repo.create_label("Label with silly name % * + created by PyGithub", "00ff00")
+        label = self.repo.create_label("Label with silly name % * + created by PyGithub", "00ff00", "Description of label with silly name")
         self.assertEqual(label.color, "00ff00")
+        self.assertEqual(label.description, "Description of label with silly name")
         self.assertEqual(label.name, "Label with silly name % * + created by PyGithub")
         self.assertEqual(label.url, "https://api.github.com/repos/jacquev6/PyGithub/labels/Label+with+silly+name+%25+%2A+%2B+created+by+PyGithub")
 


### PR DESCRIPTION
The description attribute handling requirement is
  a custom media type in the Accept header:
    [application/vnd.github.symmetra-preview+json](https://developer.github.com/v3/issues/labels/)

Limitation: 
* FIXME: `Repository.get_labels` does not report description, possibly something has changed in the preview API.

-----

Following `Repository.get_labels`, access to label's `description` property calls to `CompletableGithubObject._completeIfNeeded` and eventually `CompletableGithubObject.__complete` which requests e.g `https://api.github.com/repos/mloskot/github-label-maker/labels/mylabel`. The response, however, does NOT include the `description`

```
g = github.Github(<github_token>)
r = g.get_user().get_repo(<github_repo>)
repo_labels = r.get_labels()
i = 0
for label in repo_labels:
     if not label.description and label.description is not github.GithubObject.NotSet:
          i += 1
print(i) # always zero, regardless if labels are described in the repo
```

I've tried various hacks to ensure the required `Accept`  header is included, but nothing helps. Perhaps, I'm hitting the missing functionality due to

> [Warning](https://developer.github.com/v3/issues/labels/): The API may change without advance notice during the preview period.

FYI, I'm trying out this functionality while developing https://github.com/mloskot/github-label-maker/