### PR TITLE
Retry50x

### DIFF
--- a/github/Consts.py
+++ b/github/Consts.py
@@ -31,6 +31,7 @@
 
 REQ_IF_NONE_MATCH = "If-None-Match"
 REQ_IF_MODIFIED_SINCE = "If-Modified-Since"
+HTTPSTATUS_50X_WAIT_TIME = "10"
 
 # ##############################################################################
 # Response Header                                                              #

--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -85,7 +85,7 @@ class Github(object):
     This is the main class you instantiate to access the Github API v3. Optional parameters allow different authentication methods.
     """
 
-    def __init__(self, login_or_token=None, password=None, base_url=DEFAULT_BASE_URL, timeout=DEFAULT_TIMEOUT, client_id=None, client_secret=None, user_agent='PyGithub/Python', per_page=DEFAULT_PER_PAGE, api_preview=False, verify=True):
+    def __init__(self, login_or_token=None, password=None, base_url=DEFAULT_BASE_URL, timeout=DEFAULT_TIMEOUT, client_id=None, client_secret=None, user_agent='PyGithub/Python', per_page=DEFAULT_PER_PAGE, api_preview=False, retry50x=0, verify=True):
         """
         :param login_or_token: string
         :param password: string
@@ -95,6 +95,7 @@ class Github(object):
         :param client_secret: string
         :param user_agent: string
         :param per_page: int
+        :param retry50x: int
         :param verify: boolean or string
         """
 
@@ -106,7 +107,7 @@ class Github(object):
         assert client_secret is None or isinstance(client_secret, (str, unicode)), client_secret
         assert user_agent is None or isinstance(user_agent, (str, unicode)), user_agent
         assert isinstance(api_preview, (bool))
-        self.__requester = Requester(login_or_token, password, base_url, timeout, client_id, client_secret, user_agent, per_page, api_preview, verify)
+        self.__requester = Requester(login_or_token, password, base_url, timeout, client_id, client_secret, user_agent, per_page, api_preview, retry50x, verify)
 
     def __get_FIX_REPO_GET_GIT_REF(self):
         """

--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -72,6 +72,7 @@ import Invitation
 atLeastPython3 = sys.hexversion >= 0x03000000
 
 DEFAULT_BASE_URL = "https://api.github.com"
+DEFAULT_STATUS_URL = "https://status.github.com"
 # As of 2018-05-17, Github imposes a 10s limit for completion of API requests.
 # Thus, the timeout should be slightly > 10s to account for network/front-end
 # latency.
@@ -625,8 +626,7 @@ class Github(object):
         """
         headers, attributes = self.__requester.requestJsonAndCheck(
             "GET",
-            "/api/status.json",
-            cnx="status"
+            DEFAULT_STATUS_URL + "/api/status.json"
         )
         return Status.Status(self.__requester, headers, attributes, completed=True)
 
@@ -639,8 +639,7 @@ class Github(object):
         """
         headers, attributes = self.__requester.requestJsonAndCheck(
             "GET",
-            "/api/last-message.json",
-            cnx="status"
+            DEFAULT_STATUS_URL + "/api/last-message.json"
         )
         return StatusMessage.StatusMessage(self.__requester, headers, attributes, completed=True)
 
@@ -653,8 +652,7 @@ class Github(object):
         """
         headers, data = self.__requester.requestJsonAndCheck(
             "GET",
-            "/api/messages.json",
-            cnx="status"
+            DEFAULT_STATUS_URL + "/api/messages.json"
         )
         return [StatusMessage.StatusMessage(self.__requester, headers, attributes, completed=True) for attributes in data]
 

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -254,22 +254,28 @@ class Requester:
         self.__apiPreview = api_preview
         self.__verify = verify
 
-    def requestJsonAndCheck(self, verb, url, parameters=None, headers=None, input=None, cnx=None):
-        return self.__check(*self.requestJson(verb, url, parameters, headers, input, cnx))
+    def requestJsonAndCheck(self, verb, url, parameters=None, headers=None, input=None):
+        return self.__check(*self.requestJson(verb, url, parameters, headers, input, self.__customConnection(url)))
 
     def requestMultipartAndCheck(self, verb, url, parameters=None, headers=None, input=None):
-        return self.__check(*self.requestMultipart(verb, url, parameters, headers, input))
+        return self.__check(*self.requestMultipart(verb, url, parameters, headers, input, self.__customConnection(url)))
 
     def requestBlobAndCheck(self, verb, url, parameters=None, headers=None, input=None):
-        o = urlparse.urlparse(url)
-        self.__hostname = o.hostname
-        return self.__check(*self.requestBlob(verb, url, parameters, headers, input))
+        return self.__check(*self.requestBlob(verb, url, parameters, headers, input, self.__customConnection(url)))
 
     def __check(self, status, responseHeaders, output):
         output = self.__structuredFromJson(output)
         if status >= 400:
             raise self.__createException(status, responseHeaders, output)
         return responseHeaders, output
+
+    def __customConnection(self, url):
+        cnx = None
+        if not url.startswith("/"):
+            o = urlparse.urlparse(url)
+            if o.hostname != self.__hostname or o.port != self.__port:
+                cnx = self.__httpsConnectionClass(o.hostname, o.port)
+        return cnx
 
     def __createException(self, status, headers, output):
         if status == 401 and output.get("message") == "Bad credentials":
@@ -303,7 +309,7 @@ class Requester:
 
         return self.__requestEncode(cnx, verb, url, parameters, headers, input, encode)
 
-    def requestMultipart(self, verb, url, parameters=None, headers=None, input=None):
+    def requestMultipart(self, verb, url, parameters=None, headers=None, input=None, cnx=None):
         def encode(input):
             boundary = "----------------------------3c3ba8b523b2"
             eol = "\r\n"
@@ -317,9 +323,9 @@ class Requester:
             encoded_input += "--" + boundary + "--" + eol
             return "multipart/form-data; boundary=" + boundary, encoded_input
 
-        return self.__requestEncode(None, verb, url, parameters, headers, input, encode)
+        return self.__requestEncode(cnx, verb, url, parameters, headers, input, encode)
 
-    def requestBlob(self, verb, url, parameters={}, headers={}, input=None):
+    def requestBlob(self, verb, url, parameters={}, headers={}, input=None, cnx=None):
         def encode(local_path):
             if "Content-Type" in headers:
                 mime_type = headers["Content-Type"]
@@ -331,7 +337,7 @@ class Requester:
 
         if input:
             headers["Content-Length"] = str(os.path.getsize(input))
-        return self.__requestEncode(None, verb, url, parameters, headers, input, encode)
+        return self.__requestEncode(cnx, verb, url, parameters, headers, input, encode)
 
     def __requestEncode(self, cnx, verb, url, parameters, requestHeaders, input, encode):
         assert verb in ["HEAD", "GET", "POST", "PATCH", "PUT", "DELETE"]
@@ -372,9 +378,6 @@ class Requester:
         original_cnx = cnx
         if cnx is None:
             cnx = self.__createConnection()
-        else:
-            assert cnx == "status"
-            cnx = self.__httpsConnectionClass("status.github.com", 443)
         cnx.request(
             verb,
             url,
@@ -413,8 +416,8 @@ class Requester:
             url = self.__prefix + url
         else:
             o = urlparse.urlparse(url)
-            assert o.hostname in [self.__hostname, "uploads.github.com"], o.hostname
-            assert o.path.startswith((self.__prefix, "/api/uploads"))
+            assert o.hostname in [self.__hostname, "uploads.github.com", "status.github.com"], o.hostname
+            assert o.path.startswith((self.__prefix, "/api/"))
             assert o.port == self.__port
             url = o.path
             if o.query != "":

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -273,8 +273,13 @@ class Requester:
         cnx = None
         if not url.startswith("/"):
             o = urlparse.urlparse(url)
-            if o.hostname != self.__hostname or o.port != self.__port:
-                cnx = self.__httpsConnectionClass(o.hostname, o.port)
+            if o.hostname != self.__hostname or \
+               (o.port and o.port != self.__port) or \
+               (o.scheme != self.__scheme and not (o.scheme == "https" and self.__scheme == "http")):  # issue80
+                if o.scheme == 'http':
+                    cnx = self.__httpConnectionClass(o.hostname, o.port)
+                elif o.scheme == 'https':
+                    cnx = self.__httpsConnectionClass(o.hostname, o.port)
         return cnx
 
     def __createException(self, status, headers, output):

--- a/github/tests/ReplayData/ExposeAllAttributes.testAllClasses.txt
+++ b/github/tests/ReplayData/ExposeAllAttributes.testAllClasses.txt
@@ -265,7 +265,7 @@ None
 https
 GET
 status.github.com
-443
+None
 /api/status.json
 {'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 None
@@ -276,7 +276,7 @@ None
 https
 GET
 status.github.com
-443
+None
 /api/last-message.json
 {'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 None

--- a/github/tests/ReplayData/Status.testGetLastMessage.txt
+++ b/github/tests/ReplayData/Status.testGetLastMessage.txt
@@ -1,7 +1,7 @@
 https
 GET
 status.github.com
-443
+None
 /api/last-message.json
 {'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 None

--- a/github/tests/ReplayData/Status.testGetMessages.txt
+++ b/github/tests/ReplayData/Status.testGetMessages.txt
@@ -1,7 +1,7 @@
 https
 GET
 status.github.com
-443
+None
 /api/messages.json
 {'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 None

--- a/github/tests/ReplayData/Status.testGetStatus.txt
+++ b/github/tests/ReplayData/Status.testGetStatus.txt
@@ -1,7 +1,7 @@
 https
 GET
 status.github.com
-443
+None
 /api/status.json
 {'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 None


### PR DESCRIPTION
The Github API (without any proxy or such) returns in some occasions a `502` error, even on a trivial operations. But it would be ridiculous to try to catch those for literally every Github API operation in programs using PyGithub. So this feature allows to specify a number of retries.

It based on the already existing PR #771 because it touches the same code and I don't want to have any regressions.