### PR TITLE
Add new Organization.get_team_by_slug method

### DIFF
--- a/github/Organization.py
+++ b/github/Organization.py
@@ -790,6 +790,19 @@ class Organization(github.GithubObject.CompletableGithubObject):
         )
         return github.Team.Team(self._requester, headers, data, completed=True)
 
+    def get_team_by_slug(self, slug):
+        """
+        :calls: `GET /orgs/:org/teams/:team_slug <https://developer.github.com/v3/teams>`_
+        :param slug: string
+        :rtype: :class:`github.Team.Team`
+        """
+        assert isinstance(slug, (str, unicode)), slug
+        headers, data = self._requester.requestJsonAndCheck(
+            "GET",
+            self.url + "/teams/" + slug
+        )
+        return github.Team.Team(self._requester, headers, data, completed=True)
+
     def get_teams(self):
         """
         :calls: `GET /orgs/:org/teams <http://developer.github.com/v3/orgs/teams>`_

--- a/tests/Organization.py
+++ b/tests/Organization.py
@@ -188,6 +188,10 @@ class Organization(Framework.TestCase):
     def testGetTeams(self):
         self.assertListKeyEqual(self.org.get_teams(), lambda t: t.name, ["Members", "Owners"])
 
+    def testGetTeamBySlug(self):
+        team = self.org.get_team_by_slug("Members")
+        self.assertEqual(team.id, 141496)
+
     def testCreateHookWithMinimalParameters(self):
         hook = self.org.create_hook("web", {"url": "http://foobar.com"})
         self.assertEqual(hook.id, 257967)

--- a/tests/ReplayData/Organization.testGetTeamBySlug.txt
+++ b/tests/ReplayData/Organization.testGetTeamBySlug.txt
@@ -1,0 +1,11 @@
+https
+GET
+api.github.com
+None
+/orgs/BeaverSoftware/teams/Members
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+None
+200
+[('status', '200 OK'), ('x-ratelimit-remaining', '4994'), ('x-ratelimit-limit', '5000'), ('content-length', '128'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('etag', '"f93241eaf43847bcf38b352f25595e28"'), ('date', 'Tue, 18 Jun 2019 10:32:13 GMT'), ('content-type', 'application/json; charset=utf-8')]
+{"repos_count":1,"permission":"push","url":"https://api.github.com/teams/141496","name":"Members","id":141496,"members_count":1}
+


### PR DESCRIPTION
Add a new API call to Organization that allows fetching teams by
slug.

Closes #1116