### PR TITLE
add endpoint for "transfer repo"

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -2089,6 +2089,21 @@ class Repository(github.GithubObject.CompletableGithubObject):
         )
         return Repository(self._requester, headers, data, completed=True)
 
+    def transfer(self, new_owner, team_ids=[]):
+        """
+        :calls: `POST /repos/:owner/:repo/transfer <https://developer.github.com/v3/repos/#transfer-a-repository>`_
+        :param new_owner: string or "none" or "*"
+        :rtype: :class:`github.Repository.Repository`
+        """
+        post_parameters = {}
+        if new_owner is not None:
+            post_parameters["new_owner"] = new_owner
+        post_parameters["team_ids"] = team_ids
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST", self.url + "/transfer", input=post_parameters,
+        )
+        return Repository(self._requester, headers, data, completed=True)
+
     def get_git_blob(self, sha):
         """
         :calls: `GET /repos/:owner/:repo/git/blobs/:sha <http://developer.github.com/v3/git/blobs>`_

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -2097,7 +2097,8 @@ class Repository(github.GithubObject.CompletableGithubObject):
         :rtype: :class:`github.Repository.Repository`
         """
         assert new_owner is not None
-        assert isinstance(team_ids, list)
+        assert isinstance(new_owner, str), new_owner
+        assert all(isinstance(element, int) for element in team_ids), team_ids
         post_parameters = {"new_owner": new_owner, 'team_ids': team_ids}
         headers, data = self._requester.requestJsonAndCheck(
             "POST", self.url + "/transfer", input=post_parameters,

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -2096,10 +2096,9 @@ class Repository(github.GithubObject.CompletableGithubObject):
         :param team_ids: list. Optional. Works only under organizations.
         :rtype: :class:`github.Repository.Repository`
         """
-        post_parameters = {}
-        if new_owner is not None:
-            post_parameters["new_owner"] = new_owner
-        post_parameters["team_ids"] = team_ids
+        assert new_owner is not None
+        assert isinstance(team_ids, list)
+        post_parameters = {"new_owner": new_owner, 'team_ids': team_ids}
         headers, data = self._requester.requestJsonAndCheck(
             "POST", self.url + "/transfer", input=post_parameters,
         )

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -2092,7 +2092,8 @@ class Repository(github.GithubObject.CompletableGithubObject):
     def transfer(self, new_owner, team_ids=[]):
         """
         :calls: `POST /repos/:owner/:repo/transfer <https://developer.github.com/v3/repos/#transfer-a-repository>`_
-        :param new_owner: string or "none" or "*"
+        :param new_owner: string or "none" or "*". Required.
+        :param team_ids: list. Optional. Works only under organizations.
         :rtype: :class:`github.Repository.Repository`
         """
         post_parameters = {}


### PR DESCRIPTION
To transfer repo from one owner to another one needs to call /repos/:owner/:repo/transfer as per https://developer.github.com/v3/repos/#transfer-a-repository . This PR aims to add that endpoint to API.