### PR TITLE
Check if the version is empty in manage.sh

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -33,6 +33,10 @@ function bump {
     previousVersion=$( grep '^version =' setup.py | sed 's/version = \"\(.*\)\"/\1/' )
     echo "Next version number? (previous: '$previousVersion')"
     read version
+    if [ -z "$version" ]; then
+        echo "empty version string"
+        exit 1
+    fi
     sed -i -b "s/version = .*/version = \"$version\"/" setup.py
 }
 


### PR DESCRIPTION
If someone accidentally hits Enter when prompted for the new version, the
script merrily creates a tag called 'v', which is bothersome to tidy up.
Check if the variable is empty and error if it is.