### PR TITLE
Adding communications Retry functionality into requests via urllib3 retry object.

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -85,7 +85,7 @@ class Github(object):
     This is the main class you instantiate to access the Github API v3. Optional parameters allow different authentication methods.
     """
 
-    def __init__(self, login_or_token=None, password=None, base_url=DEFAULT_BASE_URL, timeout=DEFAULT_TIMEOUT, client_id=None, client_secret=None, user_agent='PyGithub/Python', per_page=DEFAULT_PER_PAGE, api_preview=False, verify=True):
+    def __init__(self, login_or_token=None, password=None, base_url=DEFAULT_BASE_URL, timeout=DEFAULT_TIMEOUT, client_id=None, client_secret=None, user_agent='PyGithub/Python', per_page=DEFAULT_PER_PAGE, api_preview=False, verify=True, retry=None):
         """
         :param login_or_token: string
         :param password: string
@@ -96,6 +96,7 @@ class Github(object):
         :param user_agent: string
         :param per_page: int
         :param verify: boolean or string
+        :param retry: int or urllib3 Retry Object
         """
 
         assert login_or_token is None or isinstance(login_or_token, (str, unicode)), login_or_token
@@ -106,7 +107,7 @@ class Github(object):
         assert client_secret is None or isinstance(client_secret, (str, unicode)), client_secret
         assert user_agent is None or isinstance(user_agent, (str, unicode)), user_agent
         assert isinstance(api_preview, (bool))
-        self.__requester = Requester(login_or_token, password, base_url, timeout, client_id, client_secret, user_agent, per_page, api_preview, verify)
+        self.__requester = Requester(login_or_token, password, base_url, timeout, client_id, client_secret, user_agent, per_page, api_preview, verify, retry)
 
     def __get_FIX_REPO_GET_GIT_REF(self):
         """

--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -48,6 +48,7 @@ import time
 import sys
 from httplib import HTTPSConnection
 import jwt
+import urllib3
 
 from Requester import Requester, json
 import AuthenticatedUser
@@ -96,7 +97,7 @@ class Github(object):
         :param user_agent: string
         :param per_page: int
         :param verify: boolean or string
-        :param retry: int or urllib3 Retry Object
+        :param retry: int or urllib3.util.retry.Retry object
         """
 
         assert login_or_token is None or isinstance(login_or_token, (str, unicode)), login_or_token
@@ -107,6 +108,7 @@ class Github(object):
         assert client_secret is None or isinstance(client_secret, (str, unicode)), client_secret
         assert user_agent is None or isinstance(user_agent, (str, unicode)), user_agent
         assert isinstance(api_preview, (bool))
+        assert retry is None or isinstance(retry, (int)) or isinstance(retry, (urllib3.util.Retry))
         self.__requester = Requester(login_or_token, password, base_url, timeout, client_id, client_secret, user_agent, per_page, api_preview, verify, retry)
 
     def __get_FIX_REPO_GET_GIT_REF(self):


### PR DESCRIPTION
This PR is related to #757 and #378

This is an attempt to add a communications retry feature into PyGithub that can be user defined at the top level.

This works directly with requests and uses the low level urllib3 Retry object (already used by requests) to implement the functionality.  It is backwards compatible with the current codeset.

The user can set the retry parameter in the top level `github(<login>, retry = X)` call.  Where X can be a simple `int` to define the number of retrys or it can be an `urllib3.util.retry.Retry(...)` object.  This allows the user very fine grained control over the retry system as defined by urllib3.

The structure for the Retry object can be setup like this example:
```
num_retries=3
backoff_factor=5
status_forcelist=(500, 502, 504)
retry_data = urllib3.util.retry.Retry(
                                      total=num_retries,
                                      read=num_retries,
                                      connect=num_retries,
                                      backoff_factor=backoff_factor,
                                      status_forcelist=status_forcelist
                                     )
gserver = github(<login or token>, retry = retry_data)
```
The urllib3 Retry object has many parameters, that allows the user much flexibility to configure retry's to their heart's content.

The only issue I have at the moment, is that I am completely baffled on how to add tests for this feature given the current testing infrastructure.  Any suggestions would be appreciated.

CC: @mfonville @jrouquie @sfdye 

EDIT: The code for this PR is now stale, and is being moved forward via PR #1002.  However, the discussion is still relevant.  