### PR TITLE
Added better error handling when the server returns a 5XX status code

### DIFF
--- a/github/GithubException.py
+++ b/github/GithubException.py
@@ -86,6 +86,12 @@ class RateLimitExceededException(GithubException):
     """
 
 
+class UnhandledServerException(GithubException):
+    """
+    Exception raised when a server unexpectedly raises a 5XX error
+    """
+
+
 class BadAttributeException(Exception):
     """
     Exception raised when Github returns an attribute with the wrong type.

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -297,6 +297,8 @@ class Requester:
             cls = GithubException.RateLimitExceededException
         elif status == 404 and output.get("message") == "Not Found":
             cls = GithubException.UnknownObjectException
+        elif status in range(500, 600):
+            cls = GithubException.UnhandledServerException
         else:
             cls = GithubException.GithubException
         return cls(status, output)


### PR DESCRIPTION
My Sentry recently came across an issue where the server raised a 502 server error, as this is an 'unknown' status code there's no way to handle the exception without having to catch all exceptions rather than specifically server-related errors (this caused a periodic celery task to fail, which lead to it not being run at all). 

The following change ensures all status codes from 500 to 599 (`599 in range(500, 599)` results in `False`, hence the 600) are given a custom exception class in `Requester.__createException`

The error in Sentry:

<img width="1069" alt="screen shot 2018-10-09 at 21 27 50" src="https://user-images.githubusercontent.com/6770124/46787883-13928700-cd39-11e8-8996-62f3185f8595.png">

The following would be too broad of an exception handler:

<img width="578" alt="screen shot 2018-10-11 at 09 36 46" src="https://user-images.githubusercontent.com/6770124/46787937-3d4bae00-cd39-11e8-9818-61e2f141ed59.png">
