### PR TITLE
Add six to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,8 @@ if __name__ == "__main__":
         install_requires=[
             "deprecated",
             "pyjwt",
-            "requests>=2.14.0"
+            "requests>=2.14.0",
+            "six"
         ],
         extras_require={
             "integrations": ["cryptography"]


### PR DESCRIPTION
dc2f2ad8 introduced a dependancy on six, and added it to requirements,
but not to setup.py, add it.