### PR TITLE
Replaced calls to str with calls to unicode

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -475,4 +475,4 @@ class Requester:
                     requestHeaders["Authorization"] = "Bearer (jwt removed)"
                 else:  # pragma no cover (Cannot happen, but could if we add an authentication method => be prepared)
                     requestHeaders["Authorization"] = "(unknown auth removed)"  # pragma no cover (Cannot happen, but could if we add an authentication method => be prepared)
-            logger.debug("%s %s://%s%s %s %s ==> %i %s %s", str(verb), self.__scheme, self.__hostname, str(url), str(requestHeaders), str(input), status, str(responseHeaders), str(output))
+            logger.debug("%s %s://%s%s %s %s ==> %i %s %s", unicode(verb), self.__scheme, self.__hostname, unicode(url), unicode(requestHeaders), unicode(input), status, unicode(responseHeaders), unicode(output))


### PR DESCRIPTION
When logging responses from github, sometimes "output" will contain unicode characters that are not ascii encodable.

The resulting `Exception: UnicodeEncodeError` will often mask other underlying issues or problems.

Replacing calls to `str(` with calls to `unicode(` should resolve the problem