### PR TITLE
Update link to GitHub Enterprise in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ PyGitHub is a Python (2 and 3) library to access the [GitHub API v3] and [Github
 This library enables you to manage [GitHub] resources such as repositories, user profiles, and organizations in your Python applications.
 
 [GitHub API v3]: https://developer.github.com/v3
-[Github Enterprise API v3]: https://developer.github.com/enterprise/2.13/v3/
+[Github Enterprise API v3]: https://developer.github.com/enterprise/v3/
 [GitHub]: https://github.com
 
 ## Install


### PR DESCRIPTION
Update the link to GitHub Enterprise API v3 in README so that it always redirects to the up-to-date version