### PR TITLE
Remove custom swamp-thing-preview header

### DIFF
--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -1104,7 +1104,6 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         headers, data = self._requester.requestJsonAndCheck(
             "PATCH",
             "/user/repository_invitations/" + str(invitation),
-            headers={'Accept': 'application/vnd.github.swamp-thing-preview+json'},
             input={}
         )
 

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -779,7 +779,6 @@ class Repository(github.GithubObject.CompletableGithubObject):
         headers, data = self._requester.requestJsonAndCheck(
             "PUT",
             self.url + "/collaborators/" + collaborator,
-            headers={'Accept': 'application/vnd.github.swamp-thing-preview+json'},
             input=put_parameters
         )
         # return an invitation object if there's data returned by the API. If data is empty

--- a/github/tests/ReplayData/AuthenticatedUser.testAcceptInvitation.txt
+++ b/github/tests/ReplayData/AuthenticatedUser.testAcceptInvitation.txt
@@ -3,9 +3,9 @@ PATCH
 api.github.com
 None
 /user/repository_invitations/4294886
-{'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'Accept': 'application/vnd.github.swamp-thing-preview+json', 'User-Agent': 'PyGithub/Python'}
+{'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 {}
 204
-[('status', '204 No Content'), ('x-ratelimit-remaining', '4981'), ('x-github-media-type', 'github.swamp-thing-preview; format=json'), ('x-content-type-options', 'nosniff'), ('content-security-policy', "default-src 'none'"), ('access-control-expose-headers', 'ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval'), ('x-github-request-id', 'D039:11DAA:17FC875:24A1090:59635F0C'), ('strict-transport-security', 'max-age=31536000; includeSubdomains; preload'), ('vary', 'Accept-Encoding'), ('server', 'GitHub.com'), ('x-ratelimit-limit', '5000'), ('x-runtime-rack', '0.072659'), ('x-xss-protection', '1; mode=block'), ('x-served-by', '7f48e2f7761567e923121f17538d7a6d'), ('date', 'Mon, 10 Jul 2017 11:03:40 GMT'), ('access-control-allow-origin', '*'), ('x-frame-options', 'deny'), ('x-ratelimit-reset', '1499685825')]
+[('status', '204 No Content'), ('x-ratelimit-remaining', '4981'), ('x-content-type-options', 'nosniff'), ('content-security-policy', "default-src 'none'"), ('access-control-expose-headers', 'ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval'), ('x-github-request-id', 'D039:11DAA:17FC875:24A1090:59635F0C'), ('strict-transport-security', 'max-age=31536000; includeSubdomains; preload'), ('vary', 'Accept-Encoding'), ('server', 'GitHub.com'), ('x-ratelimit-limit', '5000'), ('x-runtime-rack', '0.072659'), ('x-xss-protection', '1; mode=block'), ('x-served-by', '7f48e2f7761567e923121f17538d7a6d'), ('date', 'Mon, 10 Jul 2017 11:03:40 GMT'), ('access-control-allow-origin', '*'), ('x-frame-options', 'deny'), ('x-ratelimit-reset', '1499685825')]
 
 

--- a/github/tests/ReplayData/Issue214.testCollaborators.txt
+++ b/github/tests/ReplayData/Issue214.testCollaborators.txt
@@ -36,7 +36,7 @@ PUT
 api.github.com
 None
 /repos/farrd/PyGithub/collaborators/marcmenges
-{'Accept': 'application/vnd.github.swamp-thing-preview+json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 None
 204
 [('status', '204 No Content'), ('x-ratelimit-remaining', '4762'), ('x-github-media-type', 'github.beta; format=json'), ('x-content-type-options', 'nosniff'), ('access-control-expose-headers', 'ETag, Link, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval'), ('x-github-request-id', 'A99159CE:6DAA:6192A15:52AF94DC'), ('vary', 'Accept-Encoding'), ('server', 'GitHub.com'), ('x-ratelimit-limit', '5000'), ('access-control-allow-credentials', 'true'), ('date', 'Tue, 17 Dec 2013 00:03:41 GMT'), ('access-control-allow-origin', '*'), ('x-ratelimit-reset', '1387240227')]

--- a/github/tests/ReplayData/Repository.testAssignees.txt
+++ b/github/tests/ReplayData/Repository.testAssignees.txt
@@ -47,7 +47,7 @@ PUT
 api.github.com
 None
 /repos/jacquev6/PyGithub/collaborators/Lyloa
-{'Accept': 'application/vnd.github.swamp-thing-preview+json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 None
 204
 [('status', '204 No Content'), ('x-ratelimit-remaining', '4993'), ('x-github-media-type', 'github.beta; format=json'), ('x-content-type-options', 'nosniff'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('cache-control', ''), ('date', 'Fri, 07 Sep 2012 23:12:27 GMT')]

--- a/github/tests/ReplayData/Repository.testCollaborators.txt
+++ b/github/tests/ReplayData/Repository.testCollaborators.txt
@@ -25,7 +25,7 @@ PUT
 api.github.com
 None
 /repos/jacquev6/PyGithub/collaborators/Lyloa
-{'Accept': 'application/vnd.github.swamp-thing-preview+json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 None
 204
 [('status', '204 No Content'), ('x-ratelimit-remaining', '4953'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"d41d8cd98f00b204e9800998ecf8427e"'), ('date', 'Sun, 27 May 2012 05:34:27 GMT')]


### PR DESCRIPTION
The Repository Invitation API graduated on July 17, 2017, so the custom
Accept header is no longer required.