### PR TITLE
fix topics attribute always return None

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -727,7 +727,8 @@ class Repository(github.GithubObject.CompletableGithubObject):
         """
         :type: list of strings
         """
-        self._completeIfNotSet(self._topics)
+        if self._topics is github.GithubObject.NotSet:
+            self._topics = self._makeListOfStringsAttribute(self.get_topics())
         return self._topics.value
 
     @property

--- a/tests/ReplayData/Repository.testTopicsAttribute.txt
+++ b/tests/ReplayData/Repository.testTopicsAttribute.txt
@@ -1,0 +1,11 @@
+https
+GET
+api.github.com
+None
+/repos/jacquev6/PyGithub/topics
+{'Authorization': 'Basic login_and_password_removed', 'Accept': 'application/vnd.github.mercy-preview+json', 'User-Agent': 'PyGithub/Python'}
+None
+200
+[('content-length', '30'), ('x-runtime-rack', '0.081855'), ('vary', 'Accept, Authorization, Cookie, X-GitHub-OTP'), ('x-xss-protection', '1; mode=block'), ('x-content-type-options', 'nosniff'), ('etag', '"c34823528b2c41eadf247bcea3b7dabc"'), ('cache-control', 'private, max-age=60, s-maxage=60'), ('referrer-policy', 'origin-when-cross-origin, strict-origin-when-cross-origin'), ('status', '200 OK'), ('x-ratelimit-remaining', '4994'), ('x-github-media-type', 'github.mercy-preview; format=json'), ('access-control-expose-headers', 'ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval'), ('x-github-request-id', '4C20:5398:FE4A88:26DA323:5AD7F450'), ('date', 'Thu, 19 Apr 2018 01:43:45 GMT'), ('access-control-allow-origin', '*'), ('content-security-policy', "default-src 'none'"), ('strict-transport-security', 'max-age=31536000; includeSubdomains; preload'), ('server', 'GitHub.com'), ('x-ratelimit-limit', '5000'), ('x-frame-options', 'deny'), ('content-type', 'application/json; charset=utf-8'), ('x-ratelimit-reset', '1524105758')]
+{"names":["testing","github"]}
+

--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -90,7 +90,6 @@ class Repository(Framework.TestCase):
         self.assertEqual(self.repo.source, None)
         self.assertEqual(self.repo.ssh_url, "git@github.com:jacquev6/PyGithub.git")
         self.assertEqual(self.repo.svn_url, "https://github.com/jacquev6/PyGithub")
-        self.assertEqual(self.repo.topics, None)
         self.assertEqual(self.repo.updated_at, datetime.datetime(2012, 5, 27, 6, 55, 28))
         self.assertEqual(self.repo.url, "https://api.github.com/repos/jacquev6/PyGithub")
         self.assertEqual(self.repo.watchers, 15)
@@ -654,6 +653,11 @@ class Repository(Framework.TestCase):
 
     def testGetLicense(self):
         self.assertEqual(len(self.repo.get_license().content), 47646)
+
+    def testTopicsAttribute(self):
+        topic_list = self.repo.topics
+        topic = u'github'
+        self.assertIn(topic, topic_list)
 
     def testGetTopics(self):
         topic_list = self.repo.get_topics()


### PR DESCRIPTION
It resolves #1208. Fixing it is not as easy as it looks like. Currently PyGithub tries to use a common way to request GitHub v3 API. 

https://github.com/PyGithub/PyGithub/blob/74cd6856de404dc3109360860b712d62458c24eb/github/Repository.py#L725-L739

Due to GitHub preview handling, each individual preview has its own MIME type(the `Accept` header) to enable it. I'm not sure it's good to use some MIME type by default. If I put the `mercy-preview` in default `Accept` header, there will be 33 fail tests. And if GitHub adds some new preview, we need to change the ReplayData again.

If any good idea, please tell me, I will change.