### PR TITLE
Use TestCase.assertRaises()

### DIFF
--- a/github/tests/Authentication.py
+++ b/github/tests/Authentication.py
@@ -56,15 +56,11 @@ class Authentication(Framework.BasicTestCase):
     def testAuthorizationHeaderWithLogin(self):
         # See special case in Framework.fixAuthorizationHeader
         g = github.Github("fake_login", "fake_password")
-        try:
+        with self.assertRaises(github.GithubException):
             g.get_user().name
-        except github.GithubException:
-            pass
 
     def testAuthorizationHeaderWithToken(self):
         # See special case in Framework.fixAuthorizationHeader
         g = github.Github("ZmFrZV9sb2dpbjpmYWtlX3Bhc3N3b3Jk")
-        try:
+        with self.assertRaises(github.GithubException):
             g.get_user().name
-        except github.GithubException:
-            pass

--- a/github/tests/Exceptions.py
+++ b/github/tests/Exceptions.py
@@ -39,87 +39,66 @@ import Framework
 atMostPython2 = sys.hexversion < 0x03000000
 
 
-class Exceptions(Framework.TestCase):  # To stay compatible with Python 2.6, we do not use self.assertRaises with only one argument
+class Exceptions(Framework.TestCase):
     def testInvalidInput(self):
-        raised = False
-        try:
+        with self.assertRaises(github.GithubException) as raisedexp:
             self.g.get_user().create_key("Bad key", "xxx")
-        except github.GithubException, exception:
-            raised = True
-            self.assertEqual(exception.status, 422)
-            self.assertEqual(
-                exception.data,
-                {
-                    "errors": [
-                        {
-                            "code": "custom",
-                            "field": "key",
-                            "message": "key is invalid. It must begin with 'ssh-rsa' or 'ssh-dss'. Check that you're copying the public half of the key",
-                            "resource": "PublicKey"
-                        }
-                    ],
-                    "message": "Validation Failed"
-                }
-            )
-        self.assertTrue(raised)
+        self.assertEqual(raisedexp.exception.status, 422)
+        self.assertEqual(
+            raisedexp.exception.data, {
+                "errors": [
+                    {
+                        "code": "custom",
+                        "field": "key",
+                        "message": "key is invalid. It must begin with 'ssh-rsa' or 'ssh-dss'. Check that you're copying the public half of the key",
+                        "resource": "PublicKey"
+                    }
+                ],
+                "message": "Validation Failed"
+            }
+        )
 
     def testNonJsonDataReturnedByGithub(self):
         # Replay data was forged according to https://github.com/jacquev6/PyGithub/pull/182
-        raised = False
-        try:
+        with self.assertRaises(github.GithubException) as raisedexp:
             self.g.get_user("jacquev6")
-        except github.GithubException, exception:
-            raised = True
-            self.assertEqual(exception.status, 503)
-            self.assertEqual(
-                exception.data,
-                {
-                    "data": "<html><body><h1>503 Service Unavailable</h1>No server is available to handle this request.</body></html>",
-                }
-            )
-        self.assertTrue(raised)
+        self.assertEqual(raisedexp.exception.status, 503)
+        self.assertEqual(
+            raisedexp.exception.data,
+            {
+                "data": "<html><body><h1>503 Service Unavailable</h1>No server is available to handle this request.</body></html>",
+            }
+        )
 
     def testUnknownObject(self):
-        raised = False
-        try:
+        with self.assertRaises(github.GithubException) as raisedexp:
             self.g.get_user().get_repo("Xxx")
-        except github.GithubException, exception:
-            raised = True
-            self.assertEqual(exception.status, 404)
-            self.assertEqual(exception.data, {"message": "Not Found"})
-            if atMostPython2:
-                self.assertEqual(str(exception), "404 {u'message': u'Not Found'}")
-            else:
-                self.assertEqual(str(exception), "404 {'message': 'Not Found'}")  # pragma no cover (Covered with Python 3)
-        self.assertTrue(raised)
+        self.assertEqual(raisedexp.exception.status, 404)
+        self.assertEqual(raisedexp.exception.data, {"message": "Not Found"})
+        if atMostPython2:
+            self.assertEqual(str(raisedexp.exception), "404 {u'message': u'Not Found'}")
+        else:
+            self.assertEqual(str(raisedexp.exception), "404 {'message': 'Not Found'}")  # pragma no cover (Covered with Python 3)
 
     def testUnknownUser(self):
-        raised = False
-        try:
+        with self.assertRaises(github.GithubException) as raisedexp:
             self.g.get_user("ThisUserShouldReallyNotExist")
-        except github.GithubException, exception:
-            raised = True
-            self.assertEqual(exception.status, 404)
-            self.assertEqual(exception.data, {"message": "Not Found"})
-            if atMostPython2:
-                self.assertEqual(str(exception), "404 {u'message': u'Not Found'}")
-            else:
-                self.assertEqual(str(exception), "404 {'message': 'Not Found'}")  # pragma no cover (Covered with Python 3)
-        self.assertTrue(raised)
+        self.assertEqual(raisedexp.exception.status, 404)
+        self.assertEqual(raisedexp.exception.data, {"message": "Not Found"})
+        if atMostPython2:
+            self.assertEqual(str(raisedexp.exception), "404 {u'message': u'Not Found'}")
+        else:
+            self.assertEqual(str(raisedexp.exception), "404 {'message': 'Not Found'}")  # pragma no cover (Covered with Python 3)
 
     def testBadAuthentication(self):
-        raised = False
-        try:
+        with self.assertRaises(github.GithubException) as raisedexp:
             github.Github("BadUser", "BadPassword").get_user().login
-        except github.GithubException, exception:
-            raised = True
-            self.assertEqual(exception.status, 401)
-            self.assertEqual(exception.data, {"message": "Bad credentials"})
-            if atMostPython2:
-                self.assertEqual(str(exception), "401 {u'message': u'Bad credentials'}")
-            else:
-                self.assertEqual(str(exception), "401 {'message': 'Bad credentials'}")  # pragma no cover (Covered with Python 3)
-        self.assertTrue(raised)
+        self.assertEqual(raisedexp.exception.status, 401)
+        self.assertEqual(raisedexp.exception.data, {"message": "Bad credentials"})
+        if atMostPython2:
+            self.assertEqual(str(raisedexp.exception), "401 {u'message': u'Bad credentials'}")
+        else:
+            self.assertEqual(str(raisedexp.exception), "401 {'message': 'Bad credentials'}")  # pragma no cover (Covered with Python 3)
 
     def testExceptionPickling(self):
         pickle.loads(pickle.dumps(github.GithubException('foo', 'bar')))

--- a/github/tests/Issue134.py
+++ b/github/tests/Issue134.py
@@ -32,13 +32,9 @@ import github
 class Issue134(Framework.BasicTestCase):  # https://github.com/jacquev6/PyGithub/pull/134
     def testGetAuthorizationsFailsWhenAutenticatedThroughOAuth(self):
         g = github.Github(self.oauth_token)
-        raised = False
-        try:
+        with self.assertRaises(github.GithubException) as raisedexp:
             list(g.get_user().get_authorizations())
-        except github.GithubException, exception:
-            raised = True
-            self.assertEqual(exception.status, 404)
-        self.assertTrue(raised)
+        self.assertEqual(raisedexp.exception.status, 404)
 
     def testGetAuthorizationsSucceedsWhenAutenticatedThroughLoginPassword(self):
         g = github.Github(self.login, self.password)

--- a/github/tests/Repository.py
+++ b/github/tests/Repository.py
@@ -551,14 +551,10 @@ class Repository(Framework.TestCase):
         self.assertEqual(commit, None)
 
     def testMergeWithConflict(self):
-        raised = False
-        try:
+        with self.assertRaises(github.GithubException) as raisedexp:
             commit = self.repo.merge("branchForBase", "branchForHead")
-        except github.GithubException, exception:
-            raised = True
-            self.assertEqual(exception.status, 409)
-            self.assertEqual(exception.data, {"message": "Merge conflict"})
-        self.assertTrue(raised)
+        self.assertEqual(raisedexp.exception.status, 409)
+        self.assertEqual(raisedexp.exception.data, {"message": "Merge conflict"})
 
     def testGetIssuesComments(self):
         self.assertListKeyEqual(self.repo.get_issues_comments()[:40], lambda c: c.id, [5168757, 5181640, 5183010, 5186061, 5226090, 5449237, 5518272, 5547576, 5780183, 5781803, 5820199, 5820912, 5924198, 5965724, 5965812, 5965891, 5966555, 5966633, 5981084, 5981232, 5981409, 5981451, 5991965, 6019700, 6088432, 6293572, 6305625, 6357374, 6357422, 6447481, 6467193, 6467312, 6467642, 6481200, 6481392, 6556134, 6557261, 6568164, 6568181, 6568553])
@@ -574,14 +570,10 @@ class Repository(Framework.TestCase):
         self.repo.subscribe_to_hub("push", "http://requestb.in/1bc1sc61", "my_secret")
 
     def testBadSubscribePubSubHubbub(self):
-        raised = False
-        try:
+        with self.assertRaises(github.GithubException) as raisedexp:
             self.repo.subscribe_to_hub("non-existing-event", "http://requestb.in/1bc1sc61")
-        except github.GithubException, exception:
-            raised = True
-            self.assertEqual(exception.status, 422)
-            self.assertEqual(exception.data, {"message": "Invalid event: \"non-existing-event\""})
-        self.assertTrue(raised)
+        self.assertEqual(raisedexp.exception.status, 422)
+        self.assertEqual(raisedexp.exception.data, {"message": "Invalid event: \"non-existing-event\""})
 
     def testUnsubscribePubSubHubbub(self):
         self.repo.unsubscribe_from_hub("push", "http://requestb.in/1bc1sc61")


### PR DESCRIPTION
Now that we no longer support Python 2.6, we can use the assertRaises()
method of TestCase as a context manager, tiding up a large amount of
technical debt.