### PR TITLE
PUT /orgs/:org/memberships/:username requires role parameter to be in the body

### DIFF
--- a/github/Organization.py
+++ b/github/Organization.py
@@ -313,12 +313,12 @@ class Organization(github.GithubObject.CompletableGithubObject):
         """
         assert isinstance(role, (str, unicode)), role
         assert isinstance(member, github.NamedUser.NamedUser), member
-        url_parameters = {
+        put_parameters = {
             "role": role,
         }
         headers, data = self._requester.requestJsonAndCheck(
             "PUT",
-            self.url + "/memberships/" + member._identity, parameters=url_parameters
+            self.url + "/memberships/" + member._identity, input=put_parameters
         )
 
     def add_to_public_members(self, public_member):


### PR DESCRIPTION
The documentation doesn't make it clear, but it seems that the `role` parameter must be part of the JSON PUT body instead of the URL parameters. With the current code, it's not possible to change a user's role to an admin because the URL parameter gets ignored.

This behavior was observed with GitHub Enterprise 2.14.10 and seems to appear in the replay data in this repo too: https://github.com/PyGithub/PyGithub/blob/f0e0762a0d286dab47146f9357b06714a86d3c25/github/tests/ReplayData/Organization.testAddMembersAdminRole.txt#L23-L32