### PR TITLE
Add support for getting / replacing topics (#634)

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -673,7 +673,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
     @property
     def topics(self):
         """
-        :type: list 
+        :type: list of strings
         """
         self._completeIfNotSet(self._topics)
         return self._topics.value
@@ -2314,7 +2314,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_topics(self):
         """
-        :calls: `GET /repos/:owner/:repo/topics <http://developer.github.com/v3/repos>`_
+        :calls: `GET /repos/:owner/:repo/topics <https://developer.github.com/v3/repos/#list-all-topics-for-a-repository>`_
         :rtype: list of strings
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -2452,11 +2452,14 @@ class Repository(github.GithubObject.CompletableGithubObject):
         :param topics: list of strings
         :rtype: None
         """
+        post_parameters = {
+            'names': topics
+        }
         headers, data = self._requester.requestJsonAndCheck(
             "PUT",
             self.url + "/topics",
             headers={'Accept': 'application/vnd.github.mercy-preview+json'},
-            input=topics
+            input=post_parameters
         )
 
     def remove_from_collaborators(self, collaborator):

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -671,6 +671,14 @@ class Repository(github.GithubObject.CompletableGithubObject):
         return self._teams_url.value
 
     @property
+    def topics(self):
+        """
+        :type: list 
+        """
+        self._completeIfNotSet(self._topics)
+        return self._topics.value
+
+    @property
     def trees_url(self):
         """
         :type: string
@@ -2304,6 +2312,18 @@ class Repository(github.GithubObject.CompletableGithubObject):
             None
         )
 
+    def get_topics(self):
+        """
+        :calls: `GET /repos/:owner/:repo/topics <http://developer.github.com/v3/repos>`_
+        :rtype: list of strings
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/topics",
+            headers={'Accept': 'application/vnd.github.mercy-preview+json'}
+        )
+        return data['names']
+
     def get_watchers(self):
         """
         :calls: `GET /repos/:owner/:repo/watchers <http://developer.github.com/v3/activity/starring>`_
@@ -2424,6 +2444,19 @@ class Repository(github.GithubObject.CompletableGithubObject):
             "PATCH",
             self.url + "/branches/" + branch,
             input=post_parameters
+        )
+
+    def replace_topics(self, topics):
+        """
+        :calls: `PUT /repos/:owner/:repo/topics <http://developer.github.com/v3/repos>`_
+        :param topics: list of strings
+        :rtype: None
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "PUT",
+            self.url + "/topics",
+            headers={'Accept': 'application/vnd.github.mercy-preview+json'},
+            input=topics
         )
 
     def remove_from_collaborators(self, collaborator):
@@ -2564,6 +2597,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         self._svn_url = github.GithubObject.NotSet
         self._tags_url = github.GithubObject.NotSet
         self._teams_url = github.GithubObject.NotSet
+        self._topics = github.GithubObject.NotSet
         self._trees_url = github.GithubObject.NotSet
         self._updated_at = github.GithubObject.NotSet
         self._url = github.GithubObject.NotSet
@@ -2709,6 +2743,8 @@ class Repository(github.GithubObject.CompletableGithubObject):
             self._teams_url = self._makeStringAttribute(attributes["teams_url"])
         if "trees_url" in attributes:  # pragma no branch
             self._trees_url = self._makeStringAttribute(attributes["trees_url"])
+        if "topics" in attributes: # pragma no branch
+            self._topics = self._makeListOfStringsAttribute(attributes["topics"])
         if "updated_at" in attributes:  # pragma no branch
             self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
         if "url" in attributes:  # pragma no branch

--- a/github/tests/ReplayData/Repository.testGetTopics.txt
+++ b/github/tests/ReplayData/Repository.testGetTopics.txt
@@ -1,0 +1,11 @@
+https
+GET
+api.github.com
+None
+/repos/peterkline/PyGithub/topics
+{'Authorization': 'Basic login_and_password_removed', 'Accept': 'application/vnd.github.mercy-preview+json', 'User-Agent': 'PyGithub/Python'}
+None
+200
+[('content-length', '30'), ('x-runtime-rack', '0.081855'), ('vary', 'Accept, Authorization, Cookie, X-GitHub-OTP'), ('x-xss-protection', '1; mode=block'), ('x-content-type-options', 'nosniff'), ('etag', '"c34823528b2c41eadf247bcea3b7dabc"'), ('cache-control', 'private, max-age=60, s-maxage=60'), ('referrer-policy', 'origin-when-cross-origin, strict-origin-when-cross-origin'), ('status', '200 OK'), ('x-ratelimit-remaining', '4994'), ('x-github-media-type', 'github.mercy-preview; format=json'), ('access-control-expose-headers', 'ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval'), ('x-github-request-id', '4C20:5398:FE4A88:26DA323:5AD7F450'), ('date', 'Thu, 19 Apr 2018 01:43:45 GMT'), ('access-control-allow-origin', '*'), ('content-security-policy', "default-src 'none'"), ('strict-transport-security', 'max-age=31536000; includeSubdomains; preload'), ('server', 'GitHub.com'), ('x-ratelimit-limit', '5000'), ('x-frame-options', 'deny'), ('content-type', 'application/json; charset=utf-8'), ('x-ratelimit-reset', '1524105758')]
+{"names":["testing","github"]}
+

--- a/github/tests/ReplayData/Repository.testReplaceTopics.txt
+++ b/github/tests/ReplayData/Repository.testReplaceTopics.txt
@@ -1,11 +1,11 @@
 https
-GET
+PUT
 api.github.com
 None
 /repos/jacquev6/PyGithub/topics
-{'Authorization': 'Basic login_and_password_removed', 'Accept': 'application/vnd.github.mercy-preview+json', 'User-Agent': 'PyGithub/Python'}
-None
+{'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'Accept': 'application/vnd.github.mercy-preview+json', 'User-Agent': 'PyGithub/Python'}
+{"names": ["github", "testing"]}
 200
 [('content-length', '30'), ('x-runtime-rack', '0.081855'), ('vary', 'Accept, Authorization, Cookie, X-GitHub-OTP'), ('x-xss-protection', '1; mode=block'), ('x-content-type-options', 'nosniff'), ('etag', '"c34823528b2c41eadf247bcea3b7dabc"'), ('cache-control', 'private, max-age=60, s-maxage=60'), ('referrer-policy', 'origin-when-cross-origin, strict-origin-when-cross-origin'), ('status', '200 OK'), ('x-ratelimit-remaining', '4994'), ('x-github-media-type', 'github.mercy-preview; format=json'), ('access-control-expose-headers', 'ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval'), ('x-github-request-id', '4C20:5398:FE4A88:26DA323:5AD7F450'), ('date', 'Thu, 19 Apr 2018 01:43:45 GMT'), ('access-control-allow-origin', '*'), ('content-security-policy', "default-src 'none'"), ('strict-transport-security', 'max-age=31536000; includeSubdomains; preload'), ('server', 'GitHub.com'), ('x-ratelimit-limit', '5000'), ('x-frame-options', 'deny'), ('content-type', 'application/json; charset=utf-8'), ('x-ratelimit-reset', '1524105758')]
-{"names":["testing","github"]}
+{"names": ["testing","github"]}
 

--- a/github/tests/Repository.py
+++ b/github/tests/Repository.py
@@ -82,6 +82,7 @@ class Repository(Framework.TestCase):
         self.assertEqual(self.repo.source, None)
         self.assertEqual(self.repo.ssh_url, "git@github.com:jacquev6/PyGithub.git")
         self.assertEqual(self.repo.svn_url, "https://github.com/jacquev6/PyGithub")
+        self.assertEqual(self.repo.topics, None)
         self.assertEqual(self.repo.updated_at, datetime.datetime(2012, 5, 27, 6, 55, 28))
         self.assertEqual(self.repo.url, "https://api.github.com/repos/jacquev6/PyGithub")
         self.assertEqual(self.repo.watchers, 15)
@@ -710,6 +711,11 @@ class Repository(Framework.TestCase):
 
     def testGetLicense(self):
         self.assertEqual(len(self.repo.get_license().content), 47646)
+
+    def testGetTopics(self):
+        topic_list = self.repo.get_topics()
+        topic = u'github'
+        self.assertEquals(topic in topic_list, True)
 
 
 class LazyRepository(Framework.TestCase):

--- a/github/tests/Repository.py
+++ b/github/tests/Repository.py
@@ -715,8 +715,10 @@ class Repository(Framework.TestCase):
     def testGetTopics(self):
         topic_list = self.repo.get_topics()
         topic = u'github'
-        self.assertEquals(topic in topic_list, True)
+        self.assertIn(topic, topic_list)
 
+    def testReplaceTopics(self):
+        self.repo.replace_topics(['github', 'testing'])
 
 class LazyRepository(Framework.TestCase):
 


### PR DESCRIPTION
This is mostly @peterkline's work, just trying to replace #635 (which hasn't been updated) and adjust for some of the changes requested / discussed there.

This seems to resolves the existing test failure, and I think resolves most of the other feedback in the other PR. It also switches the input to `replace_topics()` to the expected array as discussed. Would appreciate feedback, esp. on the test case I added. Because there's no expected return from the method, I think that test is acceptable as-is? I'm not that familiar with this module's test setup, though, so let me know if I should update anything.

I didn't have much luck rebasing, so I just patched, but I did retain original author on the first commit.
cc @sfdye 