### PR TITLE
Fixed #1147 Missing support for license attribute in Repository

### DIFF
--- a/github/License.py
+++ b/github/License.py
@@ -3,6 +3,7 @@
 ############################ Copyrights and license ############################
 #                                                                              #
 # Copyright 2018 Wan Liuyang <tsfdye@gmail.com>                                #
+# Copyright 2019 Juhapekka Piiroinen <juhapekka.piiroinen@1337.fi>             #
 #                                                                              #
 # This file is part of PyGithub.                                               #
 # http://pygithub.readthedocs.io/                                              #
@@ -160,3 +161,11 @@ class License(github.GithubObject.CompletableGithubObject):
             self._conditions = self._makeListOfStringsAttribute(attributes["conditions"])
         if "limitations" in attributes:  # pragma no branch
             self._limitations = self._makeListOfStringsAttribute(attributes["limitations"])
+
+
+class RepositoryLicense(License):
+    """
+    This class represents Licenses which is returned with Repository request.
+    """
+    def _completeIfNeeded(self):
+        pass

--- a/github/License.py
+++ b/github/License.py
@@ -3,7 +3,6 @@
 ############################ Copyrights and license ############################
 #                                                                              #
 # Copyright 2018 Wan Liuyang <tsfdye@gmail.com>                                #
-# Copyright 2019 Juhapekka Piiroinen <juhapekka.piiroinen@1337.fi>             #
 #                                                                              #
 # This file is part of PyGithub.                                               #
 # http://pygithub.readthedocs.io/                                              #
@@ -161,11 +160,3 @@ class License(github.GithubObject.CompletableGithubObject):
             self._conditions = self._makeListOfStringsAttribute(attributes["conditions"])
         if "limitations" in attributes:  # pragma no branch
             self._limitations = self._makeListOfStringsAttribute(attributes["limitations"])
-
-
-class RepositoryLicense(License):
-    """
-    This class represents License information which is returned with the Repository request.
-    """
-    def _completeIfNeeded(self):
-        pass

--- a/github/License.py
+++ b/github/License.py
@@ -165,7 +165,7 @@ class License(github.GithubObject.CompletableGithubObject):
 
 class RepositoryLicense(License):
     """
-    This class represents Licenses which is returned with Repository request.
+    This class represents License information which is returned with the Repository request.
     """
     def _completeIfNeeded(self):
         pass

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -134,6 +134,7 @@ import github.Referrer
 import github.Path
 import github.Clones
 import github.View
+import github.License
 
 import Consts
 
@@ -503,7 +504,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
     @property
     def license(self):
         """
-        :type: :class:`github.License.RepositoryLicense`
+        :type: :class:`github.License.License`
         """
         self._completeIfNotSet(self._license)
         return self._license.value
@@ -2930,7 +2931,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         if "pushed_at" in attributes:  # pragma no branch
             self._pushed_at = self._makeDatetimeAttribute(attributes["pushed_at"])
         if "license" in attributes:  # pragma no branch
-            self._license = self._makeClassAttribute(github.License.RepositoryLicense, attributes["license"])
+            self._license = self._makeClassAttribute(github.License.License, attributes["license"])
         if "size" in attributes:  # pragma no branch
             self._size = self._makeIntAttribute(attributes["size"])
         if "source" in attributes:  # pragma no branch

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -66,6 +66,7 @@
 # Copyright 2018 Zilei Gu <zileig@andrew.cmu.edu>                              #
 # Copyright 2018 Yves Zumbach <yzumbach@andrew.cmu.edu>                        #
 # Copyright 2018 Leying Chen <leyingc@andrew.cmu.edu>                          #
+# Copyright 2019 Juhapekka Piiroinen <juhapekka.piiroinen@1337.fi>             #
 #                                                                              #
 # This file is part of PyGithub.                                               #
 # http://pygithub.readthedocs.io/                                              #
@@ -498,6 +499,11 @@ class Repository(github.GithubObject.CompletableGithubObject):
         """
         self._completeIfNotSet(self._languages_url)
         return self._languages_url.value
+
+    @property
+    def license(self):
+        self._completeIfNotSet(self._license)
+        return self._license.value
 
     @property
     def master_branch(self):
@@ -2763,6 +2769,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         self._labels_url = github.GithubObject.NotSet
         self._language = github.GithubObject.NotSet
         self._languages_url = github.GithubObject.NotSet
+        self._license = github.GithubObject.NotSet
         self._master_branch = github.GithubObject.NotSet
         self._merges_url = github.GithubObject.NotSet
         self._milestones_url = github.GithubObject.NotSet
@@ -2919,6 +2926,8 @@ class Repository(github.GithubObject.CompletableGithubObject):
             self._pulls_url = self._makeStringAttribute(attributes["pulls_url"])
         if "pushed_at" in attributes:  # pragma no branch
             self._pushed_at = self._makeDatetimeAttribute(attributes["pushed_at"])
+        if "license" in attributes:  # pragma no branch
+            self._license = self._makeClassAttribute(github.License.RepositoryLicense, attributes["license"])
         if "size" in attributes:  # pragma no branch
             self._size = self._makeIntAttribute(attributes["size"])
         if "source" in attributes:  # pragma no branch

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -502,6 +502,9 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     @property
     def license(self):
+        """
+        :type: :class:`github.License.RepositoryLicense`
+        """
         self._completeIfNotSet(self._license)
         return self._license.value
 

--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -93,7 +93,10 @@ class Repository(Framework.TestCase):
         self.assertEqual(self.repo.updated_at, datetime.datetime(2012, 5, 27, 6, 55, 28))
         self.assertEqual(self.repo.url, "https://api.github.com/repos/jacquev6/PyGithub")
         self.assertEqual(self.repo.watchers, 15)
-
+        self.assertEqual(self.repo.license.key, "lgpl-3.0")
+        self.assertEqual(self.repo.license.name, "GNU Lesser General Public License v3.0")
+        self.assertEqual(self.repo.license.spdx_id, "LGPL-3.0")
+        self.assertEqual(self.repo.license.url, "https://api.github.com/licenses/lgpl-3.0")
         # test __repr__() based on this attributes
         self.assertEqual(self.repo.__repr__(), 'Repository(full_name="jacquev6/PyGithub")')
 


### PR DESCRIPTION
This adds new attribute 'license' to Repository. Which allows access to the license information which is already retrieved earlier.