### PR TITLE
Correct URL for assignees on PRs

### DIFF
--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -804,7 +804,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
         post_parameters = {"assignees": [assignee.login if isinstance(assignee, github.NamedUser.NamedUser) else assignee for assignee in assignees]}
         headers, data = self._requester.requestJsonAndCheck(
             "POST",
-            self.url + "/assignees",
+            self.issue_url + "/assignees",
             input=post_parameters
         )
         self._useAttributes(data)
@@ -819,7 +819,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
         post_parameters = {"assignees": [assignee.login if isinstance(assignee, github.NamedUser.NamedUser) else assignee for assignee in assignees]}
         headers, data = self._requester.requestJsonAndCheck(
             "DELETE",
-            self.url + "/assignees",
+            self.issue_url + "/assignees",
             input=post_parameters
         )
         self._useAttributes(data)

--- a/tests/ReplayData/PullRequest.testAddAndRemoveAssignees.txt
+++ b/tests/ReplayData/PullRequest.testAddAndRemoveAssignees.txt
@@ -13,7 +13,7 @@ https
 POST
 api.github.com
 None
-/repos/jacquev6/PyGithub/pulls/31/assignees
+/repos/jacquev6/PyGithub/issues/31/assignees
 {'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 {"assignees":["jayfk","jzelinskie"]}
 201
@@ -24,7 +24,7 @@ https
 DELETE
 api.github.com
 None
-/repos/jacquev6/PyGithub/pulls/31/assignees
+/repos/jacquev6/PyGithub/issues/31/assignees
 {'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 {"assignees":["jayfk","jzelinskie"]}
 200


### PR DESCRIPTION
The URL that was used for POST/DELETE when adding and removing
assignees was the PR itself, when it should be the issue_url.

Fixes #1294