### PR TITLE
Delete brach associated with pr

### DIFF
--- a/github/GithubException.py
+++ b/github/GithubException.py
@@ -121,3 +121,8 @@ class TwoFactorException(GithubException):
     """
     Exception raised when Github requires a onetime password for two-factor authentication
     """
+
+class GitRefInUseException(GithubException):
+    """
+    Exception raised when attempting to delete a GitRef object that is still in use.
+    """

--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -781,7 +781,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
             # Check for other pull requests referencing the same ref.
             # If found, abort.
-            remaining_pulls = self.head.repo.get_pulls(self.head.ref)
+            remaining_pulls = self.head.repo.get_pulls(head=self.head.ref)
             if remaining_pulls > 0:
                 raise GithubException.GitRefInUseException(data="PRs referencing this branch remain.  Not deleting the branch")
 

--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -55,7 +55,7 @@ import github.File
 import github.IssueComment
 import github.Commit
 import github.PullRequestReview
-
+import github.GithubException
 
 class PullRequest(github.GithubObject.CompletableGithubObject):
     """
@@ -775,7 +775,16 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
             self.url + "/merge",
             input=post_parameters
         )
+
+
         if delete_branch == True:
+
+            # Check for other pull requests referencing the same ref.
+            # If found, abort.
+            remaining_pulls = self.head.repo.get_pulls(self.head.ref)
+            if remaining_pulls > 0:
+                raise GithubException.GitRefInUseException(data="PRs referencing this branch remain.  Not deleting the branch")
+
             self.head.repo.get_git_ref( "heads/%s"%(self.head.ref) ).delete()
 
 

--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -777,7 +777,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
         )
 
 
-        if delete_branch == True:
+        if delete_branch:
 
             # Check for other pull requests referencing the same ref.
             # If found, abort.

--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -782,7 +782,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
             # Check for other pull requests referencing the same ref.
             # If found, abort.
             remaining_pulls = self.head.repo.get_pulls(head=self.head.ref)
-            if remaining_pulls > 0:
+            if remaining_pulls:
                 raise GithubException.GitRefInUseException(data="PRs referencing this branch remain.  Not deleting the branch")
 
             self.head.repo.get_git_ref( "heads/%s"%(self.head.ref) ).delete()

--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -751,7 +751,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
         )
         return status == 204
 
-    def merge(self, commit_message=github.GithubObject.NotSet, commit_title=github.GithubObject.NotSet, merge_method=github.GithubObject.NotSet, sha=github.GithubObject.NotSet):
+    def merge(self, commit_message=github.GithubObject.NotSet, commit_title=github.GithubObject.NotSet, merge_method=github.GithubObject.NotSet, sha=github.GithubObject.NotSet, delete_branch=False):
         """
         :calls: `PUT /repos/:owner/:repo/pulls/:number/merge <http://developer.github.com/v3/pulls>`_
         :param commit_message: string
@@ -775,6 +775,10 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
             self.url + "/merge",
             input=post_parameters
         )
+        if delete_branch == True:
+            self.head.repo.get_git_ref( "heads/%s"%(self.head.ref) ).delete()
+
+
         return github.PullRequestMergeStatus.PullRequestMergeStatus(self._requester, headers, data, completed=True)
 
     def _initAttributes(self):


### PR DESCRIPTION
Issue #580 Added a `delete_branch` flag to the `pr.merge(...)` method.  If the flag is true, it checks if the branch is part of other PRs.  If it is not, then it deletes the branch.  