### PR TITLE
01 is a syntax error in Python 3

### DIFF
--- a/github/tests/AuthenticatedUser.py
+++ b/github/tests/AuthenticatedUser.py
@@ -245,7 +245,7 @@ class AuthenticatedUser(Framework.TestCase):
         self.assertListKeyEqual(self.user.get_notifications(all=True), lambda n: n.id, [])
 
     def testMarkNotificationsAsRead(self):
-        self.user.mark_notifications_as_read(datetime.datetime(2018, 10, 18, 18, 20, 01, 0))
+        self.user.mark_notifications_as_read(datetime.datetime(2018, 10, 18, 18, 20, 1, 0))
 
     def testGetTeams(self):
         self.assertListKeyEqual(self.user.get_teams(), lambda t: t.name, ["Owners", "Honoraries", "Honoraries", "Honoraries", "Honoraries", "Honoraries", "Honoraries", "Honoraries", "Honoraries", "Honoraries"])


### PR DESCRIPTION
@sfdye Can I please get your help in closing these syntax error?

$ __python3 -c "01"__  # --> SyntaxError: invalid token
* https://docs.python.org/3/whatsnew/3.0.html?highlight=octal%20literals#integers

In Python 3:
* __1__ is decimal one
* __0o1__ is octal one
* __01__ is a syntax error