### PR TITLE
Use assertRaises in other exception test in Retry

### DIFF
--- a/tests/Retry.py
+++ b/tests/Retry.py
@@ -75,10 +75,8 @@ class Retry(Framework.TestCase):
         self.assertEquals(repository.full_name, REPO_NAME)
 
     def testRaisesRetryErrorAfterMaxRetries(self):
-        try:
+        with self.assertRaises(requests.exceptions.RetryError):
             response = self.g.get_repo('PyGithub/PyGithub')
-            self.fail("RetryError should have been raised")
-        except requests.exceptions.RetryError:
-            self.assertEquals(len(httpretty.latest_requests), 4)
-            for request in httpretty.latest_requests:
-                self.assertEquals(request.path, '/repos/PyGithub/PyGithub')
+        self.assertEquals(len(httpretty.latest_requests), 4)
+        for request in httpretty.latest_requests:
+            self.assertEquals(request.path, '/repos/PyGithub/PyGithub')


### PR DESCRIPTION
I missed this use of try/except in the Retry tests during my last patch,
switch to using self.assertRaises().