### PR TITLE
Allow sha=None for InputGitTreeElement

### DIFF
--- a/github/InputGitTreeElement.py
+++ b/github/InputGitTreeElement.py
@@ -53,7 +53,7 @@ class InputGitTreeElement(object):
         :param mode: string
         :param type: string
         :param content: string
-        :param sha: string
+        :param sha: string or None
         """
 
         assert isinstance(path, (str, six.text_type)), path
@@ -62,8 +62,10 @@ class InputGitTreeElement(object):
         assert content is github.GithubObject.NotSet or isinstance(
             content, (str, six.text_type)
         ), content
-        assert sha is github.GithubObject.NotSet or isinstance(
-            sha, (str, six.text_type)
+        assert (
+            sha is github.GithubObject.NotSet
+            or sha is None
+            or isinstance(sha, (str, six.text_type))
         ), sha
         self.__path = path
         self.__mode = mode

--- a/tests/ReplayData/Repository.testCreateGitTreeWithNullSha.txt
+++ b/tests/ReplayData/Repository.testCreateGitTreeWithNullSha.txt
@@ -1,0 +1,10 @@
+https
+POST
+api.github.com
+None
+/repos/jacquev6/PyGithub/git/trees
+{'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+{"tree": [{"path": "Baz.bar", "type": "blob", "mode": "100644", "sha": null}]}
+201
+[('date', 'Fri, 27 Dec 2019 00:51:47 GMT'), ('content-type', 'application/json; charset=utf-8'), ('content-length', '401'), ('server', 'GitHub.com'), ('status', '201 Created'), ('x-ratelimit-limit', '5000'), ('x-ratelimit-remaining', '4996'), ('x-ratelimit-reset', '1577411349'), ('cache-control', 'private, max-age=60, s-maxage=60'), ('vary', 'Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding'), ('etag', '"92c715dcb38b27913fafb5f0b0033832"'), ('x-oauth-scopes', 'public_repo, repo:status'), ('x-accepted-oauth-scopes', ''), ('location', 'https://api.github.com/repos/jacquev6/PyGithub/git/trees/9b8166fc80d0f0fe9192d4bf1dbaa87f194e012f'), ('x-github-media-type', 'github.v3; format=json'), ('access-control-expose-headers', 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type'), ('access-control-allow-origin', '*'), ('strict-transport-security', 'max-age=31536000; includeSubdomains; preload'), ('x-frame-options', 'deny'), ('x-content-type-options', 'nosniff'), ('x-xss-protection', '1; mode=block'), ('referrer-policy', 'origin-when-cross-origin, strict-origin-when-cross-origin'), ('content-security-policy', "default-src 'none'"), ('x-github-request-id', 'CDCA:2D1A:67EE9D:75F15E:5E0555A3')]
+{"sha":"9b8166fc80d0f0fe9192d4bf1dbaa87f194e012f","url":"https://api.github.com/repos/jacquev6/PyGithub/git/trees/9b8166fc80d0f0fe9192d4bf1dbaa87f194e012f","tree":[{"path":"README.md","mode":"100644","type":"blob","sha":"54f3a4bf0a60f29d7c4798b590f92ffd56dd6d21","size":12,"url":"https://api.github.com/repos/jacquev6/PyGithub/git/blobs/54f3a4bf0a60f29d7c4798b590f92ffd56dd6d21"}],"truncated":false}

--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -283,6 +283,19 @@ class Repository(Framework.TestCase):
         )
         self.assertEqual(tree.sha, "fae707821159639589bf94f3fb0a7154ec5d441b")
 
+    def testCreateGitTreeWithNullSha(self):
+        tree = self.repo.create_git_tree(
+            [
+                github.InputGitTreeElement(
+                    "Baz.bar",
+                    "100644",
+                    "blob",
+                    sha=None,
+                )
+            ]
+        )
+        self.assertEqual(tree.sha, "9b8166fc80d0f0fe9192d4bf1dbaa87f194e012f")
+
     def testCreateGitCommit(self):
         tree = self.repo.get_git_tree("107139a922f33bab6fbeb9f9eb8787e7f19e0528")
         commit = self.repo.create_git_commit("Commit created by PyGithub", tree, [])


### PR DESCRIPTION
InputGitTreeElement is used to build tree objects for
Repository.create_git_tree(). However, the GitHub API allows passing
sha=null to delete a file, which we don't allow. Extend the checking in
InputGitTreeElement to also allow None, and add a test for good measure.

Fixes #1318