### PR TITLE
Allow GithubObject.update() to be passed headers

### DIFF
--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -279,7 +279,7 @@ class CompletableGithubObject(GithubObject):
         self._storeAndUseAttributes(headers, data)
         self.__completed = True
 
-    def update(self):
+    def update(self, additional_headers=None):
         '''
         Check and update the object with conditional request
         :rtype: Boolean value indicating whether the object is changed
@@ -289,6 +289,8 @@ class CompletableGithubObject(GithubObject):
             conditionalRequestHeader[Consts.REQ_IF_NONE_MATCH] = self.etag
         if self.last_modified is not None:
             conditionalRequestHeader[Consts.REQ_IF_MODIFIED_SINCE] = self.last_modified
+        if additional_headers is not None:
+            conditionalRequestHeader.update(additional_headers)
 
         status, responseHeaders, output = self._requester.requestJson(
             "GET",

--- a/github/SourceImport.py
+++ b/github/SourceImport.py
@@ -23,6 +23,7 @@
 ################################################################################
 
 from __future__ import absolute_import
+from github import Consts
 import github.GithubObject
 
 
@@ -142,6 +143,10 @@ class SourceImport(github.GithubObject.CompletableGithubObject):
         """
         self._completeIfNotSet(self._vcs_url)
         return self._vcs_url.value
+
+    def update(self):
+        import_header = {"Accept": Consts.mediaTypeImportPreview}
+        return super(SourceImport, self).update(additional_headers=import_header)
 
     def _initAttributes(self):
         self._authors_count = github.GithubObject.NotSet

--- a/tests/ReplayData/SourceImport.testUpdate.txt
+++ b/tests/ReplayData/SourceImport.testUpdate.txt
@@ -1,0 +1,10 @@
+https
+GET
+api.github.com
+None
+/repos/brix4dayz/source-import-test/import
+{'Authorization': 'Basic login_and_password_removed', 'Accept': 'application/vnd.github.barred-rock-preview', 'User-Agent': 'PyGithub/Python', 'If-None-Match': '"8659af05bfc77665551bec8f8a6bb2ce"'}
+None
+200
+[('content-length', '533'), ('x-runtime-rack', '0.137115'), ('vary', 'Accept, Authorization, Cookie, X-GitHub-OTP'), ('x-oauth-scopes', 'repo'), ('x-xss-protection', '1; mode=block'), ('x-content-type-options', 'nosniff'), ('x-accepted-oauth-scopes', ''), ('etag', '"8659af05bfc77665551bec8f8a6bb2ce"'), ('cache-control', 'private, max-age=60, s-maxage=60'), ('status', '200 OK'), ('x-ratelimit-remaining', '4987'), ('x-github-media-type', 'github.barred-rock-preview'), ('access-control-expose-headers', 'ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval'), ('x-github-request-id', 'D34D:2057:22D5E83:4403573:5A374787'), ('date', 'Mon, 18 Dec 2017 04:43:51 GMT'), ('access-control-allow-origin', '*'), ('content-security-policy', "default-src 'none'"), ('strict-transport-security', 'max-age=31536000; includeSubdomains; preload'), ('server', 'GitHub.com'), ('x-ratelimit-limit', '5000'), ('x-frame-options', 'deny'), ('content-type', 'application/json; charset=utf-8'), ('x-ratelimit-reset', '1513572653')]
+{"vcs":"mercurial","use_lfs":"undecided","vcs_url":"https://bitbucket.org/hfuss/source-import-test","status":"complete","status_text":"Done","has_large_files":false,"large_files_size":0,"large_files_count":0,"authors_count":1,"url":"https://api.github.com/repos/brix4dayz/source-import-test/import","html_url":"https://github.com/brix4dayz/source-import-test/import","authors_url":"https://api.github.com/repos/brix4dayz/source-import-test/import/authors","repository_url":"https://api.github.com/repos/brix4dayz/source-import-test"}

--- a/tests/SourceImport.py
+++ b/tests/SourceImport.py
@@ -50,3 +50,9 @@ class SourceImport(Framework.TestCase):
 
         self.assertEqual(self.source_import.__repr__(),
                          'SourceImport(vcs_url="https://bitbucket.org/hfuss/source-import-test", url="https://api.github.com/repos/brix4dayz/source-import-test/import", status="complete", repository_url="https://api.github.com/repos/brix4dayz/source-import-test")')
+
+    def testUpdate(self):
+        # The real test is that update() method passes the header
+        update_ret = self.source_import.update()
+        self.assertTrue(update_ret)
+        self.assertEqual(self.source_import.status, "complete")


### PR DESCRIPTION
SourceImport.update() is really GithubObject.update(), which just calls
GET on the object's URL. Refetching a source import requires an
additional header, so change GithubObject.update() to pass any it is
given, and add a test for SourceImport.update()

Fixes #1297