### PR TITLE
[WIP] Replace broken edit_user|team_push_restrictions with full implementation of the API

### DIFF
--- a/github/Branch.py
+++ b/github/Branch.py
@@ -334,12 +334,12 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
             github.Team.Team,
             self._requester,
             self.protection_url + "/restrictions/teams",
-            None
+            None,
         )
 
-    def edit_user_push_restrictions(self, *users):
+    def add_user_push_restrictions(self, *users):
         """
-        :calls: `POST /repos/:owner/:repo/branches/:branch/protection/restrictions <https://developer.github.com/v3/repos/branches>`_
+        :calls: `POST /repos/:owner/:repo/branches/:branch/protection/restrictions/users <https://developer.github.com/v3/repos/branches>`_
         :users: list of strings
         """
         assert all(isinstance(element, (str, unicode)) or isinstance(element, (str, unicode)) for element in users), users
@@ -350,15 +350,68 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
             input=users
         )
 
-    def edit_team_push_restrictions(self, *teams):
+    def replace_user_push_restrictions(self, *users):
         """
-        :calls: `POST /repos/:owner/:repo/branches/:branch/protection/restrictions <https://developer.github.com/v3/repos/branches>`_
-        :teams: list of strings
+        :calls: `PUT /repos/:owner/:repo/branches/:branch/protection/restrictions/users <https://developer.github.com/v3/repos/branches>`_
+        :users: list of strings
+        """
+        assert all(isinstance(element, (str, unicode)) or isinstance(element, (str, unicode)) for element in users), users
+
+        headers, data = self._requester.requestJsonAndCheck(
+            "PUT",
+            self.protection_url + "/restrictions/users",
+            input=users
+        )
+
+    def remove_user_push_restrictions(self, *users):
+        """
+        :calls: `DELETE /repos/:owner/:repo/branches/:branch/protection/restrictions/users <https://developer.github.com/v3/repos/branches>`_
+        :users: list of strings
+        """
+        assert all(isinstance(element, (str, unicode)) or isinstance(element, (str, unicode)) for element in users), users
+
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.protection_url + "/restrictions/users",
+            input=users
+        )
+
+
+    def add_team_push_restrictions(self, *teams):
+        """
+        :calls: `POST /repos/:owner/:repo/branches/:branch/protection/restrictions/teams <https://developer.github.com/v3/repos/branches>`_
+        :teams: list of strings (team slugs)
         """
         assert all(isinstance(element, (str, unicode)) or isinstance(element, (str, unicode)) for element in teams), teams
 
         headers, data = self._requester.requestJsonAndCheck(
             "POST",
+            self.protection_url + "/restrictions/teams",
+            input=teams
+        )
+
+    def replace_team_push_restrictions(self, *teams):
+        """
+        :calls: `PUT /repos/:owner/:repo/branches/:branch/protection/restrictions/teams <https://developer.github.com/v3/repos/branches>`_
+        :teams: list of strings (team slugs)
+        """
+        assert all(isinstance(element, (str, unicode)) or isinstance(element, (str, unicode)) for element in teams), teams
+
+        headers, data = self._requester.requestJsonAndCheck(
+            "PUT",
+            self.protection_url + "/restrictions/teams",
+            input=teams
+        )
+
+    def remove_team_push_restrictions(self, *teams):
+        """
+        :calls: `DELETE /repos/:owner/:repo/branches/:branch/protection/restrictions/teams <https://developer.github.com/v3/repos/branches>`_
+        :teams: list of strings (team slugs)
+        """
+        assert all(isinstance(element, (str, unicode)) or isinstance(element, (str, unicode)) for element in teams), teams
+
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
             self.protection_url + "/restrictions/teams",
             input=teams
         )


### PR DESCRIPTION
[Here is the relevant Github API documentation](https://developer.github.com/v3/repos/branches/#list-team-restrictions-of-protected-branch).

As can be seen from the docs, `edit_*_push_restrictions` is a misnomer. In the current API, [POST will only *add*, never remove](https://developer.github.com/v3/repos/branches/#add-team-restrictions-of-protected-branch). This commit adds a more fine-grained API:

* `add_user|team_push_restrictions` (`POST`)
* `replace_user|team_push_restrictions` (`PUT`)
* `remove_user|team_push_restrictions` (`DELETE`)

`replace_user|team_push_restriction` could also be called `edit_user|team_push_restriction` but I find the name slightly misleading. It also can't safely replace the old `edit_user|team_push_restriction` functions as those would have only ever added users or teams.

The way this PR is built right now, it's a breaking change. Advice and opinions on alternative approaches are welcome.