### PR TITLE
Added nested teams and parent (address issue#1337)

### DIFF
--- a/github/Team.py
+++ b/github/Team.py
@@ -155,6 +155,14 @@ class Team(github.GithubObject.CompletableGithubObject):
         self._completeIfNotSet(self._privacy)
         return self._privacy.value
 
+    @property
+    def parent(self):
+        """
+        :type: string
+        """
+        self._completeIfNotSet(self._parent)
+        return self._parent.value
+
     def add_to_members(self, member):
         """
         This API call is deprecated. Use `add_membership` instead.
@@ -262,6 +270,18 @@ class Team(github.GithubObject.CompletableGithubObject):
             "PATCH", self.url, input=post_parameters
         )
         self._useAttributes(data)
+
+    def get_teams(self):
+        """
+        :calls: `GET /teams/:id/teams <https://developer.github.com/enterprise/2.17/v3/teams/#list-child-teams>`_
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Team.Team`
+        """
+        return github.PaginatedList.PaginatedList(
+            github.Team.Team,
+            self._requester,
+            self.url + '/teams',
+            None,
+        )
 
     def get_discussions(self):
         """
@@ -393,6 +413,7 @@ class Team(github.GithubObject.CompletableGithubObject):
         self._url = github.GithubObject.NotSet
         self._organization = github.GithubObject.NotSet
         self._privacy = github.GithubObject.NotSet
+        self._parent = github.GithubObject.NotSet
 
     def _useAttributes(self, attributes):
         if "id" in attributes:  # pragma no branch
@@ -423,3 +444,7 @@ class Team(github.GithubObject.CompletableGithubObject):
             )
         if "privacy" in attributes:  # pragma no branch
             self._privacy = self._makeStringAttribute(attributes["privacy"])
+        if attributes.get("parent") is not None:  # pragma no branch
+            self._parent = self._makeClassAttribute(
+                github.Team.Team, attributes["parent"]
+            )

--- a/github/Team.py
+++ b/github/Team.py
@@ -273,7 +273,7 @@ class Team(github.GithubObject.CompletableGithubObject):
 
     def get_teams(self):
         """
-        :calls: `GET /teams/:id/teams <https://developer.github.com/enterprise/2.17/v3/teams/#list-child-teams>`_
+        :calls: `GET /teams/:id/teams <https://developer.github.com/v3/teams/#list-child-teams>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Team.Team`
         """
         return github.PaginatedList.PaginatedList(
@@ -444,7 +444,7 @@ class Team(github.GithubObject.CompletableGithubObject):
             )
         if "privacy" in attributes:  # pragma no branch
             self._privacy = self._makeStringAttribute(attributes["privacy"])
-        if attributes.get("parent") is not None:  # pragma no branch
+        if "parent" in attributes:  # pragma no branch
             self._parent = self._makeClassAttribute(
                 github.Team.Team, attributes["parent"]
             )

--- a/tests/ReplayData/Team.testGetTeams.txt
+++ b/tests/ReplayData/Team.testGetTeams.txt
@@ -1,0 +1,11 @@
+https
+GET
+api.github.com
+None
+/teams/189850/teams
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+None
+200
+[('status', '200 OK'), ('x-ratelimit-remaining', '4973'), ('content-length', '150'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"43d7c883d1cb7d50a08d2c189550023c"'), ('date', 'Sun, 27 May 2012 05:13:46 GMT'), ('content-type', 'application/json; charset=utf-8')]
+[{"name":"DummyTeam1","id":189851,"parent":{"name":"Team created by PyGithub","id":189850}},{"name":"DummyTeam2","id":189852,"parent":{"name":"Team created by PyGithub","id":189850}},{"name":"DummyTeam3","id":189853,"parent":{"name":"Team created by PyGithub","id":189850}}]
+

--- a/tests/Team.py
+++ b/tests/Team.py
@@ -55,6 +55,7 @@ class Team(Framework.TestCase):
         self.assertEqual(self.team.url, "https://api.github.com/teams/189850")
         self.assertEqual(self.team.organization, self.org)
         self.assertEqual(self.team.privacy, "closed")
+        self.assertEqual(self.team.parent, None)
 
         # test __repr__() based on this attributes
         self.assertEqual(
@@ -137,6 +138,17 @@ class Team(Framework.TestCase):
         self.assertEqual(self.team.description, "Description edited by PyGithub")
         self.assertEqual(self.team.permission, "admin")
         self.assertEqual(self.team.privacy, "secret")
+
+    def testGetTeams(self):
+        nested_teams = self.team.get_teams()
+        self.assertListKeyEqual(
+            nested_teams,
+            lambda t: t.name,
+            ['DummyTeam1', 'DummyTeam2', 'DummyTeam3']
+        )
+        parent = nested_teams[0].parent
+        self.assertEqual(self.team.name, parent.name)
+        self.assertEqual(self.team.id, parent.id)
 
     def testDelete(self):
         self.team.delete()


### PR DESCRIPTION
Address [issue#1337](https://github.com/PyGithub/PyGithub/issues/1337)

Example usage:
```python
>>> org = gh.get_organization('testorggshefer')
>>> teams = list(org.get_teams())
>>> teams
[Team(name="a", id=3593732), Team(name="aa", id=3593733), Team(name="aaa", id=3593746), Team(name="ab", id=3593734)]
>>> nested_teams = list(teams[0].get_teams())
>>> nested_teams
[Team(name="aa", id=3593733), Team(name="ab", id=3593734)]
>>> nested_teams[0].parent
Team(name="a", id=3593732)
```