### PR TITLE
Fix directories for coverage in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
 install:
   - pip install codecov
 script:
-  - coverage run --source github/tests setup.py test
+  - coverage run --source github,tests setup.py test
 after_success:
   - codecov
 notifications:


### PR DESCRIPTION
The directory github/tests no longer exists, correct the path for Travis
goodness.