### PR TITLE
Add two factor attributes on organizations

### DIFF
--- a/github/Organization.py
+++ b/github/Organization.py
@@ -281,6 +281,14 @@ class Organization(github.GithubObject.CompletableGithubObject):
         return self._total_private_repos.value
 
     @property
+    def two_factor_status(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._two_factor_requirement_enabled)
+        return self._two_factor_requirement_enabled.value
+
+    @property
     def type(self):
         """
         :type: string
@@ -945,6 +953,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
         )
 
     def _initAttributes(self):
+        self._two_factor_requirement_enabled = github.GithubObject.NotSet
         self._avatar_url = github.GithubObject.NotSet
         self._billing_email = github.GithubObject.NotSet
         self._blog = github.GithubObject.NotSet
@@ -1031,6 +1040,8 @@ class Organization(github.GithubObject.CompletableGithubObject):
             self._repos_url = self._makeStringAttribute(attributes["repos_url"])
         if "total_private_repos" in attributes:  # pragma no branch
             self._total_private_repos = self._makeIntAttribute(attributes["total_private_repos"])
+        if "two_factor_requirement_enabled" in attributes:  # pragma no branch
+            self._two_factor_requirement_enabled = self._makeStringAttribute(attributes["two_factor_requirement_enabled"])
         if "type" in attributes:  # pragma no branch
             self._type = self._makeStringAttribute(attributes["type"])
         if "updated_at" in attributes:  # pragma no branch

--- a/github/Organization.py
+++ b/github/Organization.py
@@ -281,7 +281,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
         return self._total_private_repos.value
 
     @property
-    def two_factor_status(self):
+    def two_factor_requirement_enabled(self):
         """
         :type: bool
         """
@@ -1041,7 +1041,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
         if "total_private_repos" in attributes:  # pragma no branch
             self._total_private_repos = self._makeIntAttribute(attributes["total_private_repos"])
         if "two_factor_requirement_enabled" in attributes:  # pragma no branch
-            self._two_factor_requirement_enabled = self._makeStringAttribute(attributes["two_factor_requirement_enabled"])
+            self._two_factor_requirement_enabled = self._makeBoolAttribute(attributes["two_factor_requirement_enabled"])
         if "type" in attributes:  # pragma no branch
             self._type = self._makeStringAttribute(attributes["type"])
         if "updated_at" in attributes:  # pragma no branch

--- a/tests/Organization.py
+++ b/tests/Organization.py
@@ -72,6 +72,7 @@ class Organization(Framework.TestCase):
         self.assertEqual(self.org.public_gists, 0)
         self.assertEqual(self.org.public_repos, 27)
         self.assertEqual(self.org.total_private_repos, 7)
+        self.assertEqual(self.org.two_factor_requirement_enabled, True)
         self.assertEqual(self.org.type, "Organization")
         self.assertEqual(self.org.url, "https://api.github.com/orgs/BeaverSoftware")
 

--- a/tests/Organization.py
+++ b/tests/Organization.py
@@ -72,7 +72,7 @@ class Organization(Framework.TestCase):
         self.assertEqual(self.org.public_gists, 0)
         self.assertEqual(self.org.public_repos, 27)
         self.assertEqual(self.org.total_private_repos, 7)
-        self.assertEqual(self.org.two_factor_requirement_enabled, True)
+        self.assertEqual(self.org.two_factor_requirement_enabled, None)
         self.assertEqual(self.org.type, "Organization")
         self.assertEqual(self.org.url, "https://api.github.com/orgs/BeaverSoftware")
 


### PR DESCRIPTION
If you have the role of `org:admin` on an organization, you can view whether or not a second factor is required in order to be a member of an organization. (See https://developer.github.com/v3/orgs/#get-an-organization for more information). This PR adds `two_factor_requirement_enabled` as an attribute to the organization model. 

If a user doesn't have the correct permissions set on their personal access token or doesn't have `org:admin`, this value will be null in the JSON and `None` in pygithub.