### PR TITLE
Add description field when creating a new team

### DIFF
--- a/github/Organization.py
+++ b/github/Organization.py
@@ -457,19 +457,21 @@ class Organization(github.GithubObject.CompletableGithubObject):
         )
         return github.Repository.Repository(self._requester, headers, data, completed=True)
 
-    def create_team(self, name, repo_names=github.GithubObject.NotSet, permission=github.GithubObject.NotSet, privacy=github.GithubObject.NotSet):
+    def create_team(self, name, repo_names=github.GithubObject.NotSet, permission=github.GithubObject.NotSet, privacy=github.GithubObject.NotSet, description=github.GithubObject.NotSet):
         """
         :calls: `POST /orgs/:org/teams <http://developer.github.com/v3/orgs/teams>`_
         :param name: string
         :param repo_names: list of :class:`github.Repository.Repository`
         :param permission: string
         :param privacy: string
+        :param description: string
         :rtype: :class:`github.Team.Team`
         """
         assert isinstance(name, (str, unicode)), name
         assert repo_names is github.GithubObject.NotSet or all(isinstance(element, github.Repository.Repository) for element in repo_names), repo_names
         assert permission is github.GithubObject.NotSet or isinstance(permission, (str, unicode)), permission
         assert privacy is github.GithubObject.NotSet or isinstance(privacy, (str, unicode)), privacy
+        assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
         post_parameters = {
             "name": name,
         }
@@ -479,6 +481,8 @@ class Organization(github.GithubObject.CompletableGithubObject):
             post_parameters["permission"] = permission
         if privacy is not github.GithubObject.NotSet:
             post_parameters['privacy'] = privacy
+        if description is not github.GithubObject.NotSet:
+            post_parameters["description"] = description
         headers, data = self._requester.requestJsonAndCheck(
             "POST",
             self.url + "/teams",

--- a/tests/Organization.py
+++ b/tests/Organization.py
@@ -127,8 +127,9 @@ class Organization(Framework.TestCase):
 
     def testCreateTeamWithAllArguments(self):
         repo = self.org.get_repo("FatherBeaver")
-        team = self.org.create_team("Team also created by PyGithub", [repo], "push", "secret")
+        team = self.org.create_team("Team also created by PyGithub", [repo], "push", "secret", "Description also created by PyGithub")
         self.assertEqual(team.id, 189852)
+        self.assertEqual(team.description, "Description also created by PyGithub")
 
     def testDeleteHook(self):
         hook = self.org.create_hook("web", {"url": "http://foobar.com"})

--- a/tests/ReplayData/Organization.testCreateTeamWithAllArguments.txt
+++ b/tests/ReplayData/Organization.testCreateTeamWithAllArguments.txt
@@ -15,7 +15,7 @@ api.github.com
 None
 /orgs/BeaverSoftware/teams
 {'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
-{"repo_names": ["BeaverSoftware/FatherBeaver"], "name": "Team also created by PyGithub", "permission": "push", "privacy": "secret"}
+{"repo_names": ["BeaverSoftware/FatherBeaver"], "name": "Team also created by PyGithub", "permission": "push", "privacy": "secret", "description":"Description also created by PyGithub"}
 201
 [('status', '201 Created'), ('x-ratelimit-remaining', '4982'), ('content-length', '150'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"6e3fb00de6ca4c112feee3a1438d6f0e"'), ('date', 'Sat, 26 May 2012 21:00:26 GMT'), ('content-type', 'application/json; charset=utf-8'), ('location', 'https://api.github.com/teams/189852')]
-{"repos_count":1,"url":"https://api.github.com/teams/189852","members_count":0,"name":"Team also created by PyGithub","permission":"push","id":189852}
+{"repos_count":1,"url":"https://api.github.com/teams/189852","members_count":0,"name":"Team also created by PyGithub","permission":"push","description":"Description also created by PyGithub","id":189852}


### PR DESCRIPTION
https://developer.github.com/v3/teams/#create-team has a supported field for `description`.
This PR adds support for creating teams with a description.