### PR TITLE
GitRelease methods documentation

### DIFF
--- a/github/GitRelease.py
+++ b/github/GitRelease.py
@@ -170,7 +170,7 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
         :calls: `DELETE /repos/:owner/:repo/releases/:release_id <https://developer.github.com/v3/repos/releases/#delete-a-release>`_
         :rtype: None
         """
-        self._requester.requestJsonAndCheck(
+        headers, data = self._requester.requestJsonAndCheck(
             "DELETE",
             self.url
         )

--- a/github/GitRelease.py
+++ b/github/GitRelease.py
@@ -166,6 +166,10 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
         return self._zipball_url.value
 
     def delete_release(self):
+        """
+        :calls: `DELETE /repos/:owner/:repo/releases/:release_id <https://developer.github.com/v3/repos/releases/#delete-a-release>`_
+        :rtype: bool
+        """
         headers, data = self._requester.requestJsonAndCheck(
             "DELETE",
             self.url
@@ -173,6 +177,10 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
         return True
 
     def update_release(self, name, message, draft=False, prerelease=False):
+        """
+        :calls: `PATCH /repos/:owner/:repo/releases/:release_id <https://developer.github.com/v3/repos/releases/#edit-a-release>`_
+        :rtype: :class:`github.GitRelease.GitRelease`
+        """
         assert isinstance(name, (str, unicode)), name
         assert isinstance(message, (str, unicode)), message
         assert isinstance(draft, bool), draft
@@ -192,6 +200,10 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
         return github.GitRelease.GitRelease(self._requester, headers, data, completed=True)
 
     def upload_asset(self, path, label="", content_type=""):
+        """
+        :calls: `POST https://<upload_url>/repos/:owner/:repo/releases/:release_id/assets?name=foo.zip <https://developer.github.com/v3/repos/releases/#upload-a-release-asset>`_
+        :rtype: :class:`github.GitReleaseAsset.GitReleaseAsset`
+        """
         assert isinstance(path, (str, unicode)), path
         assert isinstance(label, (str, unicode)), label
 
@@ -212,6 +224,10 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
         return github.GitReleaseAsset.GitReleaseAsset(self._requester, resp_headers, data, completed=True)
 
     def get_assets(self):
+        """
+        :calls: `GET /repos/:owner/:repo/releases/:release_id/assets <https://developer.github.com/v3/repos/releases/#list-assets-for-a-release>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList`
+        """
         return github.PaginatedList.PaginatedList(
             github.GitReleaseAsset.GitReleaseAsset,
             self._requester,

--- a/github/GitRelease.py
+++ b/github/GitRelease.py
@@ -168,13 +168,12 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
     def delete_release(self):
         """
         :calls: `DELETE /repos/:owner/:repo/releases/:release_id <https://developer.github.com/v3/repos/releases/#delete-a-release>`_
-        :rtype: bool
+        :rtype: None
         """
-        headers, data = self._requester.requestJsonAndCheck(
+        self._requester.requestJsonAndCheck(
             "DELETE",
             self.url
         )
-        return True
 
     def update_release(self, name, message, draft=False, prerelease=False):
         """

--- a/github/tests/GitRelease.py
+++ b/github/tests/GitRelease.py
@@ -81,7 +81,7 @@ class Release(Framework.TestCase):
 
     def testDelete(self):
         self.release = self.g.get_user().get_repo("PyGithub").get_releases()[0]
-        self.assertTrue(self.release.delete_release())
+        self.release.delete_release()
 
     def testUpdate(self):
         self.release = self.g.get_user().get_repo("PyGithub").get_releases()[0]


### PR DESCRIPTION
Hi, here's my small contribution to the documentation in relation to #819 

Few things:
* the `delete_release` method always returns `True` so not sure if the return type is truly valid - potentially a bug
* I've tried generating the documentation locally to check if formatting is ok but failed - is there a guide to it?   I followed the read the docs starter guide but that didn't seem to reflect the way it's done here
