### PR TITLE
Cleanup try/except import in PaginatedList

### DIFF
--- a/github/PaginatedList.py
+++ b/github/PaginatedList.py
@@ -39,10 +39,7 @@ import six
 #                                                                              #
 ################################################################################
 
-try:
-    from urllib.parse import parse_qs
-except ImportError:
-    from six.moves.urllib.parse import parse_qs
+from six.moves.urllib.parse import parse_qs
 
 
 class PaginatedListBase:


### PR DESCRIPTION
Since we're using six.moves to import parse_qs, we don't need to check
for an import exception, we can just import it directly.