### PR TITLE
Add Python 3.8 to classifiers list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
   include:
     - python: "3.7"
       dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+    - python: "3.8"
+      dist: xenial
 install:
   - pip install codecov flake8
 script:

--- a/setup.py
+++ b/setup.py
@@ -106,10 +106,10 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
             "Topic :: Software Development",
         ],
         test_suite="tests.AllTests",
-        use_2to3=True,
         python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
         install_requires=[
             "deprecated",


### PR DESCRIPTION
Add 3.8 to the classifiers list, drop the use of 2to3, and run tests
against 3.8.