### PR TITLE
Handle unicode strings when recording responses (#1253)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,8 @@ if __name__ == "__main__":
         },
         tests_require=[
             "cryptography",
-            "httpretty==0.9.6"
+            "httpretty==0.9.6",
+            "mock==3.0.5",
+            "parameterized==0.7.0",
         ]
     )

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,22 @@
 #                                                                              #
 ################################################################################
 
-import setuptools
+import sys
 import textwrap
 
+import setuptools
+
+
 version = "1.43.8"
+
+tests_require=[
+    "cryptography",
+    "httpretty==0.9.6",
+    "parameterized==0.7.0",
+]
+
+if sys.version_info < (3, 3):
+    tests_require.append("mock==3.0.5")
 
 
 if __name__ == "__main__":
@@ -108,10 +120,5 @@ if __name__ == "__main__":
         extras_require={
             "integrations": ["cryptography"]
         },
-        tests_require=[
-            "cryptography",
-            "httpretty==0.9.6",
-            "mock==3.0.5",
-            "parameterized==0.7.0",
-        ]
+        tests_require=tests_require
     )

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ import setuptools
 
 version = "1.43.8"
 
-tests_require=[
+tests_require = [
     "cryptography",
     "httpretty==0.9.6",
     "parameterized==0.7.0",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,4 @@
 cryptography
 httpretty==0.9.6
+mock==3.0.5; python_version < '3.3'
+parameterized==0.7.0

--- a/tests/AllTests.py
+++ b/tests/AllTests.py
@@ -107,6 +107,8 @@ from .Equality import *
 from .Search import *
 from .Retry import *
 
+from .Connection import *
+
 from .Issue33 import *
 from .Issue50 import *
 from .Issue54 import *

--- a/tests/Connection.py
+++ b/tests/Connection.py
@@ -88,31 +88,27 @@ class Connection(unittest.TestCase):
         connection.getresponse.return_value = response
 
         # write mock response to buffer
-
         recording_connection = RecordingMockConnection(file, protocol, host, None, lambda *args, **kwds: connection)
         recording_connection.request(verb, url, None, headers)
         recording_connection.getresponse()
         recording_connection.close()
 
+        # validate contents of buffer
         file_value_lines = file.getvalue().split("\n")
         expected_recording_lines = (protocol + expected_recording).split("\n")
         self.assertEquals(file_value_lines[:5], expected_recording_lines[:5])
         self.assertEquals(eval(file_value_lines[5]), eval(expected_recording_lines[5]))  # dict literal, so keys not in guaranteed order
         self.assertEquals(file_value_lines[6:], expected_recording_lines[6:])
 
-        # rewind buffer and attempt to read from it
-
-        # mirror Framework.BasicTestCase without the wiring for an actual replay test
+        # required for replay to work as expected
         httpretty.enable(allow_net_connect=False)
 
+        # rewind buffer and attempt to replay response from it
         file.seek(0)
-
         replaying_connection = replaying_connection_class(self, file, host=host, port=None)
         replaying_connection.request(verb, url, None, headers)
         replaying_connection.getresponse()
 
-    def tearDown(self):
-        # mirror Framework.BasicTestCase without the wiring for an actual replay test
-        unittest.TestCase.tearDown(self)
+        # not necessarily required for subsequent tests
         httpretty.disable()
         httpretty.reset()

--- a/tests/Connection.py
+++ b/tests/Connection.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+
+############################ Copyrights and license ############################
+#                                                                              #
+# Copyright 2019 Adam Baratz <adam.baratz@gmail.com>                           #
+#                                                                              #
+# This file is part of PyGithub.                                               #
+# http://pygithub.readthedocs.io/                                              #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+################################################################################
+
+from __future__ import absolute_import
+
+import itertools
+import unittest
+from io import StringIO
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
+
+import httpretty
+from parameterized import parameterized
+
+from . import Framework
+
+
+PARAMETERS = itertools.product(
+    [
+        (Framework.ReplayingHttpConnection, "http"),
+        (Framework.ReplayingHttpsConnection, "https"),
+    ],
+    [
+        (
+            "{\"body\":\"BODY TEXT\"}",
+            '\nGET\napi.github.com\nNone\n/user\n{\'Authorization\': \'Basic login_and_password_removed\', \'User-Agent\': \'PyGithub/Python\'}\nNone\n200\n[]\n{"body":"BODY TEXT"}\n\n',
+        ),
+        (
+            u"{\"body\":\"BODY\xa0TEXT\"}",
+            u'\nGET\napi.github.com\nNone\n/user\n{\'Authorization\': \'Basic login_and_password_removed\', \'User-Agent\': \'PyGithub/Python\'}\nNone\n200\n[]\n{"body":"BODY\xa0TEXT"}\n\n',
+        ),
+        (
+            "BODY TEXT",
+            '\nGET\napi.github.com\nNone\n/user\n{\'Authorization\': \'Basic login_and_password_removed\', \'User-Agent\': \'PyGithub/Python\'}\nNone\n200\n[]\nBODY TEXT\n\n',
+        ),
+        (
+            u"BODY\xa0TEXT",
+            u'\nGET\napi.github.com\nNone\n/user\n{\'Authorization\': \'Basic login_and_password_removed\', \'User-Agent\': \'PyGithub/Python\'}\nNone\n200\n[]\nBODY\xa0TEXT\n\n',
+        ),
+    ],
+)
+
+
+class RecordingMockConnection(Framework.RecordingConnection):
+    def __init__(self, file, protocol, host, port, realConnection):
+        self._realConnection = realConnection
+        Framework.RecordingConnection.__init__(self, file, protocol, host, port)
+
+
+class Connection(unittest.TestCase):
+    @parameterized.expand(itertools.chain(*p) for p in PARAMETERS)
+    def testRecordAndReplay(self, replaying_connection_class, protocol, response_body, expected_recording):
+        file = StringIO()
+        host = "api.github.com"
+        verb = "GET"
+        url = "/user"
+        headers = {'Authorization': 'Basic p4ssw0rd', 'User-Agent': 'PyGithub/Python'}
+
+        response = Mock()
+        response.status = 200
+        response.getheaders.return_value = {}
+        response.read.return_value = response_body
+
+        connection = Mock()
+        connection.getresponse.return_value = response
+
+        # write mock response to buffer
+
+        recording_connection = RecordingMockConnection(file, protocol, host, None, lambda *args, **kwds: connection)
+        recording_connection.request(verb, url, None, headers)
+        recording_connection.getresponse()
+        recording_connection.close()
+
+        self.assertEquals(file.getvalue(), protocol + expected_recording)
+
+        # rewind buffer and attempt to read from it
+
+        # mirror Framework.BasicTestCase without the wiring for an actual replay test
+        httpretty.enable(allow_net_connect=False)
+
+        file.seek(0)
+
+        replaying_connection = replaying_connection_class(self, file, host=host, port=None)
+        replaying_connection.request(verb, url, None, headers)
+        replaying_connection.getresponse()
+
+    def tearDown(self):
+        # mirror Framework.BasicTestCase without the wiring for an actual replay test
+        unittest.TestCase.tearDown(self)
+        httpretty.disable()
+        httpretty.reset()

--- a/tests/Connection.py
+++ b/tests/Connection.py
@@ -94,7 +94,11 @@ class Connection(unittest.TestCase):
         recording_connection.getresponse()
         recording_connection.close()
 
-        self.assertEquals(file.getvalue(), protocol + expected_recording)
+        file_value_lines = file.getvalue().split("\n")
+        expected_recording_lines = (protocol + expected_recording).split("\n")
+        self.assertEquals(file_value_lines[:5], expected_recording_lines[:5])
+        self.assertEquals(eval(file_value_lines[5]), eval(expected_recording_lines[5]))  # dict literal, so keys not in guaranteed order
+        self.assertEquals(file_value_lines[6:], expected_recording_lines[6:])
 
         # rewind buffer and attempt to read from it
 


### PR DESCRIPTION
The string handled had some muddled assumptions about binary vs. string vs. unicode data. I updated to assume unicode at all times and added test coverage. I also tried running a test with the `--record` function to validate in practice.