### PR TITLE
Add methods to add and remove repos from installation

### DIFF
--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -358,6 +358,22 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         self._completeIfNotSet(self._url)
         return self._url.value
 
+    def add_repository_to_installation(self, repository, installation_id):
+        """
+        :calls: `PUT /user/installations/:installation_id/repositories/:repository_id <https://developer.github.com/v3/apps/installations>`_
+        :param repository: :class:`github.Repository.Repository`
+        :param installation_id: int
+        :rtype: bool
+        """
+        assert isinstance(repository, github.Repository.Repository), repository
+        assert isinstance(installation_id, int), installation_id
+        status, headers, data = self._requester.requestJson(
+            "PUT",
+            "/user/installations/{}/repositories/{}".format(installation_id, repository.id),
+            headers={"Accept": Consts.mediaTypeIntegrationPreview},
+        )
+        return status == 204
+
     def add_to_emails(self, *emails):
         """
         :calls: `POST /user/emails <http://developer.github.com/v3/users/emails>`_
@@ -1122,6 +1138,22 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
             "DELETE",
             "/repos/" + watched._identity + "/subscription"
         )
+
+    def remove_repository_from_installation(self, repository, installation_id):
+        """
+        :calls: `DELETE /user/installations/:installation_id/repositories/:repository_id <https://developer.github.com/v3/apps/installations>`_
+        :param repository: :class:`github.Repository.Repository`
+        :param installation_id: int
+        :rtype: bool
+        """
+        assert isinstance(repository, github.Repository.Repository), repository
+        assert isinstance(installation_id, int), installation_id
+        status, headers, data = self._requester.requestJson(
+            "DELETE",
+            "/user/installations/{}/repositories/{}".format(installation_id, repository.id),
+            headers={"Accept": Consts.mediaTypeIntegrationPreview},
+        )
+        return status == 204
 
     def accept_invitation(self, invitation):
         """

--- a/github/tests/AuthenticatedUser.py
+++ b/github/tests/AuthenticatedUser.py
@@ -257,3 +257,11 @@ class AuthenticatedUser(Framework.TestCase):
 
     def testGetMigrations(self):
         self.assertEqual(self.user.get_migrations().totalCount, 46)
+
+    def testAddRepositoryToInstallation(self):
+        gitflow = self.g.get_user("nvie").get_repo("gitflow")
+        self.assertTrue(self.user.add_repository_to_installation(gitflow, 12345))
+
+    def testRemoveRepositoryFromInstallation(self):
+        gitflow = self.g.get_user("nvie").get_repo("gitflow")
+        self.assertTrue(self.user.remove_repository_from_installation(gitflow, 12345))

--- a/github/tests/ReplayData/AuthenticatedUser.testAddRepositoryToInstallation.txt
+++ b/github/tests/ReplayData/AuthenticatedUser.testAddRepositoryToInstallation.txt
@@ -1,0 +1,31 @@
+https
+GET
+api.github.com
+None
+/users/nvie
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+None
+200
+[('status', '200 OK'), ('content-length', '603'), ('x-github-media-type', 'github.beta; format=json'), ('x-content-type-options', 'nosniff'), ('vary', 'Accept, Authorization, Cookie'), ('x-ratelimit-remaining', '4972'), ('server', 'nginx/1.0.13'), ('last-modified', 'Mon, 03 Sep 2012 09:24:06 GMT'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"eeac2be05fbbb88d548aaf0353a465f9"'), ('cache-control', 'private, s-maxage=60, max-age=60'), ('date', 'Fri, 07 Sep 2012 23:34:41 GMT'), ('content-type', 'application/json; charset=utf-8')]
+{"type":"User","gravatar_id":"466ef7561a0b100dc5a1021959962d28","avatar_url":"https://secure.gravatar.com/avatar/466ef7561a0b100dc5a1021959962d28?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png","login":"nvie","public_repos":64,"created_at":"2009-05-12T21:19:38Z","html_url":"https://github.com/nvie","email":"vincent@3rdcloud.com","company":"3rd Cloud","followers":347,"hireable":false,"public_gists":28,"name":"Vincent Driessen","blog":"http://nvie.com","url":"https://api.github.com/users/nvie","following":41,"location":"Netherlands","bio":null,"id":83844}
+
+https
+GET
+api.github.com
+None
+/repos/nvie/gitflow
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+None
+200
+[('status', '200 OK'), ('content-length', '1272'), ('x-github-media-type', 'github.beta; format=json'), ('x-content-type-options', 'nosniff'), ('vary', 'Accept, Authorization, Cookie'), ('x-ratelimit-remaining', '4971'), ('server', 'nginx/1.0.13'), ('last-modified', 'Fri, 07 Sep 2012 23:33:59 GMT'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"65c6be3387ac59ebbbf02e7b4c793b8e"'), ('cache-control', 'private, s-maxage=60, max-age=60'), ('date', 'Fri, 07 Sep 2012 23:34:42 GMT'), ('content-type', 'application/json; charset=utf-8')]
+{"master_branch":"develop","forks":429,"watchers_count":4650,"has_downloads":true,"owner":{"gravatar_id":"466ef7561a0b100dc5a1021959962d28","avatar_url":"https://secure.gravatar.com/avatar/466ef7561a0b100dc5a1021959962d28?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png","login":"nvie","url":"https://api.github.com/users/nvie","id":83844},"open_issues_count":100,"description":"Git extensions to provide high-level repository operations for Vincent Driessen's branching model.","permissions":{"pull":true,"push":false,"admin":false},"forks_count":429,"clone_url":"https://github.com/nvie/gitflow.git","created_at":"2010-01-20T23:14:12Z","mirror_url":null,"html_url":"https://github.com/nvie/gitflow","network_count":429,"has_wiki":true,"watchers":4650,"size":4430,"fork":false,"open_issues":100,"has_issues":true,"updated_at":"2012-09-07T23:33:59Z","full_name":"nvie/gitflow","name":"gitflow","url":"https://api.github.com/repos/nvie/gitflow","ssh_url":"git@github.com:nvie/gitflow.git","git_url":"git://github.com/nvie/gitflow.git","private":false,"id":481366,"language":"Shell","homepage":"http://nvie.com/posts/a-successful-git-branching-model/","svn_url":"https://github.com/nvie/gitflow","pushed_at":"2012-07-10T09:18:03Z"}
+
+https
+PUT
+api.github.com
+None
+/user/installations/12345/repositories/481366
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python', 'Accept': 'application/vnd.github.machine-man-preview+json'}
+None
+204
+[('status', '204 No Content'), ('x-ratelimit-remaining', '4968'), ('x-github-media-type', 'github.beta; format=json'), ('x-content-type-options', 'nosniff'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('cache-control', ''), ('date', 'Fri, 07 Sep 2012 23:34:44 GMT')]

--- a/github/tests/ReplayData/AuthenticatedUser.testRemoveRepositoryFromInstallation.txt
+++ b/github/tests/ReplayData/AuthenticatedUser.testRemoveRepositoryFromInstallation.txt
@@ -1,0 +1,31 @@
+https
+GET
+api.github.com
+None
+/users/nvie
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+None
+200
+[('status', '200 OK'), ('content-length', '603'), ('x-github-media-type', 'github.beta; format=json'), ('x-content-type-options', 'nosniff'), ('vary', 'Accept, Authorization, Cookie'), ('x-ratelimit-remaining', '4972'), ('server', 'nginx/1.0.13'), ('last-modified', 'Mon, 03 Sep 2012 09:24:06 GMT'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"eeac2be05fbbb88d548aaf0353a465f9"'), ('cache-control', 'private, s-maxage=60, max-age=60'), ('date', 'Fri, 07 Sep 2012 23:34:41 GMT'), ('content-type', 'application/json; charset=utf-8')]
+{"type":"User","gravatar_id":"466ef7561a0b100dc5a1021959962d28","avatar_url":"https://secure.gravatar.com/avatar/466ef7561a0b100dc5a1021959962d28?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png","login":"nvie","public_repos":64,"created_at":"2009-05-12T21:19:38Z","html_url":"https://github.com/nvie","email":"vincent@3rdcloud.com","company":"3rd Cloud","followers":347,"hireable":false,"public_gists":28,"name":"Vincent Driessen","blog":"http://nvie.com","url":"https://api.github.com/users/nvie","following":41,"location":"Netherlands","bio":null,"id":83844}
+
+https
+GET
+api.github.com
+None
+/repos/nvie/gitflow
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+None
+200
+[('status', '200 OK'), ('content-length', '1272'), ('x-github-media-type', 'github.beta; format=json'), ('x-content-type-options', 'nosniff'), ('vary', 'Accept, Authorization, Cookie'), ('x-ratelimit-remaining', '4971'), ('server', 'nginx/1.0.13'), ('last-modified', 'Fri, 07 Sep 2012 23:33:59 GMT'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"65c6be3387ac59ebbbf02e7b4c793b8e"'), ('cache-control', 'private, s-maxage=60, max-age=60'), ('date', 'Fri, 07 Sep 2012 23:34:42 GMT'), ('content-type', 'application/json; charset=utf-8')]
+{"master_branch":"develop","forks":429,"watchers_count":4650,"has_downloads":true,"owner":{"gravatar_id":"466ef7561a0b100dc5a1021959962d28","avatar_url":"https://secure.gravatar.com/avatar/466ef7561a0b100dc5a1021959962d28?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png","login":"nvie","url":"https://api.github.com/users/nvie","id":83844},"open_issues_count":100,"description":"Git extensions to provide high-level repository operations for Vincent Driessen's branching model.","permissions":{"pull":true,"push":false,"admin":false},"forks_count":429,"clone_url":"https://github.com/nvie/gitflow.git","created_at":"2010-01-20T23:14:12Z","mirror_url":null,"html_url":"https://github.com/nvie/gitflow","network_count":429,"has_wiki":true,"watchers":4650,"size":4430,"fork":false,"open_issues":100,"has_issues":true,"updated_at":"2012-09-07T23:33:59Z","full_name":"nvie/gitflow","name":"gitflow","url":"https://api.github.com/repos/nvie/gitflow","ssh_url":"git@github.com:nvie/gitflow.git","git_url":"git://github.com/nvie/gitflow.git","private":false,"id":481366,"language":"Shell","homepage":"http://nvie.com/posts/a-successful-git-branching-model/","svn_url":"https://github.com/nvie/gitflow","pushed_at":"2012-07-10T09:18:03Z"}
+
+https
+DELETE
+api.github.com
+None
+/user/installations/12345/repositories/481366
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python', 'Accept': 'application/vnd.github.machine-man-preview+json'}
+None
+204
+[('status', '204 No Content'), ('x-ratelimit-remaining', '4968'), ('x-github-media-type', 'github.beta; format=json'), ('x-content-type-options', 'nosniff'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('cache-control', ''), ('date', 'Fri, 07 Sep 2012 23:34:44 GMT')]


### PR DESCRIPTION
Adding methods for the two APIs below:
* https://developer.github.com/v3/apps/installations/#add-repository-to-installation
* https://developer.github.com/v3/apps/installations/#remove-repository-from-installation

Two reasons why the methods are in `AuthenticatedUser.py` and not in `Installation.py`:
1. The API endpoints start with `/user`
1. The APIs require a personal access token, whereas `Installation.py` uses an installation access token.