### PR TITLE
Allow editing of Team descriptions

### DIFF
--- a/github/Team.py
+++ b/github/Team.py
@@ -16,6 +16,7 @@
 # Copyright 2018 Isuru Fernando <isuruf@gmail.com>                             #
 # Copyright 2018 James D'Amato <james.j.damato@gmail.com>                      #
 # Copyright 2018 sfdye <tsfdye@gmail.com>                                      #
+# Copyright 2018 Jacopo Notarstefano <jacopo.notarstefano@gmail.com>           #
 #                                                                              #
 # This file is part of PyGithub.                                               #
 # http://pygithub.readthedocs.io/                                              #
@@ -226,20 +227,24 @@ class Team(github.GithubObject.CompletableGithubObject):
             self.url
         )
 
-    def edit(self, name, permission=github.GithubObject.NotSet, privacy=github.GithubObject.NotSet):
+    def edit(self, name, description=github.GithubObject.NotSet, permission=github.GithubObject.NotSet, privacy=github.GithubObject.NotSet):
         """
         :calls: `PATCH /teams/:id <http://developer.github.com/v3/orgs/teams>`_
         :param name: string
+        :param description: string
         :param permission: string
         :param privacy: string
         :rtype: None
         """
         assert isinstance(name, (str, unicode)), name
+        assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
         assert permission is github.GithubObject.NotSet or isinstance(permission, (str, unicode)), permission
         assert privacy is github.GithubObject.NotSet or isinstance(privacy, (str, unicode)), privacy
         post_parameters = {
             "name": name,
         }
+        if description is not github.GithubObject.NotSet:
+            post_parameters["description"] = description
         if permission is not github.GithubObject.NotSet:
             post_parameters["permission"] = permission
         if privacy is not github.GithubObject.NotSet:

--- a/github/tests/ReplayData/Team.testEditWithAllArguments.txt
+++ b/github/tests/ReplayData/Team.testEditWithAllArguments.txt
@@ -4,8 +4,8 @@ api.github.com
 None
 /teams/189850
 {'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
-{"name": "Name edited twice by PyGithub", "permission": "admin", "privacy": "secret"}
+{"name": "Name edited twice by PyGithub", "permission": "admin", "privacy": "secret", "description": "Description edited by PyGithub"}
 200
 [('status', '200 OK'), ('x-ratelimit-remaining', '4949'), ('content-length', '170'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"8856425cedbdf3075576e823f39fc3d6"'), ('date', 'Sat, 26 May 2012 21:14:46 GMT'), ('content-type', 'application/json; charset=utf-8')]
-{"permission":"admin","members_count":0,"url":"https://api.github.com/teams/189850","repos_count":0,"privacy":"secret","name":"Name edited twice by PyGithub","id":189850}
+{"permission":"admin","members_count":0,"url":"https://api.github.com/teams/189850","repos_count":0,"privacy":"secret","name":"Name edited twice by PyGithub","id":189850, "description": "Description edited by PyGithub"}
 

--- a/github/tests/Team.py
+++ b/github/tests/Team.py
@@ -12,6 +12,7 @@
 # Copyright 2018 Isuru Fernando <isuruf@gmail.com>                             #
 # Copyright 2018 James D'Amato <james.j.damato@gmail.com>                      #
 # Copyright 2018 sfdye <tsfdye@gmail.com>                                      #
+# Copyright 2018 Jacopo Notarstefano <jacopo.notarstefano@gmail.com>           #
 #                                                                              #
 # This file is part of PyGithub.                                               #
 # http://pygithub.readthedocs.io/                                              #
@@ -87,8 +88,9 @@ class Team(Framework.TestCase):
         self.assertEqual(self.team.name, "Name edited by PyGithub")
 
     def testEditWithAllArguments(self):
-        self.team.edit("Name edited twice by PyGithub", "admin", "secret")
+        self.team.edit("Name edited twice by PyGithub", "Description edited by PyGithub", "admin", "secret")
         self.assertEqual(self.team.name, "Name edited twice by PyGithub")
+        self.assertEqual(self.team.description, "Description edited by PyGithub")
         self.assertEqual(self.team.permission, "admin")
         self.assertEqual(self.team.privacy, "secret")
 


### PR DESCRIPTION
PR https://github.com/PyGithub/PyGithub/pull/753 added this property but forgot to make it editable. The current PR fixes this omission.