### PR TITLE
Allow unicode type in PullRequest.create_review

### DIFF
--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -428,7 +428,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
         :rtype: :class:`github.PullRequestReview.PullRequestReview`
         """
         assert isinstance(commit, github.Commit.Commit), commit
-        assert isinstance(body, str), body
+        assert isinstance(body, (str, unicode)), body
         assert event is github.GithubObject.NotSet or isinstance(event, str), event
         assert comments is github.GithubObject.NotSet or isinstance(comments, list), comments
         post_parameters = {'commit_id': commit.sha, 'body': body}

--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -428,7 +428,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
         :rtype: :class:`github.PullRequestReview.PullRequestReview`
         """
         assert isinstance(commit, github.Commit.Commit), commit
-        assert isinstance(body, (str, unicode)), body
+        assert isinstance(body, basestring), body
         assert event is github.GithubObject.NotSet or isinstance(event, str), event
         assert comments is github.GithubObject.NotSet or isinstance(comments, list), comments
         post_parameters = {'commit_id': commit.sha, 'body': body}


### PR DESCRIPTION
`create_review` method of `PeullRequest` asserts `body` to be a type of
`str`. Let's allow to have `unicode` there as well.