### PR TITLE
Improve __repr__ method of Milestone class

### DIFF
--- a/github/Milestone.py
+++ b/github/Milestone.py
@@ -45,7 +45,7 @@ class Milestone(github.GithubObject.CompletableGithubObject):
     """
 
     def __repr__(self):
-        return self.get__repr__({"number": self._number.value})
+        return self.get__repr__({"number": self._number.value, "title": self._title.value})
 
     @property
     def closed_issues(self):

--- a/github/tests/Milestone.py
+++ b/github/tests/Milestone.py
@@ -52,7 +52,7 @@ class Milestone(Framework.TestCase):
         self.assertEqual(self.milestone.creator.login, "jacquev6")
 
         # test __repr__() based on this attributes
-        self.assertEqual(self.milestone.__repr__(), 'Milestone(number=1)')
+        self.assertEqual(self.milestone.__repr__(), 'Milestone(title="Version 0.4", number=1)')
 
     def testEditWithMinimalParameters(self):
         self.milestone.edit("Title edited by PyGithub")


### PR DESCRIPTION
This commit add the title of milestone in string representation of Milestone class.
This modification improve readbility of milestone instances.

Before:
```python
>>> repo.get_milestone(number=1)
Milestone(number=1) 
```
After:
```python
>>> repo.get_milestone(number=1)
Milestone(title='Milestone Example', number=1) 
```