### PR TITLE
Drop use of assertEquals

### DIFF
--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -535,12 +535,12 @@ class Repository(Framework.TestCase):
     def testGetContentsDir(self):
         contents = self.repo.get_contents("")
         self.assertTrue(isinstance(contents, list))
-        self.assertEquals(len(contents), 14)
+        self.assertEqual(len(contents), 14)
 
     def testGetContentsDirWithSlash(self):
         contents = self.repo.get_contents("/")
         self.assertTrue(isinstance(contents, list))
-        self.assertEquals(len(contents), 14)
+        self.assertEqual(len(contents), 14)
 
     def testGetContentsWithRef(self):
         self.assertEqual(len(self.repo.get_readme(ref="refs/heads/topic/ExperimentOnDocumentation").content), 6747)

--- a/tests/Retry.py
+++ b/tests/Retry.py
@@ -55,29 +55,29 @@ class Retry(Framework.TestCase):
     def testShouldNotRetryWhenStatusNotOnList(self):
         with self.assertRaises(github.GithubException):
             self.g.get_repo(REPO_NAME)
-        self.assertEquals(len(httpretty.latest_requests), 1)
+        self.assertEqual(len(httpretty.latest_requests), 1)
 
     def testReturnsRepoAfter3Retries(self):
         repository = self.g.get_repo(REPO_NAME)
-        self.assertEquals(len(httpretty.latest_requests), 4)
+        self.assertEqual(len(httpretty.latest_requests), 4)
         for request in httpretty.latest_requests:
-            self.assertEquals(request.path, '/repos/' + REPO_NAME)
+            self.assertEqual(request.path, '/repos/' + REPO_NAME)
 
         self.assertIsInstance(repository, github.Repository.Repository)
-        self.assertEquals(repository.full_name, REPO_NAME)
+        self.assertEqual(repository.full_name, REPO_NAME)
 
     def testReturnsRepoAfter1Retry(self):
         repository = self.g.get_repo(REPO_NAME)
-        self.assertEquals(len(httpretty.latest_requests), 2)
+        self.assertEqual(len(httpretty.latest_requests), 2)
         for request in httpretty.latest_requests:
-            self.assertEquals(request.path, '/repos/' + REPO_NAME)
+            self.assertEqual(request.path, '/repos/' + REPO_NAME)
 
         self.assertIsInstance(repository, github.Repository.Repository)
-        self.assertEquals(repository.full_name, REPO_NAME)
+        self.assertEqual(repository.full_name, REPO_NAME)
 
     def testRaisesRetryErrorAfterMaxRetries(self):
         with self.assertRaises(requests.exceptions.RetryError):
             self.g.get_repo('PyGithub/PyGithub')
-        self.assertEquals(len(httpretty.latest_requests), 4)
+        self.assertEqual(len(httpretty.latest_requests), 4)
         for request in httpretty.latest_requests:
-            self.assertEquals(request.path, '/repos/PyGithub/PyGithub')
+            self.assertEqual(request.path, '/repos/PyGithub/PyGithub')


### PR DESCRIPTION
TestCase.assertEquals is deprecated, at least in modern Python 3, so
which to assertEqual, which is used everywhere else.