### PR TITLE
Fix github API requests after asset upload

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -72,6 +72,7 @@ import Invitation
 atLeastPython3 = sys.hexversion >= 0x03000000
 
 DEFAULT_BASE_URL = "https://api.github.com"
+DEFAULT_STATUS_URL = "https://status.github.com"
 # As of 2018-05-17, Github imposes a 10s limit for completion of API requests.
 # Thus, the timeout should be slightly > 10s to account for network/front-end
 # latency.
@@ -625,8 +626,7 @@ class Github(object):
         """
         headers, attributes = self.__requester.requestJsonAndCheck(
             "GET",
-            "/api/status.json",
-            cnx="status"
+            DEFAULT_STATUS_URL + "/api/status.json"
         )
         return Status.Status(self.__requester, headers, attributes, completed=True)
 
@@ -639,8 +639,7 @@ class Github(object):
         """
         headers, attributes = self.__requester.requestJsonAndCheck(
             "GET",
-            "/api/last-message.json",
-            cnx="status"
+            DEFAULT_STATUS_URL + "/api/last-message.json"
         )
         return StatusMessage.StatusMessage(self.__requester, headers, attributes, completed=True)
 
@@ -653,8 +652,7 @@ class Github(object):
         """
         headers, data = self.__requester.requestJsonAndCheck(
             "GET",
-            "/api/messages.json",
-            cnx="status"
+            DEFAULT_STATUS_URL + "/api/messages.json"
         )
         return [StatusMessage.StatusMessage(self.__requester, headers, attributes, completed=True) for attributes in data]
 

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -254,22 +254,28 @@ class Requester:
         self.__apiPreview = api_preview
         self.__verify = verify
 
-    def requestJsonAndCheck(self, verb, url, parameters=None, headers=None, input=None, cnx=None):
-        return self.__check(*self.requestJson(verb, url, parameters, headers, input, cnx))
+    def requestJsonAndCheck(self, verb, url, parameters=None, headers=None, input=None):
+        return self.__check(*self.requestJson(verb, url, parameters, headers, input, self.__customConnection(url)))
 
     def requestMultipartAndCheck(self, verb, url, parameters=None, headers=None, input=None):
-        return self.__check(*self.requestMultipart(verb, url, parameters, headers, input))
+        return self.__check(*self.requestMultipart(verb, url, parameters, headers, input, self.__customConnection(url)))
 
     def requestBlobAndCheck(self, verb, url, parameters=None, headers=None, input=None):
-        o = urlparse.urlparse(url)
-        self.__hostname = o.hostname
-        return self.__check(*self.requestBlob(verb, url, parameters, headers, input))
+        return self.__check(*self.requestBlob(verb, url, parameters, headers, input, self.__customConnection(url)))
 
     def __check(self, status, responseHeaders, output):
         output = self.__structuredFromJson(output)
         if status >= 400:
             raise self.__createException(status, responseHeaders, output)
         return responseHeaders, output
+
+    def __customConnection(self, url):
+        cnx = None
+        if not url.startswith("/"):
+            o = urlparse.urlparse(url)
+            if o.hostname != self.__hostname or o.port != self.__port:
+                cnx = self.__httpsConnectionClass(o.hostname, o.port)
+        return cnx
 
     def __createException(self, status, headers, output):
         if status == 401 and output.get("message") == "Bad credentials":
@@ -303,7 +309,7 @@ class Requester:
 
         return self.__requestEncode(cnx, verb, url, parameters, headers, input, encode)
 
-    def requestMultipart(self, verb, url, parameters=None, headers=None, input=None):
+    def requestMultipart(self, verb, url, parameters=None, headers=None, input=None, cnx=None):
         def encode(input):
             boundary = "----------------------------3c3ba8b523b2"
             eol = "\r\n"
@@ -317,9 +323,9 @@ class Requester:
             encoded_input += "--" + boundary + "--" + eol
             return "multipart/form-data; boundary=" + boundary, encoded_input
 
-        return self.__requestEncode(None, verb, url, parameters, headers, input, encode)
+        return self.__requestEncode(cnx, verb, url, parameters, headers, input, encode)
 
-    def requestBlob(self, verb, url, parameters={}, headers={}, input=None):
+    def requestBlob(self, verb, url, parameters={}, headers={}, input=None, cnx=None):
         def encode(local_path):
             if "Content-Type" in headers:
                 mime_type = headers["Content-Type"]
@@ -331,7 +337,7 @@ class Requester:
 
         if input:
             headers["Content-Length"] = str(os.path.getsize(input))
-        return self.__requestEncode(None, verb, url, parameters, headers, input, encode)
+        return self.__requestEncode(cnx, verb, url, parameters, headers, input, encode)
 
     def __requestEncode(self, cnx, verb, url, parameters, requestHeaders, input, encode):
         assert verb in ["HEAD", "GET", "POST", "PATCH", "PUT", "DELETE"]
@@ -372,9 +378,6 @@ class Requester:
         original_cnx = cnx
         if cnx is None:
             cnx = self.__createConnection()
-        else:
-            assert cnx == "status"
-            cnx = self.__httpsConnectionClass("status.github.com", 443)
         cnx.request(
             verb,
             url,
@@ -413,8 +416,8 @@ class Requester:
             url = self.__prefix + url
         else:
             o = urlparse.urlparse(url)
-            assert o.hostname in [self.__hostname, "uploads.github.com"], o.hostname
-            assert o.path.startswith((self.__prefix, "/api/uploads"))
+            assert o.hostname in [self.__hostname, "uploads.github.com", "status.github.com"], o.hostname
+            assert o.path.startswith((self.__prefix, "/api/"))
             assert o.port == self.__port
             url = o.path
             if o.query != "":

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -273,8 +273,13 @@ class Requester:
         cnx = None
         if not url.startswith("/"):
             o = urlparse.urlparse(url)
-            if o.hostname != self.__hostname or o.port != self.__port:
-                cnx = self.__httpsConnectionClass(o.hostname, o.port)
+            if o.hostname != self.__hostname or \
+               (o.port and o.port != self.__port) or \
+               (o.scheme != self.__scheme and not (o.scheme == "https" and self.__scheme == "http")):  # issue80
+                if o.scheme == 'http':
+                    cnx = self.__httpConnectionClass(o.hostname, o.port)
+                elif o.scheme == 'https':
+                    cnx = self.__httpsConnectionClass(o.hostname, o.port)
         return cnx
 
     def __createException(self, status, headers, output):

--- a/github/tests/ReplayData/ExposeAllAttributes.testAllClasses.txt
+++ b/github/tests/ReplayData/ExposeAllAttributes.testAllClasses.txt
@@ -265,7 +265,7 @@ None
 https
 GET
 status.github.com
-443
+None
 /api/status.json
 {'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 None
@@ -276,7 +276,7 @@ None
 https
 GET
 status.github.com
-443
+None
 /api/last-message.json
 {'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 None

--- a/github/tests/ReplayData/Status.testGetLastMessage.txt
+++ b/github/tests/ReplayData/Status.testGetLastMessage.txt
@@ -1,7 +1,7 @@
 https
 GET
 status.github.com
-443
+None
 /api/last-message.json
 {'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 None

--- a/github/tests/ReplayData/Status.testGetMessages.txt
+++ b/github/tests/ReplayData/Status.testGetMessages.txt
@@ -1,7 +1,7 @@
 https
 GET
 status.github.com
-443
+None
 /api/messages.json
 {'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 None

--- a/github/tests/ReplayData/Status.testGetStatus.txt
+++ b/github/tests/ReplayData/Status.testGetStatus.txt
@@ -1,7 +1,7 @@
 https
 GET
 status.github.com
-443
+None
 /api/status.json
 {'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 None


### PR DESCRIPTION
In the old code the self.__hostname would be overwritten with uploads.github.com
but it could not be correctly re-set to api.github.com after completing the upload
Create a separate connection if hostname or port differ in requestBlobAndCheck

in the end this became quite a large overhaul, to also make this change generic
for e.g. connecting to status.github.com and similar methods

~~not sure if tests need (more) updating, if so I will update the PR accordingly~~