### PR TITLE
add Dismiss PR Reviews functionality

### DIFF
--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -525,7 +525,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
             "GET",
             self._parentUrl(self.url) + "/comments/" + str(id)
         )
-        return github.PullRequestComment.PullRequestComment(self._requester, headers, data, completed=True)
+        return github.PullRequestComment.PullRequestComment(self._requester, headers, data, completed=True)    
 
     def get_comments(self):
         """
@@ -625,6 +625,26 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
         headers, data = self._requester.requestJsonAndCheck(
             "GET",
             self.url + "/reviews/" + str(id),
+        )
+        return github.PullRequestReview.PullRequestReview(self._requester, headers, data, completed=True)
+
+    def dismiss_review(self, id, message):
+        """
+        :calls: `PUT /repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals <https://developer.github.com/v3/pulls/reviews>`_
+        :param id: integer
+        :param message: string
+        :rtype: None
+        """
+    
+        assert isinstance(id, int), id
+        assert isinstance(message, (str, unicode)), message
+        
+        put_parameters = {"message": message}
+        
+        headers, data = self._requester.requestJsonAndCheck(
+            "PUT",
+            self.url + "/reviews/" + str(id) + "/dismissals",
+            input=put_parameters
         )
         return github.PullRequestReview.PullRequestReview(self._requester, headers, data, completed=True)
 


### PR DESCRIPTION
This PR will allow end users to dismiss pull request reviews. This is helpful in conjunction with Github webhooks to dismiss stale reviews when new commits are pushed.

This was accomplished by a 'PUT' request very similar to the functionality of the `pull_request.get_review(<id>)` that contains a body in the form of `{"message": "<your message>}` and returns the dismissed review.
