### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/github/tests/ExposeAllAttributes.py
+++ b/github/tests/ExposeAllAttributes.py
@@ -25,6 +25,7 @@
 #                                                                              #
 ################################################################################
 
+from __future__ import print_function
 import Framework
 
 
@@ -134,7 +135,7 @@ class ExposeAllAttributes(Framework.TestCase):
 
         for className, attributesMissingInClass in sorted(missingAttributes.iteritems()):
             for attrName, value in sorted(attributesMissingInClass.iteritems()):
-                print className, attrName, "->", repr(value)
+                print(className, attrName, "->", repr(value))
 
         self.assertEqual(sum(len(attrs) for attrs in missingAttributes.values()), 0)
 

--- a/github/tests/Framework.py
+++ b/github/tests/Framework.py
@@ -36,6 +36,7 @@
 #                                                                              #
 ################################################################################
 
+from __future__ import print_function
 import json
 import os
 import sys
@@ -93,7 +94,7 @@ class RecordingConnection:  # pragma no cover (Class useful only when recording 
         self.__cnx = self._realConnection(host, port, *args, **kwds)
 
     def request(self, verb, url, input, headers):
-        print verb, url, input, headers,
+        print(verb, url, input, headers, end=' ')
         self.__cnx.request(verb, url, input, headers)
         # fixAuthorizationHeader changes the parameter directly to remove Authorization token.
         # however, this is the real dictionary that *will be sent* by "requests",
@@ -116,7 +117,7 @@ class RecordingConnection:  # pragma no cover (Class useful only when recording 
         res = self.__cnx.getresponse()
 
         status = res.status
-        print "=>", status
+        print("=>", status)
         headers = res.getheaders()
         output = res.read()
 

--- a/scripts/fix_headers.py
+++ b/scripts/fix_headers.py
@@ -26,6 +26,7 @@
 #                                                                              #
 ################################################################################
 
+from __future__ import print_function
 import fnmatch
 import os
 import subprocess
@@ -155,17 +156,17 @@ def findHeadersAndFiles():
             elif fullname.endswith(".pyc"):
                 pass
             else:
-                print "Don't know what to do with", filename
+                print("Don't know what to do with", filename)
 
 
 def main():
     for header, filename in findHeadersAndFiles():
-        print "Analyzing", filename
+        print("Analyzing", filename)
         with open(filename) as f:
             lines = list(line.rstrip() for line in f)
         newLines = header.fix(filename, lines)
         if newLines != lines:
-            print " => actually modifying", filename
+            print(" => actually modifying", filename)
             with open(filename, "w") as f:
                 for line in newLines:
                     f.write(line + "\n")


### PR DESCRIPTION
@sfdye Can I please get your help in closing these syntax errors?  Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.