### PR TITLE
Use non-deprecated path for creating GitHub App access tokens

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -732,7 +732,7 @@ class GithubIntegration(object):
     def get_access_token(self, installation_id, user_id=None):
         """
         Get an access token for the given installation id.
-        POSTs https://api.github.com/installations/<installation_id>/access_tokens
+        POSTs https://api.github.com/app/installations/<installation_id>/access_tokens
         :param user_id: int
         :param installation_id: int
         :return: :class:`github.InstallationAuthorization.InstallationAuthorization`
@@ -741,7 +741,7 @@ class GithubIntegration(object):
         if user_id:
             body = {"user_id": user_id}
         response = requests.post(
-            "https://api.github.com/installations/{}/access_tokens".format(installation_id),
+            "https://api.github.com/app/installations/{}/access_tokens".format(installation_id),
             headers={
                 "Authorization": "Bearer {}".format(self.create_jwt()),
                 "Accept": Consts.mediaTypeIntegrationPreview,

--- a/github/tests/GithubIntegration.py
+++ b/github/tests/GithubIntegration.py
@@ -104,7 +104,7 @@ class GithubIntegration(unittest.TestCase):
         auth_obj = integration.get_access_token(664281)
         self.assertEqual(
             self.mock.args[0],
-            "https://api.github.com/installations/664281/access_tokens"
+            "https://api.github.com/app/installations/664281/access_tokens"
         )
         self.assertEqual(
             auth_obj.token, "v1.ce63424bc55028318325caac4f4c3a5378ca0038"


### PR DESCRIPTION
👋 Hey friends

`/installations/<installation_id>/access_tokens` has been [deprecated](https://developer.github.com/changes/2018-08-16-renaming-and-deprecation-of-github-app-installation-access-token-route/) but it has a drop-in replacement at  `/app/installations/<installation_id>/access_tokens`.

This updates `get_access_token` and associated test to use the non-deprecated URL.

```sh
$ python -m github.tests GithubIntegration                                                                                                                                                                                                  update_access_token_path ✔
..
----------------------------------------------------------------------
Ran 2 tests in 0.106s

OK
```
