### PR TITLE
Add an IncompletableObject exception

### DIFF
--- a/github/GithubException.py
+++ b/github/GithubException.py
@@ -123,3 +123,9 @@ class TwoFactorException(GithubException):
     """
     Exception raised when Github requires a onetime password for two-factor authentication
     """
+
+
+class IncompletableObject(GithubException):
+    """
+    Exception raised when we can not request an object from Github because the data returned did not include a URL
+    """

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -266,6 +266,8 @@ class CompletableGithubObject(GithubObject):
             self.__complete()
 
     def __complete(self):
+        if self._url.value is None:
+            raise GithubException.IncompletableObject(400, "Returned object contains no URL")
         headers, data = self._requester.requestJsonAndCheck(
             "GET",
             self._url.value

--- a/tests/Exceptions.py
+++ b/tests/Exceptions.py
@@ -33,6 +33,7 @@
 
 from __future__ import absolute_import
 import github
+from github.GithubException import IncompletableObject
 import pickle
 
 from . import Framework
@@ -122,3 +123,8 @@ class SpecificExceptions(Framework.TestCase):
                 res.get_page(0)
 
         self.assertRaises(github.RateLimitExceededException, exceed)
+
+    def testIncompletableObject(self):
+        github.UserKey.UserKey.setCheckAfterInitFlag(False)
+        obj = github.UserKey.UserKey(None, {}, {}, False)
+        self.assertRaises(IncompletableObject, obj._completeIfNeeded)


### PR DESCRIPTION
If a returned object from GitHub does not include an URL, that object
can not be completed, and used to fail with an obscure traceback saying
NoneType has no method startswith. Check for this, and raise
IncompletableObject instead.