### PR TITLE
Encode content for {create,update}_file

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1645,9 +1645,9 @@ class Repository(github.GithubObject.CompletableGithubObject):
             or isinstance(committer, github.InputGitAuthor),       \
             'committer must be a github.InputGitAuthor object'
 
-        content = b64encode(bytearray(content, 'utf-8'))
-        if isinstance(content, bytes):
-            content = content.decode('utf-8')
+        if not isinstance(content, bytes):
+            content = content.encode('utf-8')
+        content = b64encode(content).decode('utf-8')
         put_parameters = {'message': message, 'content': content}
 
         if branch is not github.GithubObject.NotSet:
@@ -1702,9 +1702,9 @@ class Repository(github.GithubObject.CompletableGithubObject):
             or isinstance(committer, github.InputGitAuthor),       \
             'committer must be a github.InputGitAuthor object'
 
-        content = b64encode(bytearray(content, 'utf-8'))
-        if isinstance(content, bytes):
-            content = content.decode('utf-8')
+        if not isinstance(content, bytes):
+            content = content.encode('utf-8')
+        content = b64encode(content).decode('utf-8')
 
         put_parameters = {'message': message, 'content': content,
                           'sha': sha}

--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -548,7 +548,7 @@ class Repository(Framework.TestCase):
 
     def testCreateFile(self):
         newFile = 'doc/testCreateUpdateDeleteFile.md'
-        content = 'Hello world'
+        content = 'Hello world'.encode()
         self.repo.create_file(
             path=newFile, message='Create file for testCreateFile', content=content,
             branch="master", committer=github.InputGitAuthor("Enix Yu", "enix223@163.com", "2016-01-15T16:13:30+12:00"),


### PR DESCRIPTION
If a byte object (for Python 3) was passed into either create_file or
update_file, it was attempted to be co-erced into a bytearray, which
failed. Check for encoded content before we encode it into bytes and
then base64 encode it.

Fixes #1266