### PR TITLE
Add configuration for Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,14 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+sphinx:
+  configuration: doc/conf.py
+
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
Read the Docs defaults to using Python 2 to build the documentation, so
add a configuration file so we use a supported (upstream and by us)
version.

Fixes #1341