### PR TITLE
Two fixes related to redirect

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -460,11 +460,20 @@ class Requester:
     def __log(self, verb, url, requestHeaders, input, status, responseHeaders, output):
         logger = logging.getLogger(__name__)
         if logger.isEnabledFor(logging.DEBUG):
-            if "Authorization" in requestHeaders:
-                if requestHeaders["Authorization"].startswith("Basic"):
-                    requestHeaders["Authorization"] = "Basic (login and password removed)"
-                elif requestHeaders["Authorization"].startswith("token"):
-                    requestHeaders["Authorization"] = "token (oauth token removed)"
-                else:  # pragma no cover (Cannot happen, but could if we add an authentication method => be prepared)
-                    requestHeaders["Authorization"] = "(unknown auth removed)"  # pragma no cover (Cannot happen, but could if we add an authentication method => be prepared)
-            logger.debug("%s %s://%s%s %s %s ==> %i %s %s", str(verb), self.__scheme, self.__hostname, str(url), str(requestHeaders), str(input), status, str(responseHeaders), str(output))
+            logger.debug("%s %s://%s%s %s %s ==> %i %s %s", str(verb), self.__scheme, self.__hostname, str(url), str(self.__hideAuthortizationHeader(requestHeaders)),
+                         str(input), status, str(responseHeaders), str(output))
+
+    def __hideAuthortizationHeader(self, requestHeaders, modifyExisting=False):
+        if "Authorization" not in requestHeaders:
+            return requestHeaders
+
+        rh = requestHeaders if modifyExisting else dict(requestHeaders)
+
+        if rh["Authorization"].startswith("Basic"):
+            rh["Authorization"] = "Basic (login and password removed)"
+        elif rh["Authorization"].startswith("token"):
+            rh["Authorization"] = "token (oauth token removed)"
+        else:  # pragma no cover (Cannot happen, but could if we add an authentication method => be prepared)
+            rh["Authorization"] = "(unknown auth removed)"  # pragma no cover (Cannot happen, but could if we add an authentication method => be prepared)
+
+        return rh

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -411,7 +411,7 @@ class Requester:
             return self.__requestRaw(original_cnx, verb, url, requestHeaders, input)
 
         if status == 301 and 'location' in responseHeaders:
-            return self.__requestRaw(original_cnx, verb, responseHeaders['location'], requestHeaders, input)
+            return self.__requestRaw(original_cnx, verb, self.__getURLPath(responseHeaders['location']), requestHeaders, input)
 
         return status, responseHeaders, output
 
@@ -477,3 +477,6 @@ class Requester:
             rh["Authorization"] = "(unknown auth removed)"  # pragma no cover (Cannot happen, but could if we add an authentication method => be prepared)
 
         return rh
+
+    def __getURLPath(self, url):
+        return urlparse.urlparse(url).path


### PR DESCRIPTION
Issue 1) 
__log method is immediately called after receiving the response, and the method wipes out Authorization header for security reasons.  Since the same reqeustHeader is used for redirect, the redirect will fail due to bad credentials.  The fix is to hide the Authorization header on the log but not actually changing the requestHeader.

Issue 2)
responseHeaders['location'] returns a fully qualified URL and requester is expecting a path, so users would get InvalidURL exception.

Ensured both issues are fixed with the new code.
Ensured that the tests were passing, with the exceptions of testDecodeJson, which is failing on master too. 
