### PR TITLE
Fix bug in recursive repository contents example

### DIFF
--- a/doc/examples/Repository.rst
+++ b/doc/examples/Repository.rst
@@ -83,7 +83,7 @@ Get all of the contents of the repository recursively
 
     >>> repo = g.get_repo("PyGithub/PyGithub")
     >>> contents = repo.get_contents("")
-    >>> while len(contents) > 1:
+    >>> while contents:
     ...     file_content = contents.pop(0)
     ...     if file_content.type == "dir":
     ...         contents.extend(repo.get_contents(file_content.path))


### PR DESCRIPTION
The previous code would prematurely exit when the intermediate contents list holds one thing, and that one thing has not been processed / expanded yet. Now the exit condition is when the contents list is empty, and there is nothing left to be processed.