### PR TITLE
Fix unicode output printing in logging

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -465,4 +465,8 @@ class Requester:
                     requestHeaders["Authorization"] = "token (oauth token removed)"
                 else:  # pragma no cover (Cannot happen, but could if we add an authentication method => be prepared)
                     requestHeaders["Authorization"] = "(unknown auth removed)"  # pragma no cover (Cannot happen, but could if we add an authentication method => be prepared)
-            logger.debug("%s %s://%s%s %s %s ==> %i %s %s", str(verb), self.__scheme, self.__hostname, str(url), str(requestHeaders), str(input), status, str(responseHeaders), str(output))
+            if not atLeastPython3:
+                output_str = unicode(output)
+            else:
+                output_str = str(output)
+            logger.debug("%s %s://%s%s %s %s ==> %i %s %s", str(verb), self.__scheme, self.__hostname, str(url), str(requestHeaders), str(input), status, str(responseHeaders), output_str)


### PR DESCRIPTION
The problem reproduces in python2 only:
```python
Python 2.7.12 (default, Dec  4 2017, 14:50:18) 
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from github import Github
>>> repo = Github().get_user("alesapin").get_repo("ClickHouse")
>>> import logging
>>> logging.basicConfig(level=logging.DEBUG)
>>> commit = repo.get_commit("2583abfccf1d0e229da2eaa3203cdfb548001a1b")
DEBUG:urllib3.connectionpool:https://api.github.com:443 "GET /repos/alesapin/ClickHouse/commits/2583abfccf1d0e229da2eaa3203cdfb548001a1b HTTP/1.1" 200 None
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/github/Repository.py", line 1317, in get_commit
    self.url + "/commits/" + sha
  File "/usr/local/lib/python2.7/dist-packages/github/Requester.py", line 260, in requestJsonAndCheck
    return self.__check(*self.requestJson(verb, url, parameters, headers, input, self.__customConnection(url)))
  File "/usr/local/lib/python2.7/dist-packages/github/Requester.py", line 317, in requestJson
    return self.__requestEncode(cnx, verb, url, parameters, headers, input, encode)
  File "/usr/local/lib/python2.7/dist-packages/github/Requester.py", line 370, in __requestEncode
    status, responseHeaders, output = self.__requestRaw(cnx, verb, url, requestHeaders, encoded_input)
  File "/usr/local/lib/python2.7/dist-packages/github/Requester.py", line 405, in __requestRaw
    self.__log(verb, url, requestHeaders, input, status, responseHeaders, output)
  File "/usr/local/lib/python2.7/dist-packages/github/Requester.py", line 468, in __log
    logger.debug("%s %s://%s%s %s %s ==> %i %s %s", str(verb), self.__scheme, self.__hostname, str(url), str(requestHeaders), str(input), status, str(responseHeaders), str(output))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 225115-225120: ordinal not in range(128)
```