### PR TITLE
Remove API preview parameter

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -104,7 +104,6 @@ class Github(object):
         client_secret=None,
         user_agent="PyGithub/Python",
         per_page=DEFAULT_PER_PAGE,
-        api_preview=False,
         verify=True,
         retry=None,
     ):
@@ -137,7 +136,6 @@ class Github(object):
         assert user_agent is None or isinstance(
             user_agent, (str, six.text_type)
         ), user_agent
-        assert isinstance(api_preview, (bool))
         assert (
             retry is None
             or isinstance(retry, (int))
@@ -153,7 +151,6 @@ class Github(object):
             client_secret,
             user_agent,
             per_page,
-            api_preview,
             verify,
             retry,
         )

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -267,7 +267,6 @@ class Requester:
         client_secret,
         user_agent,
         per_page,
-        api_preview,
         verify,
         retry,
     ):
@@ -315,7 +314,6 @@ class Requester:
             "See http://developer.github.com/v3/#user-agent-required"
         )
         self.__userAgent = user_agent
-        self.__apiPreview = api_preview
         self.__verify = verify
 
     def requestJsonAndCheck(self, verb, url, parameters=None, headers=None, input=None):
@@ -463,8 +461,6 @@ class Requester:
 
         self.__authenticate(url, requestHeaders, parameters)
         requestHeaders["User-Agent"] = self.__userAgent
-        if self.__apiPreview:
-            requestHeaders["Accept"] = "application/vnd.github.moondragon+json"
 
         url = self.__makeAbsoluteUrl(url)
         url = self.__addParametersToUrl(url, parameters)


### PR DESCRIPTION
The API preview flag for both MainClass and Requester was the last
hard-coded custom header, and it seems to not be relevant since
mid-2015. Remove it, if any users are using it, they shouldn't be. Its
code path was also entirely untested.