### PR TITLE
Add List pending organization invites

### DIFF
--- a/github/Organization.py
+++ b/github/Organization.py
@@ -719,6 +719,19 @@ class Organization(github.GithubObject.CompletableGithubObject):
             url_parameters
         )
 
+    def list_pending_invitations(self):
+        """
+        :calls: `GET /orgs/:org/invitations <https://developer.github.com/v3/orgs/members/>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.NamedUser.NamedUser,
+            self._requester,
+            self.url + "/invitations",
+            None
+        )
+
+
     def remove_outside_collaborator(self, collaborator):
         """
         :calls: `DELETE /orgs/:org/outside_collaborators/:username <https://developer.github.com/v3/orgs/outside_collaborators>`_

--- a/tests/Organization.py
+++ b/tests/Organization.py
@@ -255,3 +255,7 @@ class Organization(Framework.TestCase):
     def testGetMigrations(self):
         self.org = self.g.get_organization("sample-test-organisation")
         self.assertEqual(self.org.get_migrations().totalCount, 2)
+
+    def testListPendingInvitations(self):
+        self.org = self.g.get_organization("sample-test-organisation")
+        self.assertEqual(self.org.list_pending_invitations().totalCount, 3)


### PR DESCRIPTION
The GitHub v3 API has an API to [list pending organization invitations](https://developer.github.com/v3/orgs/members/#list-pending-organization-invitations). This would be great to have implemented in PyGithub.

I have a branch in my fork which solves this but I am not quite show to to go about running the test but have created an example one here. Please review my PR and let me know if there is anything I can do to assist.
