### PR TITLE
Add support for team discussions (#1246)

### DIFF
--- a/github/Consts.py
+++ b/github/Consts.py
@@ -88,6 +88,9 @@ mediaTypeLockReasonPreview = "application/vnd.github.sailor-v-preview+json"
 # https://developer.github.com/changes/2018-01-25-organization-invitation-api-preview/
 mediaTypeOrganizationInvitationPreview = "application/vnd.github.dazzler-preview+json"
 
+# https://developer.github.com/changes/2018-02-07-team-discussions-api
+mediaTypeTeamDiscussionsPreview = "application/vnd.github.echo-preview+json"
+
 # https://developer.github.com/changes/2018-03-16-protected-branches-required-approving-reviews/
 mediaTypeRequireMultipleApprovingReviews = "application/vnd.github.luke-cage-preview+json"
 

--- a/github/Team.py
+++ b/github/Team.py
@@ -48,6 +48,7 @@ import github.PaginatedList
 import github.Repository
 import github.NamedUser
 import github.Organization
+import github.TeamDiscussion
 
 from . import Consts
 import six
@@ -264,6 +265,21 @@ class Team(github.GithubObject.CompletableGithubObject):
             input=post_parameters
         )
         self._useAttributes(data)
+
+    def get_discussions(self):
+        """
+        :calls: `GET /teams/:id/discussions <https://developer.github.com/v3/teams/discussions/#list-discussions>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.TeamDiscussion.TeamDiscussion`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.TeamDiscussion.TeamDiscussion,
+            self._requester,
+            self.url + "/discussions",
+            None,
+            headers={
+                "Accept": Consts.mediaTypeTeamDiscussionsPreview
+            }
+        )
 
     def get_members(self, role=github.GithubObject.NotSet):
         """

--- a/github/TeamDiscussion.py
+++ b/github/TeamDiscussion.py
@@ -1,0 +1,211 @@
+# -*- coding: utf-8 -*-
+
+############################ Copyrights and license ############################
+#                                                                              #
+# Copyright 2019 Adam Baratz <adam.baratz@gmail.com>                           #
+#                                                                              #
+# This file is part of PyGithub.                                               #
+# http://pygithub.readthedocs.io/                                              #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+################################################################################
+
+from __future__ import absolute_import
+
+import github.GithubObject
+import github.NamedUser
+
+
+class TeamDiscussion(github.GithubObject.NonCompletableGithubObject):
+    """
+    This class represents TeamDiscussions. The reference can be found here https://developer.github.com/v3/teams/discussions/
+    """
+
+    def __repr__(self):
+        return self.get__repr__({"number": self._number.value, "title": self._title.value})
+
+    @property
+    def author(self):
+        """
+        :type: :class:`github.NamedUser.NamedUser`
+        """
+        return self._author.value
+
+    @property
+    def body(self):
+        """
+        :type: string
+        """
+        return self._body.value
+
+    @property
+    def body_html(self):
+        """
+        :type: string
+        """
+        return self._body_html.value
+
+    @property
+    def body_version(self):
+        """
+        :type: string
+        """
+        return self._body_version.value
+
+    @property
+    def comments_count(self):
+        """
+        :type: integer
+        """
+        return self._comments_count.value
+
+    @property
+    def comments_url(self):
+        """
+        :type: string
+        """
+        return self._comments_url.value
+
+    @property
+    def created_at(self):
+        """
+        :type: datetime.datetime
+        """
+        return self._created_at.value
+
+    @property
+    def html_url(self):
+        """
+        :type: string
+        """
+        return self._html_url.value
+
+    @property
+    def last_edited_at(self):
+        """
+        :type: datetime.datetime
+        """
+        return self._last_edited_at.value
+
+    @property
+    def node_id(self):
+        """
+        :type: string
+        """
+        return self._node_id.value
+
+    @property
+    def number(self):
+        """
+        :type: integer
+        """
+        return self._number.value
+
+    @property
+    def pinned(self):
+        """
+        :type: bool
+        """
+        return self._pinned.value
+
+    @property
+    def private(self):
+        """
+        :type: bool
+        """
+        return self._private.value
+
+    @property
+    def team_url(self):
+        """
+        :type: string
+        """
+        return self._team_url.value
+
+    @property
+    def title(self):
+        """
+        :type: string
+        """
+        return self._title.value
+
+    @property
+    def updated_at(self):
+        """
+        :type: datetime.datetime
+        """
+        return self._updated_at.value
+
+    @property
+    def url(self):
+        """
+        :type: string
+        """
+        return self._url.value
+
+    def _initAttributes(self):
+        self._author = github.GithubObject.NotSet
+        self._body = github.GithubObject.NotSet
+        self._body_html = github.GithubObject.NotSet
+        self._body_version = github.GithubObject.NotSet
+        self._comments_count = github.GithubObject.NotSet
+        self._comments_url = github.GithubObject.NotSet
+        self._created_at = github.GithubObject.NotSet
+        self._html_url = github.GithubObject.NotSet
+        self._last_edited_at = github.GithubObject.NotSet
+        self._node_id = github.GithubObject.NotSet
+        self._number = github.GithubObject.NotSet
+        self._pinned = github.GithubObject.NotSet
+        self._private = github.GithubObject.NotSet
+        self._team_url = github.GithubObject.NotSet
+        self._title = github.GithubObject.NotSet
+        self._updated_at = github.GithubObject.NotSet
+        self._url = github.GithubObject.NotSet
+
+    def _useAttributes(self, attributes):
+        if "author" in attributes:  # pragma no branch
+            self._author = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["author"])
+        if "body" in attributes:  # pragma no branch
+            self._body = self._makeStringAttribute(attributes["body"])
+        if "body_html" in attributes:  # pragma no branch
+            self._body_html = self._makeStringAttribute(attributes["body_html"])
+        if "body_version" in attributes:  # pragma no branch
+            self._body_version = self._makeStringAttribute(attributes["body_version"])
+        if "comments_count" in attributes:  # pragma no branch
+            self._comments_count = self._makeIntAttribute(attributes["comments_count"])
+        if "comments_url" in attributes:  # pragma no branch
+            self._comments_url = self._makeStringAttribute(attributes["comments_url"])
+        if "created_at" in attributes:  # pragma no branch
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
+        if "html_url" in attributes:  # pragma no branch
+            self._html_url = self._makeStringAttribute(attributes["html_url"])
+        if "last_edited_at" in attributes:  # pragma no branch
+            self._last_edited_at = self._makeDatetimeAttribute(attributes["last_edited_at"])
+        if "node_id" in attributes:  # pragma no branch
+            self._node_id = self._makeStringAttribute(attributes["node_id"])
+        if "number" in attributes:  # pragma no branch
+            self._number = self._makeIntAttribute(attributes["number"])
+        if "pinned" in attributes:  # pragma no branch
+            self._pinned = self._makeBoolAttribute(attributes["pinned"])
+        if "private" in attributes:  # pragma no branch
+            self._private = self._makeBoolAttribute(attributes["private"])
+        if "team_url" in attributes:  # pragma no branch
+            self._team_url = self._makeStringAttribute(attributes["team_url"])
+        if "title" in attributes:
+            self._title = self._makeStringAttribute(attributes["title"])
+        if "updated_at" in attributes:  # pragma no branch
+            self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/TeamDiscussion.py
+++ b/github/TeamDiscussion.py
@@ -28,7 +28,7 @@ import github.GithubObject
 import github.NamedUser
 
 
-class TeamDiscussion(github.GithubObject.NonCompletableGithubObject):
+class TeamDiscussion(github.GithubObject.CompletableGithubObject):
     """
     This class represents TeamDiscussions. The reference can be found here https://developer.github.com/v3/teams/discussions/
     """
@@ -41,6 +41,7 @@ class TeamDiscussion(github.GithubObject.NonCompletableGithubObject):
         """
         :type: :class:`github.NamedUser.NamedUser`
         """
+        self._completeIfNotSet(self._author)
         return self._author.value
 
     @property
@@ -48,6 +49,7 @@ class TeamDiscussion(github.GithubObject.NonCompletableGithubObject):
         """
         :type: string
         """
+        self._completeIfNotSet(self._body)
         return self._body.value
 
     @property
@@ -55,6 +57,7 @@ class TeamDiscussion(github.GithubObject.NonCompletableGithubObject):
         """
         :type: string
         """
+        self._completeIfNotSet(self._body_html)
         return self._body_html.value
 
     @property
@@ -62,6 +65,7 @@ class TeamDiscussion(github.GithubObject.NonCompletableGithubObject):
         """
         :type: string
         """
+        self._completeIfNotSet(self._body_version)
         return self._body_version.value
 
     @property
@@ -69,6 +73,7 @@ class TeamDiscussion(github.GithubObject.NonCompletableGithubObject):
         """
         :type: integer
         """
+        self._completeIfNotSet(self._comments_count)
         return self._comments_count.value
 
     @property
@@ -76,6 +81,7 @@ class TeamDiscussion(github.GithubObject.NonCompletableGithubObject):
         """
         :type: string
         """
+        self._completeIfNotSet(self._comments_url)
         return self._comments_url.value
 
     @property
@@ -83,6 +89,7 @@ class TeamDiscussion(github.GithubObject.NonCompletableGithubObject):
         """
         :type: datetime.datetime
         """
+        self._completeIfNotSet(self._created_at)
         return self._created_at.value
 
     @property
@@ -90,6 +97,7 @@ class TeamDiscussion(github.GithubObject.NonCompletableGithubObject):
         """
         :type: string
         """
+        self._completeIfNotSet(self._html_url)
         return self._html_url.value
 
     @property
@@ -97,6 +105,7 @@ class TeamDiscussion(github.GithubObject.NonCompletableGithubObject):
         """
         :type: datetime.datetime
         """
+        self._completeIfNotSet(self._last_edited_at)
         return self._last_edited_at.value
 
     @property
@@ -104,6 +113,7 @@ class TeamDiscussion(github.GithubObject.NonCompletableGithubObject):
         """
         :type: string
         """
+        self._completeIfNotSet(self._node_id)
         return self._node_id.value
 
     @property
@@ -111,6 +121,7 @@ class TeamDiscussion(github.GithubObject.NonCompletableGithubObject):
         """
         :type: integer
         """
+        self._completeIfNotSet(self._number)
         return self._number.value
 
     @property
@@ -118,6 +129,7 @@ class TeamDiscussion(github.GithubObject.NonCompletableGithubObject):
         """
         :type: bool
         """
+        self._completeIfNotSet(self._pinned)
         return self._pinned.value
 
     @property
@@ -125,6 +137,7 @@ class TeamDiscussion(github.GithubObject.NonCompletableGithubObject):
         """
         :type: bool
         """
+        self._completeIfNotSet(self._private)
         return self._private.value
 
     @property
@@ -132,6 +145,7 @@ class TeamDiscussion(github.GithubObject.NonCompletableGithubObject):
         """
         :type: string
         """
+        self._completeIfNotSet(self._team_url)
         return self._team_url.value
 
     @property
@@ -139,6 +153,7 @@ class TeamDiscussion(github.GithubObject.NonCompletableGithubObject):
         """
         :type: string
         """
+        self._completeIfNotSet(self._title)
         return self._title.value
 
     @property
@@ -146,6 +161,7 @@ class TeamDiscussion(github.GithubObject.NonCompletableGithubObject):
         """
         :type: datetime.datetime
         """
+        self._completeIfNotSet(self._updated_at)
         return self._updated_at.value
 
     @property
@@ -153,6 +169,7 @@ class TeamDiscussion(github.GithubObject.NonCompletableGithubObject):
         """
         :type: string
         """
+        self._completeIfNotSet(self._url)
         return self._url.value
 
     def _initAttributes(self):

--- a/tests/ReplayData/Team.testDiscussions.txt
+++ b/tests/ReplayData/Team.testDiscussions.txt
@@ -1,0 +1,11 @@
+https
+GET
+api.github.com
+None
+/teams/189850/discussions
+{'Accept': 'application/vnd.github.echo-preview+json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+None
+200
+[('status', '200 OK'), ('x-ratelimit-remaining', '4974'), ('content-length', '1595'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"03555a65309084f36bcf959063a39d35"'), ('date', 'Sat, 26 May 2012 21:09:52 GMT'), ('content-type', 'application/json; charset=utf-8')]
+[{"author":{"login":"jacquev6","id":327146,"node_id":"MDQ6VXNlcjMyNzE0Ng==","avatar_url":"https://secure.gravatar.com/avatar/b68de5ae38616c296fa345d2b9df2225?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-140.png","gravatar_id":"b68de5ae38616c296fa345d2b9df2225","url":"https://api.github.com/users/jacquev6","html_url":"https://github.com/jacquev6","followers_url":"https://api.github.com/users/jacquev6/followers","following_url":"https://api.github.com/users/jacquev6/following{/other_user}","gists_url":"https://api.github.com/users/jacquev6/gists{/gist_id}","starred_url":"https://api.github.com/users/jacquev6/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jacquev6/subscriptions","organizations_url":"https://api.github.com/users/jacquev6/orgs","repos_url":"https://api.github.com/users/jacquev6/repos","events_url":"https://api.github.com/users/jacquev6/events{/privacy}","received_events_url":"https://api.github.com/users/jacquev6/received_events","type":"User"},"body":"BODY","body_html":"<p>BODY</p>","body_version":"bedf0740b01d2d758cff9873c2387817","comments_count":0,"comments_url":"https://api.github.com/teams/189850/discussions/1/comments","created_at":"2019-10-08T21:03:36Z","last_edited_at":null,"html_url":"https://github.com/orgs/BeaverSoftware/teams/Team/discussions/1","node_id":"MDE0OlRlYW1EaXNjdXNzaW9uMzA=","number":1,"pinned":true,"private":false,"team_url":"https://api.github.com/teams/189850","title":"TITLE","updated_at":"2019-10-08T21:03:36Z","url":"https://api.github.com/teams/189850/discussions/1"}]
+

--- a/tests/Team.py
+++ b/tests/Team.py
@@ -35,6 +35,9 @@
 ################################################################################
 
 from __future__ import absolute_import
+
+from datetime import datetime
+
 from . import Framework
 
 
@@ -56,6 +59,29 @@ class Team(Framework.TestCase):
 
         # test __repr__() based on this attributes
         self.assertEqual(self.team.__repr__(), 'Team(name="Team created by PyGithub", id=189850)')
+
+    def testDiscussions(self):
+        discussions = list(self.team.get_discussions())
+        self.assertEqual(len(discussions), 1)
+
+        d = discussions[0]
+        self.assertEqual(d.author.login, "jacquev6")
+        self.assertEqual(d.body, "BODY")
+        self.assertEqual(d.body_html, "<p>BODY</p>")
+        self.assertEqual(d.body_version, "bedf0740b01d2d758cff9873c2387817")
+        self.assertEqual(d.comments_count, 0)
+        self.assertEqual(d.comments_url, "https://api.github.com/teams/189850/discussions/1/comments")
+        self.assertEqual(d.created_at, datetime(2019, 10, 8, 21, 3, 36))
+        self.assertEqual(d.html_url, "https://github.com/orgs/BeaverSoftware/teams/Team/discussions/1")
+        self.assertEqual(d.last_edited_at, None)
+        self.assertEqual(d.node_id, "MDE0OlRlYW1EaXNjdXNzaW9uMzA=")
+        self.assertEqual(d.number, 1)
+        self.assertEqual(d.pinned, True)
+        self.assertEqual(d.private, False)
+        self.assertEqual(d.team_url, "https://api.github.com/teams/189850")
+        self.assertEqual(d.title, "TITLE")
+        self.assertEqual(d.updated_at, datetime(2019, 10, 8, 21, 3, 36))
+        self.assertEqual(d.url, "https://api.github.com/teams/189850/discussions/1")
 
     def testMembers(self):
         user = self.g.get_user("jacquev6")


### PR DESCRIPTION
This patch adds support for a feature in preview. This seemed reasonable since a number of other similar features have been added. I tested by writing a unit test with mock data that replicates the format of a real response. I also tested on a GitHub Enterprise instance and was able to access expected data.

I omitted implementing the ability to get a single comment, as well as create, edit, and delete. I'm happy to go back and do this, but I wanted to get feedback on what I've done so far since this is my first PR.

I omitted another feature, a preview feature inside the preview feature: reactions to discussions. The schema is totally different to the existing `github.Reaction.Reaction` class (and, IMO, kind of peculiar in comparison). I'd prefer deferring on this particular feature.