### PR TITLE
Fix PyPI wheel deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,11 @@ notifications:
 deploy:
   provider: pypi
   skip_existing: true
+  distributions: sdist bdist_wheel
   user: jacquev6
   password:
     secure: eorsWtbj7JUBcy/Ovohg2yxyvyF4Sz9QNqtdPJhLSBzd1S01qoVLVAqsQhfZTxMlSOE4RCPOm+VodhV55oa1RboLah4DpDDW998J61QSo9im7Ch2GBkL3C6XqhWAFr6g4KqTG4h/6QTp5dF8vebXiMADmpshCMMpUxm3FccFY7k=
   on:
     tags: true
-    distributions: "sdist bdist_wheel"
     repo: PyGithub/PyGithub
     python: "2.7"


### PR DESCRIPTION
`distributions` should be under `deploy`, not `deploy.on`
https://docs.travis-ci.com/user/deployment/pypi/#uploading-different-distributions

Fixes #1321 