### PR TITLE
Repository.create_project() body is optional

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1262,15 +1262,15 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def create_project(self, name, body=github.GithubObject.NotSet):
         """
-        calls: `POST /repos/:owner/:repo/projects <https://developer.github.com/v3/projects/#create-a-repository-project>`_
+        :calls: `POST /repos/:owner/:repo/projects <https://developer.github.com/v3/projects/#create-a-repository-project>`_
         :param name: string
         :param body: string
+        :rtype: :class:`github.Project.Project`
         """
         assert isinstance(name, str), name
         assert body is github.GithubObject.NotSet or isinstance(body, str), body
         post_parameters = {
             "name": name,
-            "body": body,
         }
         import_header = {"Accept": Consts.mediaTypeProjectsPreview}
         if body is not github.GithubObject.NotSet:


### PR DESCRIPTION
The POST parameters passed to the create_project API call did not
consider the body optional, and always included it. Fix up a formatting
error in the docstring for good measure.

Fixes #1357