### PR TITLE
Refactor Repository.get_protected_branch

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -48,6 +48,7 @@ import time
 import sys
 from httplib import HTTPSConnection
 import jwt
+import warnings
 
 from Requester import Requester, json
 import AuthenticatedUser
@@ -106,6 +107,8 @@ class Github(object):
         assert user_agent is None or isinstance(user_agent, (str, unicode)), user_agent
         assert isinstance(api_preview, (bool))
         self.__requester = Requester(login_or_token, password, base_url, timeout, client_id, client_secret, user_agent, per_page, api_preview, verify)
+        # Always warn about deprecation
+        warnings.simplefilter('always', DeprecationWarning)
 
     def __get_FIX_REPO_GET_GIT_REF(self):
         """

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -75,6 +75,7 @@ import sys
 import urllib
 import datetime
 from base64 import b64encode
+import warnings
 
 import github.GithubObject
 import github.PaginatedList
@@ -1244,17 +1245,10 @@ class Repository(github.GithubObject.CompletableGithubObject):
         return github.Branch.Branch(self._requester, headers, data, completed=True)
 
     def get_protected_branch(self, branch):
-        """
-        :calls: `GET /repos/:owner/:repo/branches/:branch <https://developer.github.com/v3/repos/#response-10>`_
-        :param branch: string
-        :rtype: :class:`github.Branch.Branch`
-        """
-        assert isinstance(branch, (str, unicode)), branch
-        headers, data = self._requester.requestJsonAndCheck(
-            "GET",
-            self.url + "/branches/" + branch
-        )
-        return github.Branch.Branch(self._requester, headers, data, completed=True)
+        message = ("Repository.get_protected_branch() will be removed in "
+                   "a future release, use Repository.get_branch()")
+        warnings.warn(message, DeprecationWarning, stacklevel=2)
+        return self.get_branch(branch)
 
     def get_branches(self):
         """


### PR DESCRIPTION
The URL mentioned in the docstring for Repository.get_protected_branch
no longer seems to mention useful content, so to avoid an API break,
just return Repository.get_branch.