### PR TITLE
Move a portion of github module to use six

### DIFF
--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -41,6 +41,7 @@
 ################################################################################
 
 import datetime
+import six
 
 import github.GithubObject
 import github.PaginatedList
@@ -372,7 +373,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         :param email: string
         :rtype: None
         """
-        assert all(isinstance(element, (str, unicode)) for element in emails), emails
+        assert all(isinstance(element, six.string_types) for element in emails), emails
         post_parameters = emails
         headers, data = self._requester.requestJsonAndCheck(
             "POST",
@@ -440,12 +441,12 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         :param onetime_password: string
         :rtype: :class:`github.Authorization.Authorization`
         """
-        assert scopes is github.GithubObject.NotSet or all(isinstance(element, (str, unicode)) for element in scopes), scopes
-        assert note is github.GithubObject.NotSet or isinstance(note, (str, unicode)), note
-        assert note_url is github.GithubObject.NotSet or isinstance(note_url, (str, unicode)), note_url
-        assert client_id is github.GithubObject.NotSet or isinstance(client_id, (str, unicode)), client_id
-        assert client_secret is github.GithubObject.NotSet or isinstance(client_secret, (str, unicode)), client_secret
-        assert onetime_password is None or isinstance(onetime_password, (str, unicode)), onetime_password
+        assert scopes is github.GithubObject.NotSet or all(isinstance(element, six.string_types) for element in scopes), scopes
+        assert note is github.GithubObject.NotSet or isinstance(note, six.string_types), note
+        assert note_url is github.GithubObject.NotSet or isinstance(note_url, six.string_types), note_url
+        assert client_id is github.GithubObject.NotSet or isinstance(client_id, six.string_types), client_id
+        assert client_secret is github.GithubObject.NotSet or isinstance(client_secret, six.string_types), client_secret
+        assert onetime_password is None or isinstance(onetime_password, six.string_types), onetime_password
         post_parameters = dict()
         if scopes is not github.GithubObject.NotSet:
             post_parameters["scopes"] = scopes
@@ -492,7 +493,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         """
         assert isinstance(public, bool), public
         assert all(isinstance(element, github.InputFileContent) for element in files.itervalues()), files
-        assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
+        assert description is github.GithubObject.NotSet or isinstance(description, six.string_types), description
         post_parameters = {
             "public": public,
             "files": {key: value._identity for key, value in files.iteritems()},
@@ -513,8 +514,8 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         :param key: string
         :rtype: :class:`github.UserKey.UserKey`
         """
-        assert isinstance(title, (str, unicode)), title
-        assert isinstance(key, (str, unicode)), key
+        assert isinstance(title, six.string_types), title
+        assert isinstance(key, six.string_types), key
         post_parameters = {
             "title": title,
             "key": key,
@@ -550,17 +551,17 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         :param allow_rebase_merge: bool
         :rtype: :class:`github.Repository.Repository`
         """
-        assert isinstance(name, (str, unicode)), name
-        assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
-        assert homepage is github.GithubObject.NotSet or isinstance(homepage, (str, unicode)), homepage
+        assert isinstance(name, six.string_types), name
+        assert description is github.GithubObject.NotSet or isinstance(description, six.string_types), description
+        assert homepage is github.GithubObject.NotSet or isinstance(homepage, six.string_types), homepage
         assert private is github.GithubObject.NotSet or isinstance(private, bool), private
         assert has_issues is github.GithubObject.NotSet or isinstance(has_issues, bool), has_issues
         assert has_wiki is github.GithubObject.NotSet or isinstance(has_wiki, bool), has_wiki
         assert has_downloads is github.GithubObject.NotSet or isinstance(has_downloads, bool), has_downloads
         assert has_projects is github.GithubObject.NotSet or isinstance(has_projects, bool), has_projects
         assert auto_init is github.GithubObject.NotSet or isinstance(auto_init, bool), auto_init
-        assert license_template is github.GithubObject.NotSet or isinstance(license_template, (str, unicode)), license_template
-        assert gitignore_template is github.GithubObject.NotSet or isinstance(gitignore_template, (str, unicode)), gitignore_template
+        assert license_template is github.GithubObject.NotSet or isinstance(license_template, six.string_types), license_template
+        assert gitignore_template is github.GithubObject.NotSet or isinstance(gitignore_template, six.string_types), gitignore_template
         assert allow_squash_merge is github.GithubObject.NotSet or isinstance(allow_squash_merge, bool), allow_squash_merge
         assert allow_merge_commit is github.GithubObject.NotSet or isinstance(allow_merge_commit, bool), allow_merge_commit
         assert allow_rebase_merge is github.GithubObject.NotSet or isinstance(allow_rebase_merge, bool), allow_rebase_merge
@@ -612,13 +613,13 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         :param bio: string
         :rtype: None
         """
-        assert name is github.GithubObject.NotSet or isinstance(name, (str, unicode)), name
-        assert email is github.GithubObject.NotSet or isinstance(email, (str, unicode)), email
-        assert blog is github.GithubObject.NotSet or isinstance(blog, (str, unicode)), blog
-        assert company is github.GithubObject.NotSet or isinstance(company, (str, unicode)), company
-        assert location is github.GithubObject.NotSet or isinstance(location, (str, unicode)), location
+        assert name is github.GithubObject.NotSet or isinstance(name, six.string_types), name
+        assert email is github.GithubObject.NotSet or isinstance(email, six.string_types), email
+        assert blog is github.GithubObject.NotSet or isinstance(blog, six.string_types), blog
+        assert company is github.GithubObject.NotSet or isinstance(company, six.string_types), company
+        assert location is github.GithubObject.NotSet or isinstance(location, six.string_types), location
         assert hireable is github.GithubObject.NotSet or isinstance(hireable, bool), hireable
-        assert bio is github.GithubObject.NotSet or isinstance(bio, (str, unicode)), bio
+        assert bio is github.GithubObject.NotSet or isinstance(bio, six.string_types), bio
         post_parameters = dict()
         if name is not github.GithubObject.NotSet:
             post_parameters["name"] = name
@@ -742,11 +743,11 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         :param since: datetime.datetime
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Issue.Issue`
         """
-        assert filter is github.GithubObject.NotSet or isinstance(filter, (str, unicode)), filter
-        assert state is github.GithubObject.NotSet or isinstance(state, (str, unicode)), state
+        assert filter is github.GithubObject.NotSet or isinstance(filter, six.string_types), filter
+        assert state is github.GithubObject.NotSet or isinstance(state, six.string_types), state
         assert labels is github.GithubObject.NotSet or all(isinstance(element, github.Label.Label) for element in labels), labels
-        assert sort is github.GithubObject.NotSet or isinstance(sort, (str, unicode)), sort
-        assert direction is github.GithubObject.NotSet or isinstance(direction, (str, unicode)), direction
+        assert sort is github.GithubObject.NotSet or isinstance(sort, six.string_types), sort
+        assert direction is github.GithubObject.NotSet or isinstance(direction, six.string_types), direction
         assert since is github.GithubObject.NotSet or isinstance(since, datetime.datetime), since
         url_parameters = dict()
         if filter is not github.GithubObject.NotSet:
@@ -780,11 +781,11 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         :param since: datetime.datetime
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Issue.Issue`
         """
-        assert filter is github.GithubObject.NotSet or isinstance(filter, (str, unicode)), filter
-        assert state is github.GithubObject.NotSet or isinstance(state, (str, unicode)), state
+        assert filter is github.GithubObject.NotSet or isinstance(filter, six.string_types), filter
+        assert state is github.GithubObject.NotSet or isinstance(state, six.string_types), state
         assert labels is github.GithubObject.NotSet or all(isinstance(element, github.Label.Label) for element in labels), labels
-        assert sort is github.GithubObject.NotSet or isinstance(sort, (str, unicode)), sort
-        assert direction is github.GithubObject.NotSet or isinstance(direction, (str, unicode)), direction
+        assert sort is github.GithubObject.NotSet or isinstance(sort, six.string_types), sort
+        assert direction is github.GithubObject.NotSet or isinstance(direction, six.string_types), direction
         assert since is github.GithubObject.NotSet or isinstance(since, datetime.datetime), since
         url_parameters = dict()
         if filter is not github.GithubObject.NotSet:
@@ -837,7 +838,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         :rtype: :class:`github.Notification.Notification`
         """
 
-        assert isinstance(id, (str, unicode)), id
+        assert isinstance(id, six.string_types), id
         headers, data = self._requester.requestJsonAndCheck(
             "GET",
             "/notifications/threads/" + id
@@ -908,7 +909,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         :param name: string
         :rtype: :class:`github.Repository.Repository`
         """
-        assert isinstance(name, (str, unicode)), name
+        assert isinstance(name, six.string_types), name
         headers, data = self._requester.requestJsonAndCheck(
             "GET",
             "/repos/" + self.login + "/" + name
@@ -925,11 +926,11 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         :param direction: string
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
         """
-        assert visibility is github.GithubObject.NotSet or isinstance(visibility, (str, unicode)), visibility
-        assert affiliation is github.GithubObject.NotSet or isinstance(affiliation, (str, unicode)), affiliation
-        assert type is github.GithubObject.NotSet or isinstance(type, (str, unicode)), type
-        assert sort is github.GithubObject.NotSet or isinstance(sort, (str, unicode)), sort
-        assert direction is github.GithubObject.NotSet or isinstance(direction, (str, unicode)), direction
+        assert visibility is github.GithubObject.NotSet or isinstance(visibility, six.string_types), visibility
+        assert affiliation is github.GithubObject.NotSet or isinstance(affiliation, six.string_types), affiliation
+        assert type is github.GithubObject.NotSet or isinstance(type, six.string_types), type
+        assert sort is github.GithubObject.NotSet or isinstance(sort, six.string_types), sort
+        assert direction is github.GithubObject.NotSet or isinstance(direction, six.string_types), direction
         url_parameters = dict()
         if visibility is not github.GithubObject.NotSet:
             url_parameters["visibility"] = visibility
@@ -1082,7 +1083,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         :param email: string
         :rtype: None
         """
-        assert all(isinstance(element, (str, unicode)) for element in emails), emails
+        assert all(isinstance(element, six.string_types) for element in emails), emails
         post_parameters = emails
         headers, data = self._requester.requestJsonAndCheck(
             "DELETE",
@@ -1176,7 +1177,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         :rtype: :class:`github.Migration.Migration`
         """
         assert isinstance(repos, (list, tuple)), repos
-        assert all(isinstance(repo, (str, unicode)) for repo in repos), repos
+        assert all(isinstance(repo, six.string_types) for repo in repos), repos
         assert lock_repositories is github.GithubObject.NotSet or isinstance(lock_repositories, bool), lock_repositories
         assert exclude_attachments is github.GithubObject.NotSet or isinstance(exclude_attachments, bool), exclude_attachments
         post_parameters = {

--- a/github/Authorization.py
+++ b/github/Authorization.py
@@ -30,8 +30,9 @@
 #                                                                              #
 ################################################################################
 
-import github.GithubObject
+import six
 
+import github.GithubObject
 import github.AuthorizationApplication
 
 
@@ -135,11 +136,11 @@ class Authorization(github.GithubObject.CompletableGithubObject):
         :param note_url: string
         :rtype: None
         """
-        assert scopes is github.GithubObject.NotSet or all(isinstance(element, (str, unicode)) for element in scopes), scopes
-        assert add_scopes is github.GithubObject.NotSet or all(isinstance(element, (str, unicode)) for element in add_scopes), add_scopes
-        assert remove_scopes is github.GithubObject.NotSet or all(isinstance(element, (str, unicode)) for element in remove_scopes), remove_scopes
-        assert note is github.GithubObject.NotSet or isinstance(note, (str, unicode)), note
-        assert note_url is github.GithubObject.NotSet or isinstance(note_url, (str, unicode)), note_url
+        assert scopes is github.GithubObject.NotSet or all(isinstance(element, six.string_types) for element in scopes), scopes
+        assert add_scopes is github.GithubObject.NotSet or all(isinstance(element, six.string_types) for element in add_scopes), add_scopes
+        assert remove_scopes is github.GithubObject.NotSet or all(isinstance(element, six.string_types) for element in remove_scopes), remove_scopes
+        assert note is github.GithubObject.NotSet or isinstance(note, six.string_types), note
+        assert note_url is github.GithubObject.NotSet or isinstance(note_url, six.string_types), note_url
         post_parameters = dict()
         if scopes is not github.GithubObject.NotSet:
             post_parameters["scopes"] = scopes

--- a/github/Branch.py
+++ b/github/Branch.py
@@ -33,6 +33,8 @@
 #                                                                              #
 ################################################################################
 
+import six
+
 import github.GithubObject
 
 import github.BranchProtection
@@ -125,10 +127,10 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         changing. Use edit_required_status_checks() to avoid this.
         """
         assert strict is github.GithubObject.NotSet or isinstance(strict, bool), strict
-        assert contexts is github.GithubObject.NotSet or all(isinstance(element, (str, unicode)) or isinstance(element, (str, unicode)) for element in contexts), contexts
+        assert contexts is github.GithubObject.NotSet or all(isinstance(element, six.string_types) or isinstance(element, six.string_types) for element in contexts), contexts
         assert enforce_admins is github.GithubObject.NotSet or isinstance(enforce_admins, bool), enforce_admins
-        assert dismissal_users is github.GithubObject.NotSet or all(isinstance(element, (str, unicode)) or isinstance(element, (str, unicode)) for element in dismissal_users), dismissal_users
-        assert dismissal_teams is github.GithubObject.NotSet or all(isinstance(element, (str, unicode)) or isinstance(element, (str, unicode)) for element in dismissal_teams), dismissal_teams
+        assert dismissal_users is github.GithubObject.NotSet or all(isinstance(element, six.string_types) or isinstance(element, six.string_types) for element in dismissal_users), dismissal_users
+        assert dismissal_teams is github.GithubObject.NotSet or all(isinstance(element, six.string_types) or isinstance(element, six.string_types) for element in dismissal_teams), dismissal_teams
         assert dismiss_stale_reviews is github.GithubObject.NotSet or isinstance(dismiss_stale_reviews, bool), dismiss_stale_reviews
         assert require_code_owner_reviews is github.GithubObject.NotSet or isinstance(require_code_owner_reviews, bool), require_code_owner_reviews
         assert required_approving_review_count is github.GithubObject.NotSet or isinstance(required_approving_review_count, int), required_approving_review_count
@@ -207,7 +209,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         :contexts: list of strings
         """
         assert strict is github.GithubObject.NotSet or isinstance(strict, bool), strict
-        assert contexts is github.GithubObject.NotSet or all(isinstance(element, (str, unicode)) or isinstance(element, (str, unicode)) for element in contexts), contexts
+        assert contexts is github.GithubObject.NotSet or all(isinstance(element, six.string_types) or isinstance(element, six.string_types) for element in contexts), contexts
 
         post_parameters = {}
         if strict is not github.GithubObject.NotSet:
@@ -250,8 +252,8 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         :require_code_owner_reviews: bool
         :required_approving_review_count: int
         """
-        assert dismissal_users is github.GithubObject.NotSet or all(isinstance(element, (str, unicode)) or isinstance(element, (str, unicode)) for element in dismissal_users), dismissal_users
-        assert dismissal_teams is github.GithubObject.NotSet or all(isinstance(element, (str, unicode)) or isinstance(element, (str, unicode)) for element in dismissal_teams), dismissal_teams
+        assert dismissal_users is github.GithubObject.NotSet or all(isinstance(element, six.string_types) or isinstance(element, six.string_types) for element in dismissal_users), dismissal_users
+        assert dismissal_teams is github.GithubObject.NotSet or all(isinstance(element, six.string_types) or isinstance(element, six.string_types) for element in dismissal_teams), dismissal_teams
         assert dismiss_stale_reviews is github.GithubObject.NotSet or isinstance(dismiss_stale_reviews, bool), dismiss_stale_reviews
         assert require_code_owner_reviews is github.GithubObject.NotSet or isinstance(require_code_owner_reviews, bool), require_code_owner_reviews
         assert required_approving_review_count is github.GithubObject.NotSet or isinstance(required_approving_review_count, int), required_approving_review_count
@@ -343,7 +345,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         :calls: `POST /repos/:owner/:repo/branches/:branch/protection/restrictions <https://developer.github.com/v3/repos/branches>`_
         :users: list of strings
         """
-        assert all(isinstance(element, (str, unicode)) or isinstance(element, (str, unicode)) for element in users), users
+        assert all(isinstance(element, six.string_types) or isinstance(element, six.string_types) for element in users), users
 
         headers, data = self._requester.requestJsonAndCheck(
             "POST",
@@ -356,7 +358,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         :calls: `POST /repos/:owner/:repo/branches/:branch/protection/restrictions <https://developer.github.com/v3/repos/branches>`_
         :teams: list of strings
         """
-        assert all(isinstance(element, (str, unicode)) or isinstance(element, (str, unicode)) for element in teams), teams
+        assert all(isinstance(element, six.string_types) or isinstance(element, six.string_types) for element in teams), teams
 
         headers, data = self._requester.requestJsonAndCheck(
             "POST",

--- a/github/Commit.py
+++ b/github/Commit.py
@@ -32,6 +32,8 @@
 #                                                                              #
 ################################################################################
 
+import six
+
 import github.GithubObject
 import github.PaginatedList
 
@@ -141,9 +143,9 @@ class Commit(github.GithubObject.CompletableGithubObject):
         :param position: integer
         :rtype: :class:`github.CommitComment.CommitComment`
         """
-        assert isinstance(body, (str, unicode)), body
+        assert isinstance(body, six.string_types), body
         assert line is github.GithubObject.NotSet or isinstance(line, (int, long)), line
-        assert path is github.GithubObject.NotSet or isinstance(path, (str, unicode)), path
+        assert path is github.GithubObject.NotSet or isinstance(path, six.string_types), path
         assert position is github.GithubObject.NotSet or isinstance(position, (int, long)), position
         post_parameters = {
             "body": body,
@@ -170,10 +172,10 @@ class Commit(github.GithubObject.CompletableGithubObject):
         :param context: string
         :rtype: :class:`github.CommitStatus.CommitStatus`
         """
-        assert isinstance(state, (str, unicode)), state
-        assert target_url is github.GithubObject.NotSet or isinstance(target_url, (str, unicode)), target_url
-        assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
-        assert context is github.GithubObject.NotSet or isinstance(context, (str, unicode)), context
+        assert isinstance(state, six.string_types), state
+        assert target_url is github.GithubObject.NotSet or isinstance(target_url, six.string_types), target_url
+        assert description is github.GithubObject.NotSet or isinstance(description, six.string_types), description
+        assert context is github.GithubObject.NotSet or isinstance(context, six.string_types), context
         post_parameters = {
             "state": state,
         }

--- a/github/CommitComment.py
+++ b/github/CommitComment.py
@@ -32,6 +32,8 @@
 #                                                                              #
 ################################################################################
 
+import six
+
 import github.GithubObject
 import github.NamedUser
 
@@ -150,7 +152,7 @@ class CommitComment(github.GithubObject.CompletableGithubObject):
         :param body: string
         :rtype: None
         """
-        assert isinstance(body, (str, unicode)), body
+        assert isinstance(body, six.string_types), body
         post_parameters = {
             "body": body,
         }
@@ -182,7 +184,7 @@ class CommitComment(github.GithubObject.CompletableGithubObject):
         :param reaction_type: string
         :rtype: :class:`github.Reaction.Reaction`
         """
-        assert isinstance(reaction_type, (str, unicode)), "reaction type should be a string"
+        assert isinstance(reaction_type, six.string_types), "reaction type should be a string"
         assert reaction_type in ["+1", "-1", "laugh", "confused", "heart", "hooray"], \
             "Invalid reaction type (https://developer.github.com/v3/reactions/#reaction-types)"
 

--- a/github/Gist.py
+++ b/github/Gist.py
@@ -33,6 +33,8 @@
 #                                                                              #
 ################################################################################
 
+import six
+
 import github.GithubObject
 import github.PaginatedList
 
@@ -208,7 +210,7 @@ class Gist(github.GithubObject.CompletableGithubObject):
         :param body: string
         :rtype: :class:`github.GistComment.GistComment`
         """
-        assert isinstance(body, (str, unicode)), body
+        assert isinstance(body, six.string_types), body
         post_parameters = {
             "body": body,
         }
@@ -247,7 +249,7 @@ class Gist(github.GithubObject.CompletableGithubObject):
         :param files: dict of string to :class:`github.InputFileContent.InputFileContent`
         :rtype: None
         """
-        assert description is github.GithubObject.NotSet or isinstance(description, (str, unicode)), description
+        assert description is github.GithubObject.NotSet or isinstance(description, six.string_types), description
         assert files is github.GithubObject.NotSet or all(element is None or isinstance(element, github.InputFileContent) for element in files.itervalues()), files
         post_parameters = dict()
         if description is not github.GithubObject.NotSet:

--- a/github/GistComment.py
+++ b/github/GistComment.py
@@ -30,8 +30,9 @@
 #                                                                              #
 ################################################################################
 
-import github.GithubObject
+import six
 
+import github.GithubObject
 import github.NamedUser
 
 
@@ -107,7 +108,7 @@ class GistComment(github.GithubObject.CompletableGithubObject):
         :param body: string
         :rtype: None
         """
-        assert isinstance(body, (str, unicode)), body
+        assert isinstance(body, six.string_types), body
         post_parameters = {
             "body": body,
         }

--- a/github/GitRef.py
+++ b/github/GitRef.py
@@ -30,8 +30,9 @@
 #                                                                              #
 ################################################################################
 
-import github.GithubObject
+import six
 
+import github.GithubObject
 import github.GitObject
 
 
@@ -84,7 +85,7 @@ class GitRef(github.GithubObject.CompletableGithubObject):
         :param force: bool
         :rtype: None
         """
-        assert isinstance(sha, (str, unicode)), sha
+        assert isinstance(sha, six.string_types), sha
         assert force is github.GithubObject.NotSet or isinstance(force, bool), force
         post_parameters = {
             "sha": sha,

--- a/github/GitRelease.py
+++ b/github/GitRelease.py
@@ -36,6 +36,8 @@
 ################################################################################
 
 from os.path import basename
+import six
+
 import github.GithubObject
 import github.NamedUser
 import github.GitReleaseAsset
@@ -187,13 +189,13 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
         :rtype: :class:`github.GitRelease.GitRelease`
         """
         assert tag_name is github.GithubObject.NotSet              \
-            or isinstance(tag_name, (str, unicode)),               \
+            or isinstance(tag_name, six.string_types),               \
             'tag_name must be a str/unicode object'
         assert target_commitish is github.GithubObject.NotSet      \
-            or isinstance(target_commitish, (str, unicode)),       \
+            or isinstance(target_commitish, six.string_types),       \
             'target_commitish must be a str/unicode object'
-        assert isinstance(name, (str, unicode)), name
-        assert isinstance(message, (str, unicode)), message
+        assert isinstance(name, six.string_types), name
+        assert isinstance(message, six.string_types), message
         assert isinstance(draft, bool), draft
         assert isinstance(prerelease, bool), prerelease
         if tag_name is github.GithubObject.NotSet:
@@ -221,9 +223,9 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
         :calls: `POST https://<upload_url>/repos/:owner/:repo/releases/:release_id/assets <https://developer.github.com/v3/repos/releases/#upload-a-release-asset>`_
         :rtype: :class:`github.GitReleaseAsset.GitReleaseAsset`
         """
-        assert isinstance(path, (str, unicode)), path
-        assert isinstance(label, (str, unicode)), label
-        assert name is github.GithubObject.NotSet or isinstance(name, (str, unicode)), name
+        assert isinstance(path, six.string_types), path
+        assert isinstance(label, six.string_types), label
+        assert name is github.GithubObject.NotSet or isinstance(name, six.string_types), name
 
         post_parameters = {
             "label": label

--- a/github/GitReleaseAsset.py
+++ b/github/GitReleaseAsset.py
@@ -25,6 +25,8 @@
 #                                                                              #
 ################################################################################
 
+import six
+
 import github.GithubObject
 
 
@@ -164,8 +166,8 @@ class GitReleaseAsset(github.GithubObject.CompletableGithubObject):
         Update asset metadata.
         :rtype: github.GitReleaseAsset.GitReleaseAsset
         """
-        assert isinstance(name, (str, unicode)), name
-        assert isinstance(label, (str, unicode)), label
+        assert isinstance(name, six.string_types), name
+        assert isinstance(label, six.string_types), label
         post_parameters = {
             "name": name,
             "label": label

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -35,6 +35,7 @@
 import sys
 import datetime
 from operator import itemgetter
+import six
 
 import GithubException
 import Consts
@@ -147,7 +148,7 @@ class GithubObject(object):
 
     @staticmethod
     def _makeStringAttribute(value):
-        return GithubObject.__makeSimpleAttribute(value, (str, unicode))
+        return GithubObject.__makeSimpleAttribute(value, six.string_types)
 
     @staticmethod
     def _makeIntAttribute(value):
@@ -177,14 +178,14 @@ class GithubObject(object):
             else:
                 return datetime.datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ")
 
-        return GithubObject.__makeTransformedAttribute(value, (str, unicode), parseDatetime)
+        return GithubObject.__makeTransformedAttribute(value, six.string_types, parseDatetime)
 
     def _makeClassAttribute(self, klass, value):
         return GithubObject.__makeTransformedAttribute(value, dict, lambda value: klass(self._requester, self._headers, value, completed=False))
 
     @staticmethod
     def _makeListOfStringsAttribute(value):
-        return GithubObject.__makeSimpleListAttribute(value, (str, unicode))
+        return GithubObject.__makeSimpleListAttribute(value, six.string_types)
 
     @staticmethod
     def _makeListOfIntsAttribute(value):
@@ -205,10 +206,10 @@ class GithubObject(object):
             return _BadAttribute(value, [dict])
 
     def _makeDictOfStringsToClassesAttribute(self, klass, value):
-        if isinstance(value, dict) and all(isinstance(key, (str, unicode)) and isinstance(element, dict) for key, element in value.iteritems()):
+        if isinstance(value, dict) and all(isinstance(key, six.string_types) and isinstance(element, dict) for key, element in value.iteritems()):
             return _ValuedAttribute(dict((key, klass(self._requester, self._headers, element, completed=False)) for key, element in value.iteritems()))
         else:
-            return _BadAttribute(value, {(str, unicode): dict})
+            return _BadAttribute(value, {six.string_types: dict})
 
     @property
     def etag(self):
@@ -234,7 +235,7 @@ class GithubObject(object):
             else:
                 items = list(params.items())
             for k, v in sorted(items, key=itemgetter(0), reverse=True):
-                isText = isinstance(v, (str, unicode))
+                isText = isinstance(v, six.string_types)
                 if isText and not atLeastPython3:
                     v = v.encode('utf-8')
                 yield '{k}="{v}"'.format(k=k, v=v) if isText else '{k}={v}'.format(k=k, v=v)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 requests>=2.14.0
 pyjwt
+six
 sphinx<1.8
 sphinx-rtd-theme<0.5
 Deprecated

--- a/tests/BadAttributes.py
+++ b/tests/BadAttributes.py
@@ -27,6 +27,7 @@
 ################################################################################
 
 import datetime
+import six
 
 import Framework
 import github
@@ -41,7 +42,7 @@ class BadAttributes(Framework.TestCase):
         with self.assertRaises(github.BadAttributeException) as raisedexp:
             user.name
         self.assertEqual(raisedexp.exception.actual_value, 42)
-        self.assertEqual(raisedexp.exception.expected_type, (str, unicode))
+        self.assertEqual(raisedexp.exception.expected_type, six.string_types)
         self.assertEqual(raisedexp.exception.transformation_exception, None)
 
     def testBadAttributeTransformation(self):
@@ -51,7 +52,7 @@ class BadAttributes(Framework.TestCase):
         with self.assertRaises(github.BadAttributeException) as raisedexp:
             user.created_at
         self.assertEqual(raisedexp.exception.actual_value, "foobar")
-        self.assertEqual(raisedexp.exception.expected_type, (str, unicode))
+        self.assertEqual(raisedexp.exception.expected_type, six.string_types)
         self.assertEqual(raisedexp.exception.transformation_exception.__class__, ValueError)
         self.assertEqual(raisedexp.exception.transformation_exception.args, ("time data 'foobar' does not match format '%Y-%m-%dT%H:%M:%SZ'",))
 
@@ -62,7 +63,7 @@ class BadAttributes(Framework.TestCase):
         with self.assertRaises(github.BadAttributeException) as raisedexp:
             user.updated_at
         self.assertEqual(raisedexp.exception.actual_value, 42)
-        self.assertEqual(raisedexp.exception.expected_type, (str, unicode))
+        self.assertEqual(raisedexp.exception.expected_type, six.string_types)
         self.assertEqual(raisedexp.exception.transformation_exception, None)
 
     def testBadSimpleAttributeInList(self):
@@ -72,7 +73,7 @@ class BadAttributes(Framework.TestCase):
         with self.assertRaises(github.BadAttributeException) as raisedexp:
             hook.events
         self.assertEqual(raisedexp.exception.actual_value, ["push", 42])
-        self.assertEqual(raisedexp.exception.expected_type, [(str, unicode)])
+        self.assertEqual(raisedexp.exception.expected_type, [six.string_types])
         self.assertEqual(raisedexp.exception.transformation_exception, None)
 
     def testBadAttributeInClassAttribute(self):
@@ -99,7 +100,7 @@ class BadAttributes(Framework.TestCase):
         with self.assertRaises(github.BadAttributeException) as raisedexp:
             gist.files
         self.assertEqual(raisedexp.exception.actual_value, {"test.py": 42})
-        self.assertEqual(raisedexp.exception.expected_type, {(str, unicode): dict})
+        self.assertEqual(raisedexp.exception.expected_type, {six.string_types: dict})
         self.assertEqual(raisedexp.exception.transformation_exception, None)
 
     def testIssue195(self):
@@ -115,5 +116,5 @@ class BadAttributes(Framework.TestCase):
                 with self.assertRaises(github.BadAttributeException) as raisedexp:
                     hook.events
         self.assertEqual(raisedexp.exception.actual_value, [["commit_comment", "create", "delete", "download", "follow", "fork", "fork_apply", "gist", "gollum", "issue_comment", "issues", "member", "public", "pull_request", "pull_request_review_comment", "push", "status", "team_add", "watch"]])
-        self.assertEqual(raisedexp.exception.expected_type, [(str, unicode)])
+        self.assertEqual(raisedexp.exception.expected_type, [six.string_types])
         self.assertEqual(raisedexp.exception.transformation_exception, None)


### PR DESCRIPTION
The Python 2 deadline is fast approaching, and we still rely very
heavily on Python 2 features. To make a start on moving this code base
to work without modifications for both Python 2 and 3, use the six
module for github/[A-G] for string checking.