### PR TITLE
Example to show How to get Commit Date

### DIFF
--- a/doc/examples/Commit.rst
+++ b/doc/examples/Commit.rst
@@ -22,6 +22,8 @@ Get commit date
 .. code-block:: python
 
     # Datetime is stored in the GitAuthor objects in the commit's GitCommit.
-    commit = repo.get_commit(sha=sha)
-    commit.commit.author.date
-    commit.commit.committer.date
+    >>> commit = repo.get_commit(sha=sha)
+    >>> print(commit.commit.author.date)
+    2018-10-11 03:04:52
+    >>> print(commit.commit.committer.date)
+    2018-10-11 03:04:52

--- a/doc/examples/Commit.rst
+++ b/doc/examples/Commit.rst
@@ -15,3 +15,13 @@ Create commit status check
         description="FooCI is building",
         context="ci/FooCI"
     )
+
+Get commit date
+--------------------------
+
+.. code-block:: python
+
+    # Datetime is stored in the GitAuthor objects in the commit's GitCommit.
+    commit = repo.get_commit(sha=sha)
+    commit.commit.author.date
+    commit.commit.committer.date

--- a/doc/examples/Commit.rst
+++ b/doc/examples/Commit.rst
@@ -21,7 +21,6 @@ Get commit date
 
 .. code-block:: python
 
-    # Datetime is stored in the GitAuthor objects in the commit's GitCommit.
     >>> commit = repo.get_commit(sha=sha)
     >>> print(commit.commit.author.date)
     2018-10-11 03:04:52


### PR DESCRIPTION
## What does this change do?
Adds a small example of how to get at the date a commit took place.

### Changes
#### doc/examples/Commit.rst
Adds a block of code that demonstrates how to get at a commit's date.

## Motivation
This example is in the spirit of #874.

When I began using PyGithub it was not readily apparent to me where the commit date was being abstracted to. Being unfamiliar with Git's API, it took some convincing for me to be satisfied that the `Commit.commit.author/committer.date` path would get me the commit date.

I would hope that this would save somebody a little bit of time in the future.

## How has this been tested?
I've built the docs locally and made sure the HTML is generated as expected.

## Screenshots
![2018-10-11 3](https://user-images.githubusercontent.com/16039329/46782728-add4d980-ccfd-11e8-88dd-1e48be629eb5.png)


