### PR TITLE
Cleanup travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,8 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
-matrix:
-  include:
-    - python: "3.7"
-      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
-    - python: "3.8"
-      dist: xenial
+  - "3.7"
+  - "3.8"
 install:
   - pip install codecov flake8
 script:
@@ -28,6 +24,6 @@ deploy:
     secure: eorsWtbj7JUBcy/Ovohg2yxyvyF4Sz9QNqtdPJhLSBzd1S01qoVLVAqsQhfZTxMlSOE4RCPOm+VodhV55oa1RboLah4DpDDW998J61QSo9im7Ch2GBkL3C6XqhWAFr6g4KqTG4h/6QTp5dF8vebXiMADmpshCMMpUxm3FccFY7k=
   on:
     tags: true
-    distributions: sdist bdist_wheel
+    distributions: "sdist bdist_wheel"
     repo: PyGithub/PyGithub
     python: "2.7"


### PR DESCRIPTION
Xenial has been the default distribution since May, 2019, so tidy up the
test matrix to no longer specify it. Furthermore, due to not quoting the
distributions in the deploy config, we did not ship wheels on pypi.

Fixes #1321