### PR TITLE
Travis CI: Add Python 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
-sudo: false
+matrix:
+  include:
+    - python: "3.7"
+      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 script:
   - python setup.py test
 notifications:

--- a/setup.py
+++ b/setup.py
@@ -96,18 +96,18 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 2",
             "Programming Language :: Python :: 2.7",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.4",
             "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
+            "Programming Language :: Python :: 3.7",
             "Topic :: Software Development",
         ],
         test_suite="github.tests.AllTests",
         use_2to3=True,
-        python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+        python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
         install_requires=[
-            "requests>=2.14.0",
+            "deprecated",
             "pyjwt",
-            "Deprecated"
+            "requests>=2.14.0"
         ],
         extras_require = {
             "integrations": ["cryptography"]


### PR DESCRIPTION
Also:
* Python 3.4 reaches its end of life in 44 days so let's remove it from the testing.  https://devguide.python.org/#branchstatus
* [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).