### PR TITLE
Correct return type of MainClass.get_organizations

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -273,7 +273,7 @@ class Github(object):
         if since is not github.GithubObject.NotSet:
             url_parameters["since"] = since
         return github.PaginatedList.PaginatedList(
-            github.NamedUser.NamedUser,
+            github.Organization.Organization,
             self.__requester,
             "/organizations",
             url_parameters


### PR DESCRIPTION
The doc string and the code disagreed about the return type of
MainClass.get_organizations(), correct the code, which was incorrect.

Fixes #1177