### PR TITLE
Fix class used returning pull request comments

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -2317,7 +2317,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         if since is not github.GithubObject.NotSet:
             url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
         return github.PaginatedList.PaginatedList(
-            github.IssueComment.IssueComment,
+            github.PullRequestComment.PullRequestComment,
             self._requester,
             self.url + "/pulls/comments",
             url_parameters


### PR DESCRIPTION
When trying to pull in pull request comments I noticed that it was returning `IssueComment`s instead of `PullRequestComment`s so this just switched to use the proper type.