### PR TITLE
Bump httpretty to be a greater or equal to

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,6 @@ if __name__ == "__main__":
         },
         tests_require=[
             "cryptography",
-            "httpretty==0.9.6"
+            "httpretty>=0.9.6"
         ]
     )


### PR DESCRIPTION
Some distributions do not include httpretty 0.9.6 as is required by
setup.py. Set it to >= rather than ==.