### PR TITLE
Add support for team privacy

### DIFF
--- a/github/Team.py
+++ b/github/Team.py
@@ -139,6 +139,14 @@ class Team(github.GithubObject.CompletableGithubObject):
         self._completeIfNotSet(self._organization)
         return self._organization.value
 
+    @property
+    def privacy(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._privacy)
+        return self._privacy.value
+
     def add_to_members(self, member):
         """
         :calls: `PUT /teams/:id/members/:user <http://developer.github.com/v3/orgs/teams>`_
@@ -215,20 +223,24 @@ class Team(github.GithubObject.CompletableGithubObject):
             self.url
         )
 
-    def edit(self, name, permission=github.GithubObject.NotSet):
+    def edit(self, name, permission=github.GithubObject.NotSet, privacy=github.GithubObject.NotSet):
         """
         :calls: `PATCH /teams/:id <http://developer.github.com/v3/orgs/teams>`_
         :param name: string
         :param permission: string
+        :param privacy: string
         :rtype: None
         """
         assert isinstance(name, (str, unicode)), name
         assert permission is github.GithubObject.NotSet or isinstance(permission, (str, unicode)), permission
+        assert privacy is github.GithubObject.NotSet or isinstance(privacy, (str, unicode)), privacy
         post_parameters = {
             "name": name,
         }
         if permission is not github.GithubObject.NotSet:
             post_parameters["permission"] = permission
+        if privacy is not github.GithubObject.NotSet:
+            post_parameters["privacy"] = privacy
         headers, data = self._requester.requestJsonAndCheck(
             "PATCH",
             self.url,
@@ -332,6 +344,7 @@ class Team(github.GithubObject.CompletableGithubObject):
         self._slug = github.GithubObject.NotSet
         self._url = github.GithubObject.NotSet
         self._organization = github.GithubObject.NotSet
+        self._privacy = github.GithubObject.NotSet
 
     def _useAttributes(self, attributes):
         if "id" in attributes:  # pragma no branch
@@ -356,3 +369,5 @@ class Team(github.GithubObject.CompletableGithubObject):
             self._url = self._makeStringAttribute(attributes["url"])
         if "organization" in attributes:  # pragma no branch
             self._organization = self._makeClassAttribute(github.Organization.Organization, attributes["organization"])
+        if "privacy" in attributes:  # pragma no branch
+            self._privacy = self._makeStringAttribute(attributes["privacy"])

--- a/github/tests/ReplayData/Team.setUp.txt
+++ b/github/tests/ReplayData/Team.setUp.txt
@@ -18,5 +18,5 @@ None
 None
 200
 [('status', '200 OK'), ('x-ratelimit-remaining', '4975'), ('content-length', '145'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"03555a65309084f36bcf959063a39d35"'), ('date', 'Sat, 26 May 2012 21:09:52 GMT'), ('content-type', 'application/json; charset=utf-8')]
-{"repos_count":0,"url":"https://api.github.com/teams/189850","members_count":0,"name":"Team created by PyGithub","permission":"pull","id":189850,"organization":{"login":"BeaverSoftware","id":1424031,"url":"https://api.github.com/orgs/BeaverSoftware"}}
+{"repos_count":0,"url":"https://api.github.com/teams/189850","members_count":0,"name":"Team created by PyGithub","privacy":"closed","permission":"pull","id":189850,"organization":{"login":"BeaverSoftware","id":1424031,"url":"https://api.github.com/orgs/BeaverSoftware"}}
 

--- a/github/tests/ReplayData/Team.testEditWithAllArguments.txt
+++ b/github/tests/ReplayData/Team.testEditWithAllArguments.txt
@@ -4,8 +4,8 @@ api.github.com
 None
 /teams/189850
 {'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
-{"name": "Name edited twice by PyGithub", "permission": "admin"}
+{"name": "Name edited twice by PyGithub", "permission": "admin", "privacy": "secret"}
 200
-[('status', '200 OK'), ('x-ratelimit-remaining', '4949'), ('content-length', '151'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"8856425cedbdf3075576e823f39fc3d6"'), ('date', 'Sat, 26 May 2012 21:14:46 GMT'), ('content-type', 'application/json; charset=utf-8')]
-{"permission":"admin","members_count":0,"url":"https://api.github.com/teams/189850","repos_count":0,"name":"Name edited twice by PyGithub","id":189850}
+[('status', '200 OK'), ('x-ratelimit-remaining', '4949'), ('content-length', '170'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"8856425cedbdf3075576e823f39fc3d6"'), ('date', 'Sat, 26 May 2012 21:14:46 GMT'), ('content-type', 'application/json; charset=utf-8')]
+{"permission":"admin","members_count":0,"url":"https://api.github.com/teams/189850","repos_count":0,"privacy":"secret","name":"Name edited twice by PyGithub","id":189850}
 

--- a/github/tests/Team.py
+++ b/github/tests/Team.py
@@ -48,6 +48,7 @@ class Team(Framework.TestCase):
         self.assertEqual(self.team.repos_count, 0)
         self.assertEqual(self.team.url, "https://api.github.com/teams/189850")
         self.assertEqual(self.team.organization, self.org)
+        self.assertEqual(self.team.privacy, "closed")
 
         # test __repr__() based on this attributes
         self.assertEqual(self.team.__repr__(), 'Team(name="Team created by PyGithub", id=189850)')
@@ -85,9 +86,10 @@ class Team(Framework.TestCase):
         self.assertEqual(self.team.name, "Name edited by PyGithub")
 
     def testEditWithAllArguments(self):
-        self.team.edit("Name edited twice by PyGithub", "admin")
+        self.team.edit("Name edited twice by PyGithub", "admin", "secret")
         self.assertEqual(self.team.name, "Name edited twice by PyGithub")
         self.assertEqual(self.team.permission, "admin")
+        self.assertEqual(self.team.privacy, "secret")
 
     def testDelete(self):
         self.team.delete()


### PR DESCRIPTION
Teams contain support for privacy, by being either closed, or secret.
Export the string via a property, and allow editing it via the edit
method.