### PR TITLE
Question: Topics Preview on search repositories

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -388,7 +388,10 @@ class Github(object):
             github.Repository.Repository,
             self.__requester,
             "/search/repositories",
-            url_parameters
+            url_parameters,
+            headers={
+                "Accept": Consts.mediaTypeTopicsPreview
+            }
         )
 
     def search_users(self, query, sort=github.GithubObject.NotSet, order=github.GithubObject.NotSet, **qualifiers):


### PR DESCRIPTION
Understanding of the preview state here, opening this up more as a question and open to alternative implementation (e.g. an opt-in flag).  Would this approach be merged in directly?

In relation to:

> Note: The topics property for repositories on GitHub is currently available for developers to preview. To view the topics property in calls that return repository results, you must provide a custom media type in the Accept header: `application/vnd.github.mercy-preview+json`

https://developer.github.com/v3/search/#search-repositories
