### PR TITLE
Add feature for get repo from another user

### DIFF
--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -895,6 +895,19 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
             None
         )
 
+    def get_repo_from(self, full_name):
+        """
+        :calls: `GET /repos/:owner/:repo <http://developer.github.com/v3/repos>`_
+        :param full_name: string
+        :rtype: :class:`github.Repository.Repository`
+        """
+        assert isinstance(full_name, (str, unicode)), full_name
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            "/repos/" + full_name
+        )
+        return github.Repository.Repository(self._requester, headers, data, completed=True)
+
     def get_repo(self, name):
         """
         :calls: `GET /repos/:owner/:repo <http://developer.github.com/v3/repos>`_


### PR DESCRIPTION
Hello, sometimes I want to recover the repository in which I collaborate, but if I use the method get_repo (name) will return error because the default request is for the owner of the repository, to get around this problem I created a small function that searches the repository by full name and so I can instantiate the 'Repositoty' object, even as a contributor.

Can this be helpful to you?