### PR TITLE
Old style exceptions --> new style for Python 3

### DIFF
--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -138,7 +138,7 @@ class GithubObject(object):
         elif isinstance(value, type):
             try:
                 return _ValuedAttribute(transform(value))
-            except Exception, e:
+            except Exception as e:
                 return _BadAttribute(value, type, e)
         else:
             return _BadAttribute(value, type)

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -314,7 +314,7 @@ class Requester:
                 data = data.decode("utf-8")  # pragma no cover (Covered by Issue142.testDecodeJson with Python 3)
             try:
                 return json.loads(data)
-            except ValueError, e:
+            except ValueError as e:
                 return {'data': data}
 
     def requestJson(self, verb, url, parameters=None, headers=None, input=None, cnx=None):


### PR DESCRIPTION
@sfdye Can I please get your help in closing these __syntax errors__? Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.