### PR TITLE
Correct parameter for Label.edit

### DIFF
--- a/github/Label.py
+++ b/github/Label.py
@@ -99,7 +99,7 @@ class Label(github.GithubObject.CompletableGithubObject):
             description, str
         ), description
         post_parameters = {
-            "name": name,
+            "new_name": name,
             "color": color,
         }
         if description is not github.GithubObject.NotSet:

--- a/tests/ReplayData/Label.testEdit.txt
+++ b/tests/ReplayData/Label.testEdit.txt
@@ -4,7 +4,7 @@ api.github.com
 None
 /repos/jacquev6/PyGithub/labels/Bug
 {'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python', 'Accept': 'application/vnd.github.symmetra-preview+json'}
-{"color": "0000ff", "name": "LabelEditedByPyGithub", "description": "Description of LabelEditedByPyGithub"}
+{"color": "0000ff", "new_name": "LabelEditedByPyGithub", "description": "Description of LabelEditedByPyGithub"}
 200
 [('status', '200 OK'), ('x-ratelimit-remaining', '4965'), ('content-length', '133'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"57435796bd4f14b84ad92105669cfab1"'), ('date', 'Sat, 19 May 2012 10:17:44 GMT'), ('content-type', 'application/json; charset=utf-8')]
 {"url":"https://api.github.com/repos/jacquev6/PyGithub/labels/LabelEditedByPyGithub","name":"LabelEditedByPyGithub","color":"0000ff","description":"Description of LabelEditedByPyGithub"}


### PR DESCRIPTION
The existing code for Label.edit was passing 'name' as a parameter to
the PATCH call, but GitHub expects 'new_name', correct it.