### PR TITLE
Fix Content-Length invalid headers exception

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -327,7 +327,7 @@ class Requester:
             return mime_type, f
 
         if input:
-            headers["Content-Length"] = os.path.getsize(input)
+            headers["Content-Length"] = str(os.path.getsize(input))
         return self.__requestEncode(None, verb, url, parameters, headers, input, encode)
 
     def __requestEncode(self, cnx, verb, url, parameters, requestHeaders, input, encode):

--- a/github/tests/ReplayData/Release.testUploadAsset.txt
+++ b/github/tests/ReplayData/Release.testUploadAsset.txt
@@ -36,7 +36,7 @@ POST
 uploads.github.com
 None
 /repos/edhollandAL/PyGithub/releases/1210837/assets?label=unit+test+artifact&name=archive.zip
-{'Authorization': 'Basic login_and_password_removed', 'Content-Length': 140, 'User-Agent': 'PyGithub/Python', 'Content-Type': 'application/zip'}
+{'Authorization': 'Basic login_and_password_removed', 'Content-Length': '140', 'User-Agent': 'PyGithub/Python', 'Content-Type': 'application/zip'}
 None
 204
 [('content-length', '150'), ('vary', 'Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding'), ('x-served-by', '139317cebd6caf9cd03889139437f00b'), ('x-xss-protection', '1; mode=block'), ('x-content-type-options', 'nosniff'), ('etag', '"26708914904a29b8c9fd2ac006beb9db"'), ('access-control-allow-credentials', 'true'), ('status', '200 OK'), ('x-ratelimit-remaining', '4942'), ('x-github-media-type', 'github.v3; format=json'), ('access-control-expose-headers', 'ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval'), ('x-github-request-id', '56BCFFD3:5677:5265FA1:553A03F5'), ('cache-control', 'private, max-age=60, s-maxage=60'), ('last-modified', 'Fri, 24 Apr 2015 08:43:32 GMT'), ('date', 'Fri, 24 Apr 2015 08:51:01 GMT'), ('access-control-allow-origin', '*'), ('content-security-policy', "default-src 'none'"), ('strict-transport-security', 'max-age=31536000; includeSubdomains; preload'), ('server', 'GitHub.com'), ('x-ratelimit-limit', '5000'), ('x-frame-options', 'deny'), ('content-type', 'application/zip'), ('x-ratelimit-reset', '1429867683')]


### PR DESCRIPTION
With requests 2.11>= it is not allowed to pass int values for the header.
So we convert the size from int to string before passing it as value for Content-Length.

See e.g. https://github.com/requests/requests/issues/3512

below you can see a stack trace of the current problem
```
  File "/home/maarten/PyGithub/build/lib/github/Requester.py", line 261, in requestBlobAndCheck
    return self.__check(*self.requestBlob(verb, url, parameters, headers, input, self.__customConnection(url)))
  File "/home/maarten/PyGithub/build/lib/github/Requester.py", line 342, in requestBlob
    return self.__requestEncode(cnx, verb, url, parameters, headers, input, encode)
  File "/home/maarten/PyGithub/build/lib/github/Requester.py", line 365, in __requestEncode
    status, responseHeaders, output = self.__requestRaw(cnx, verb, url, requestHeaders, encoded_input)
  File "/home/maarten/PyGithub/build/lib/github/Requester.py", line 389, in __requestRaw
    response = cnx.getresponse()
  File "/home/maarten/PyGithub/build/lib/github/Requester.py", line 104, in getresponse
    r = verb(url, headers=self.headers, data=self.input, timeout=self.timeout)
  File "/home/maarten/.local/lib/python3.6/site-packages/requests/sessions.py", line 555, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/home/maarten/.local/lib/python3.6/site-packages/requests/sessions.py", line 494, in request
    prep = self.prepare_request(req)
  File "/home/maarten/.local/lib/python3.6/site-packages/requests/sessions.py", line 437, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "/home/maarten/.local/lib/python3.6/site-packages/requests/models.py", line 306, in prepare
    self.prepare_headers(headers)
  File "/home/maarten/.local/lib/python3.6/site-packages/requests/models.py", line 440, in prepare_headers
    check_header_validity(header)
  File "/home/maarten/.local/lib/python3.6/site-packages/requests/utils.py", line 872, in check_header_validity
    "bytes, not %s" % (name, value, type(value)))
requests.exceptions.InvalidHeader: Value for header {Content-Length: 65949023} must be of type str or bytes, not <class 'int'>
```