### PR TITLE
increase default timeout to be > github request timeout

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -72,7 +72,7 @@ import Invitation
 atLeastPython3 = sys.hexversion >= 0x03000000
 
 DEFAULT_BASE_URL = "https://api.github.com"
-# As of 2018-05-17, github imposes a 10s limit for completion of API requests.
+# As of 2018-05-17, Github imposes a 10s limit for completion of API requests.
 # Thus, the timeout should be slightly > 10s to account for network/front-end
 # latency.
 DEFAULT_TIMEOUT = 15

--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -72,7 +72,10 @@ import Invitation
 atLeastPython3 = sys.hexversion >= 0x03000000
 
 DEFAULT_BASE_URL = "https://api.github.com"
-DEFAULT_TIMEOUT = 10
+# As of 2018-05-17, github imposes a 10s limit for completion of API requests.
+# Thus, the timeout should be slightly > 10s to account for network/front-end
+# latency.
+DEFAULT_TIMEOUT = 15
 DEFAULT_PER_PAGE = 30
 
 


### PR DESCRIPTION
Github imposes a 10s limit for completion of API calls and returns an HTTP 502
if when the max time is exceeded.  However, the current default 10s request
timeout in pygithub will cause the a socket timeout before an HTTP status is
received, probably due to network latency and/or latency within the github
front-end.

#693