### PR TITLE
Remove some uses of atLeastPython3

### DIFF
--- a/github/ContentFile.py
+++ b/github/ContentFile.py
@@ -39,9 +39,6 @@ import github.GithubObject
 import github.Repository
 
 
-atLeastPython3 = sys.hexversion >= 0x03000000
-
-
 class ContentFile(github.GithubObject.CompletableGithubObject):
     """
     This class represents ContentFiles. The reference can be found here https://developer.github.com/v3/repos/contents/#get-contents
@@ -61,11 +58,7 @@ class ContentFile(github.GithubObject.CompletableGithubObject):
     @property
     def decoded_content(self):
         assert self.encoding == "base64", "unsupported encoding: %s" % self.encoding
-        if atLeastPython3:
-            content = bytearray(self.content, "utf-8")  # pragma no cover (covered by tests with Python 3.2)
-        else:
-            content = self.content
-        return base64.b64decode(content)
+        return base64.b64decode(bytearray(self.content, "utf-8"))
 
     @property
     def download_url(self):

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -231,10 +231,7 @@ class GithubObject(object):
         Converts the object to a nicely printable string.
         """
         def format_params(params):
-            if atLeastPython3:
-                items = list(params.items())
-            else:
-                items = list(params.items())
+            items = list(params.items())
             for k, v in sorted(items, key=itemgetter(0), reverse=True):
                 isText = isinstance(v, (str, six.text_type))
                 if isText and not atLeastPython3:

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -80,10 +80,7 @@ class RequestsResponse:
         self.text = r.text
 
     def getheaders(self):
-        if atLeastPython3:
-            return list(self.headers.items())
-        else:
-            return six.iteritems(self.headers)
+        return six.iteritems(self.headers)
 
     def read(self):
         return self.text
@@ -231,10 +228,7 @@ class Requester:
 
         if password is not None:
             login = login_or_token
-            if atLeastPython3:
-                self.__authorizationHeader = "Basic " + base64.b64encode((login + ":" + password).encode("utf-8")).decode("utf-8").replace('\n', '')  # pragma no cover (Covered by Authentication.testAuthorizationHeaderWithXxx with Python 3)
-            else:
-                self.__authorizationHeader = "Basic " + base64.b64encode(login + ":" + password).replace('\n', '')
+            self.__authorizationHeader = "Basic " + base64.b64encode((login + ":" + password).encode("utf-8")).decode("utf-8").replace('\n', '')
         elif login_or_token is not None:
             token = login_or_token
             self.__authorizationHeader = "token " + token
@@ -323,8 +317,8 @@ class Requester:
         if len(data) == 0:
             return None
         else:
-            if atLeastPython3 and isinstance(data, bytes):  # pragma no branch (Covered by Issue142.testDecodeJson with Python 3)
-                data = data.decode("utf-8")  # pragma no cover (Covered by Issue142.testDecodeJson with Python 3)
+            if isinstance(data, bytes):
+                data = data.decode("utf-8")
             try:
                 return json.loads(data)
             except ValueError:


### PR DESCRIPTION
There are a number of call sites that would behave differently depending
on Python 2 or 3. A fair amount of them are left over from Python 3.2 or
Python 2.6 were the current versions, and it was much harder to write
compatible code for both versions. Happily, that is now in the past, so
refactor some of them out.