### PR TITLE
Support non-default URLs in GithubIntegration

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -790,7 +790,7 @@ class GithubIntegration(object):
         }
 
         response = requests.get(
-            "{}/repos/{}/{}/installation".format(DEFAULT_BASE_URL, owner, repo),
+            "{}/repos/{}/{}/installation".format(self.base_url, owner, repo),
             headers=headers
         )
         response_dict = response.json()


### PR DESCRIPTION
The get_installation() method of GithubIntegration was hardcoded to
always use the default URL of api.github.com, making it impossible to
fetch the installation of an GitHub Enterprise installation.