### PR TITLE
Add a Topic object to cover search_topics

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -66,6 +66,7 @@ import Repository
 import Installation
 import Legacy
 import License
+import Topic
 import github.GithubObject
 import HookDescription
 import GitignoreTemplate
@@ -542,7 +543,7 @@ class Github(object):
         :calls: `GET /search/topics <http://developer.github.com/v3/search>`_
         :param query: string
         :param qualifiers: keyword dict query qualifiers
-        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Topic.Topic`
         """
         assert isinstance(query, (str, unicode)), query
         url_parameters = dict()
@@ -558,7 +559,7 @@ class Github(object):
         assert url_parameters["q"], "need at least one qualifier"
 
         return github.PaginatedList.PaginatedList(
-            github.Repository.Repository,
+            github.Topic.Topic,
             self.__requester,
             "/search/topics",
             url_parameters,

--- a/github/Topic.py
+++ b/github/Topic.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+
+############################ Copyrights and license ############################
+#                                                                              #
+# Copyright 2018 Steve Kowalik <steven@wedontsleep.org>                        #
+#                                                                              #
+# This file is part of PyGithub.                                               #
+# http://pygithub.readthedocs.io/                                              #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+################################################################################
+
+import github.GithubObject
+
+
+class Topic(github.GithubObject.CompletableGithubObject):
+    """
+    This class represents topics as used by https://github.com/topics. The object refereence can be found here https://developer.github.com/v3/search/#search-topics
+    """
+
+    def __repr__(self):
+        return self.get__repr__({"name": self._name.value})
+
+    @property
+    def name(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._name)
+        return self._name.value
+
+    @property
+    def display_name(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._display_name)
+        return self._display_name.value
+
+    @property
+    def short_description(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._short_description)
+        return self._short_description.value
+
+    @property
+    def description(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._description)
+        return self._description.value
+
+    def _initAttributes(self):
+        self._name = github.GithubObject.NotSet
+        self._display_name = github.GithubObject.NotSet
+        self._short_description = github.GithubObject.NotSet
+        self._description = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "name" in attributes:  # pragma no branch
+            self._name = self._makeStringAttribute(attributes["name"])
+        if "display_name" in attributes:  # pragma no branch
+            self._display_name = self._makeStringAttribute(attributes["display_name"])
+        if "short_description" in attributes:  # pragma no branch
+            self._short_description = self._makeStringAttribute(attributes["short_description"])
+        if "description" in attributes:  # pragma no branch
+            self._description = self._makeStringAttribute(attributes["description"])

--- a/github/tests/Search.py
+++ b/github/tests/Search.py
@@ -62,8 +62,8 @@ class Search(Framework.TestCase):
         self.assertEqual(commits.totalCount, 3)
 
     def testSearchTopics(self):
-        repos = self.g.search_topics("python", repositories=">950")
-        self.assertListKeyBegin(repos, lambda r: r.name, [u"python", u"django", u"flask", u"ruby", u"scikit-learn", u"wagtail"])
+        topics = self.g.search_topics("python", repositories=">950")
+        self.assertListKeyBegin(topics, lambda r: r.name, [u"python", u"django", u"flask", u"ruby", u"scikit-learn", u"wagtail"])
 
     def testPaginateSearchTopics(self):
         repos = self.g.search_topics("python", repositories=">950")


### PR DESCRIPTION
The return value of MainClass.search_topics() was a paginated list of
Repository, which is incorrect. Add a Topic class to encapuslate what is
returned.

Fixes #929