### PR TITLE
github/stale: use a stale label

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -19,7 +19,7 @@ exemptProjects: false
 exemptMilestones: false
 
 # Label to use when marking as stale
-# staleLabel: wontfix
+staleLabel: stale
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >


### PR DESCRIPTION
Previously it was defaulting to `wontfix` which may not be the case if an issue just goes idle.