### PR TITLE
Fix github API requests after asset upload

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -188,8 +188,6 @@ class Requester:
         return self.__check(*self.requestMultipart(verb, url, parameters, headers, input))
 
     def requestBlobAndCheck(self, verb, url, parameters=None, headers=None, input=None):
-        o = urlparse.urlparse(url)
-        self.__hostname = o.hostname
         return self.__check(*self.requestBlob(verb, url, parameters, headers, input))
 
     def __check(self, status, responseHeaders, output):
@@ -272,6 +270,8 @@ class Requester:
         if self.__apiPreview:
             requestHeaders["Accept"] = "application/vnd.github.moondragon+json"
 
+        if url.startswith("https://uploads.github.com"):
+            cnx = "uploads"
         url = self.__makeAbsoluteUrl(url)
         url = self.__addParametersToUrl(url, parameters)
 
@@ -299,8 +299,9 @@ class Requester:
         original_cnx = cnx
         if cnx is None:
             cnx = self.__createConnection()
-        else:
-            assert cnx == "status"
+        elif cnx == "uploads":
+            cnx = self.__httpsConnectionClass("uploads.github.com", 443)
+        elif cnx == "status":
             cnx = self.__httpsConnectionClass("status.github.com", 443)
         cnx.request(
             verb,

--- a/github/tests/ReplayData/Release.testUploadAsset.txt
+++ b/github/tests/ReplayData/Release.testUploadAsset.txt
@@ -34,7 +34,7 @@ None
 https
 POST
 uploads.github.com
-None
+443
 /repos/edhollandAL/PyGithub/releases/1210837/assets?label=unit+test+artifact&name=archive.zip
 {'Authorization': 'Basic login_and_password_removed', 'Content-Length': 140, 'User-Agent': 'PyGithub/Python', 'Content-Type': 'application/zip'}
 None


### PR DESCRIPTION
In the old code the `self.__hostname` would be overwritten with `uploads.github.com`
but it could not be correctly re-set to `api.github.com` after completing the upload
By handling the situation of connections to `https://uploads.github.com` the same way
we handle `status.github.com` we can resolve this problem.

The old code results if first an `upload_asset()` and then a regular api method in the following trace:
```
  File "github/Requester.py", line 185, in requestJsonAndCheck
    return self.__check(*self.requestJson(verb, url, parameters, headers, input, cnx))
  File "github/Requester.py", line 234, in requestJson
    return self.__requestEncode(cnx, verb, url, parameters, headers, input, encode)
  File "github/Requester.py", line 279, in __requestEncode
    url = self.__makeAbsoluteUrl(url)
  File "github/Requester.py", line 351, in __makeAbsoluteUrl
    assert o.hostname in [self.__hostname, "uploads.github.com"], o.hostname
AssertionError: api.github.com
```