### PR TITLE
Add url parameter to include anonymous contributors in get_contributors()

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1799,17 +1799,23 @@ class Repository(github.GithubObject.CompletableGithubObject):
             for attributes in data
         ]
 
-    def get_contributors(self):
+    def get_contributors(self, anon=github.GithubObject.NotSet):
         """
         :calls: `GET /repos/:owner/:repo/contributors <http://developer.github.com/v3/repos>`_
+        :param anon: bool
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
+        url_parameters = dict()
+        if anon is not github.GithubObject.NotSet:
+            url_parameters["anon"] = anon
+
         return github.PaginatedList.PaginatedList(
             github.NamedUser.NamedUser,
             self._requester,
             self.url + "/contributors",
-            None
+            url_parameters
         )
+
 
     def get_download(self, id):
         """

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1802,7 +1802,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
     def get_contributors(self, anon=github.GithubObject.NotSet):
         """
         :calls: `GET /repos/:owner/:repo/contributors <http://developer.github.com/v3/repos>`_
-        :param anon: bool
+        :param anon: string
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
         url_parameters = dict()


### PR DESCRIPTION
Add the anon parameter missing from get_contributors() so anonymous contributors can be included in results as specified in the [Github REST API Reference](https://developer.github.com/v3/repos/#list-contributors).
