### PR TITLE
Switch to no argument super()

### DIFF
--- a/github/SourceImport.py
+++ b/github/SourceImport.py
@@ -147,7 +147,7 @@ class SourceImport(github.GithubObject.CompletableGithubObject):
 
     def update(self):
         import_header = {"Accept": Consts.mediaTypeImportPreview}
-        return super(SourceImport, self).update(additional_headers=import_header)
+        return super().update(additional_headers=import_header)
 
     def _initAttributes(self):
         self._authors_count = github.GithubObject.NotSet

--- a/tests/AuthenticatedUser.py
+++ b/tests/AuthenticatedUser.py
@@ -41,7 +41,7 @@ from . import Framework
 
 class AuthenticatedUser(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.user = self.g.get_user()
 
     def testAttributes(self):

--- a/tests/Authorization.py
+++ b/tests/Authorization.py
@@ -34,7 +34,7 @@ from . import Framework
 
 class Authorization(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.authorization = self.g.get_user().get_authorization(372259)
 
     def testAttributes(self):

--- a/tests/Branch.py
+++ b/tests/Branch.py
@@ -37,7 +37,7 @@ from . import Framework
 
 class Branch(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_user().get_repo("PyGithub")
         self.branch = self.repo.get_branch("topic/RewriteWithGeneratedCode")
         self.protected_branch = self.repo.get_branch("integrations")

--- a/tests/BranchProtection.py
+++ b/tests/BranchProtection.py
@@ -27,7 +27,7 @@ from . import Framework
 
 class BranchProtection(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.branch_protection = (
             self.g.get_user()
             .get_repo("PyGithub")

--- a/tests/Commit.py
+++ b/tests/Commit.py
@@ -34,7 +34,7 @@ from . import Framework
 
 class Commit(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.commit = (
             self.g.get_user()
             .get_repo("PyGithub")

--- a/tests/CommitCombinedStatus.py
+++ b/tests/CommitCombinedStatus.py
@@ -33,7 +33,7 @@ from . import Framework
 
 class CommitCombinedStatus(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.combined_status = (
             self.g.get_repo("edx/edx-platform", lazy=True)
             .get_commit("74e70119a23fa3ffb3db19d4590eccfebd72b659")

--- a/tests/CommitComment.py
+++ b/tests/CommitComment.py
@@ -36,7 +36,7 @@ from . import Framework
 
 class CommitComment(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.comment = self.g.get_user().get_repo("PyGithub").get_comment(1361949)
 
     def testAttributes(self):

--- a/tests/CommitStatus.py
+++ b/tests/CommitStatus.py
@@ -37,7 +37,7 @@ from . import Framework
 
 class CommitStatus(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.statuses = list(
             self.g.get_user()
             .get_repo("PyGithub")

--- a/tests/ConditionalRequestUpdate.py
+++ b/tests/ConditionalRequestUpdate.py
@@ -32,7 +32,7 @@ from . import Framework
 
 class ConditionalRequestUpdate(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_repo("akfish/PyGithub", lazy=False)
 
     def testDidNotUpdate(self):

--- a/tests/ContentFile.py
+++ b/tests/ContentFile.py
@@ -35,7 +35,7 @@ from . import Framework
 
 class ContentFile(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.file = self.g.get_user().get_repo("PyGithub").get_readme()
 
     def testAttributes(self):

--- a/tests/Download.py
+++ b/tests/Download.py
@@ -35,7 +35,7 @@ from . import Framework
 
 class Download(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.download = self.g.get_user().get_repo("PyGithub").get_download(242550)
 
     def testAttributes(self):

--- a/tests/Event.py
+++ b/tests/Event.py
@@ -35,7 +35,7 @@ from . import Framework
 
 class Event(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.event = self.g.get_user("jacquev6").get_events()[0]
 
     def testAttributes(self):

--- a/tests/GistComment.py
+++ b/tests/GistComment.py
@@ -35,7 +35,7 @@ from . import Framework
 
 class GistComment(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.comment = self.g.get_gist("2729810").get_comment(323629)
 
     def testAttributes(self):

--- a/tests/GitBlob.py
+++ b/tests/GitBlob.py
@@ -34,7 +34,7 @@ from . import Framework
 
 class GitBlob(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.blob = (
             self.g.get_user()
             .get_repo("PyGithub")

--- a/tests/GitCommit.py
+++ b/tests/GitCommit.py
@@ -36,7 +36,7 @@ from . import Framework
 
 class GitCommit(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.commit = (
             self.g.get_user()
             .get_repo("PyGithub")

--- a/tests/GitMembership.py
+++ b/tests/GitMembership.py
@@ -45,7 +45,7 @@ from . import Framework
 
 class GitMembership(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.org = self.g.get_organization("github")
 
     def tearDown(self):

--- a/tests/GitRef.py
+++ b/tests/GitRef.py
@@ -33,7 +33,7 @@ from . import Framework
 
 class GitRef(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.ref = (
             self.g.get_user()
             .get_repo("PyGithub")

--- a/tests/GitRelease.py
+++ b/tests/GitRelease.py
@@ -43,7 +43,7 @@ from . import Framework
 
 class Release(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         # Do not get self.release here as it casues bad data to be saved in --record mode
         self.content_path = "content.txt"
         self.artifact_path = "archive.zip"

--- a/tests/GitReleaseAsset.py
+++ b/tests/GitReleaseAsset.py
@@ -36,7 +36,7 @@ class ReleaseAsset(Framework.TestCase):
     """
 
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         # Do not get self.release here as it causes bad data to be saved in --record mode
 
     def testAttributes(self):

--- a/tests/GitTag.py
+++ b/tests/GitTag.py
@@ -36,7 +36,7 @@ from . import Framework
 
 class GitTag(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.tag = (
             self.g.get_user()
             .get_repo("PyGithub")

--- a/tests/GitTree.py
+++ b/tests/GitTree.py
@@ -34,7 +34,7 @@ from . import Framework
 
 class GitTree(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.tree = (
             self.g.get_user()
             .get_repo("PyGithub")

--- a/tests/Hook.py
+++ b/tests/Hook.py
@@ -36,7 +36,7 @@ from . import Framework
 
 class Hook(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.hook = self.g.get_user().get_repo("PyGithub").get_hook(257993)
 
     def testAttributes(self):

--- a/tests/Issue.py
+++ b/tests/Issue.py
@@ -40,7 +40,7 @@ from . import Framework
 
 class Issue(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_user().get_repo("PyGithub")
         self.issue = self.repo.get_issue(28)
 

--- a/tests/Issue131.py
+++ b/tests/Issue131.py
@@ -30,7 +30,7 @@ from . import Framework
 
 class Issue131(Framework.TestCase):  # https://github.com/jacquev6/PyGithub/pull/133
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.user = self.g.get_user()
         self.repo = self.g.get_user("openmicroscopy").get_repo("ome-documentation")
 

--- a/tests/Issue133.py
+++ b/tests/Issue133.py
@@ -30,7 +30,7 @@ from . import Framework
 
 class Issue133(Framework.TestCase):  # https://github.com/jacquev6/PyGithub/pull/133
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.user = self.g.get_user()
 
     def testGetPageWithoutInitialArguments(self):

--- a/tests/Issue139.py
+++ b/tests/Issue139.py
@@ -30,7 +30,7 @@ from . import Framework
 
 class Issue139(Framework.TestCase):  # https://github.com/jacquev6/PyGithub/issues/139
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.user = self.g.get_user().get_repo("PyGithub").get_issue(139).user
 
     def testCompletion(self):

--- a/tests/Issue140.py
+++ b/tests/Issue140.py
@@ -30,7 +30,7 @@ from . import Framework
 
 class Issue140(Framework.TestCase):  # https://github.com/jacquev6/PyGithub/issues/140
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_repo("twitter/bootstrap")
 
     def testGetDirContentsThenLazyCompletionOfFile(self):

--- a/tests/Issue174.py
+++ b/tests/Issue174.py
@@ -30,7 +30,7 @@ from . import Framework
 
 class Issue174(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_repo("twitter/bootstrap")
 
     def testGetDirContentsWhithHttpRedirect(self):

--- a/tests/Issue214.py
+++ b/tests/Issue214.py
@@ -30,7 +30,7 @@ from . import Framework
 
 class Issue214(Framework.TestCase):  # https://github.com/jacquev6/PyGithub/issues/214
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_user().get_repo("PyGithub")
         self.issue = self.repo.get_issue(1)
 

--- a/tests/Issue216.py
+++ b/tests/Issue216.py
@@ -31,7 +31,7 @@ from . import Framework
 # Replay data forged by capitalizing headers from PaginatedList.setUp.txt and PaginatedList.testIteration.txt
 class Issue216(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_user("openframeworks").get_repo("openFrameworks")
         self.list = self.repo.get_issues()
 

--- a/tests/Issue278.py
+++ b/tests/Issue278.py
@@ -30,7 +30,7 @@ from . import Framework
 # Replay data forged by adding nulls to PaginatedList.setUp.txt and PaginatedList.testIteration.txt
 class Issue278(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_user("openframeworks").get_repo("openFrameworks")
         self.list = self.repo.get_issues()
 

--- a/tests/Issue33.py
+++ b/tests/Issue33.py
@@ -32,7 +32,7 @@ from . import Framework
 
 class Issue33(Framework.TestCase):  # https://github.com/jacquev6/PyGithub/issues/33
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_user("openframeworks").get_repo("openFrameworks")
 
     def testOpenIssues(self):

--- a/tests/Issue494.py
+++ b/tests/Issue494.py
@@ -28,7 +28,7 @@ from . import Framework
 
 class Issue494(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_repo("apache/brooklyn-server", lazy=True)
         self.pull = self.repo.get_pull(465)
 

--- a/tests/Issue50.py
+++ b/tests/Issue50.py
@@ -32,7 +32,7 @@ from . import Framework
 
 class Issue50(Framework.TestCase):  # https://github.com/jacquev6/PyGithub/issues/50
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_user().get_repo("PyGithub")
         self.issue = self.repo.get_issue(50)
         self.labelName = "Label with spaces and strange characters (&*#$)"

--- a/tests/Issue54.py
+++ b/tests/Issue54.py
@@ -34,7 +34,7 @@ from . import Framework
 
 class Issue54(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_user().get_repo("TestRepo")
 
     def testConversion(self):

--- a/tests/Issue572.py
+++ b/tests/Issue572.py
@@ -29,7 +29,7 @@ from . import Framework
 
 class Issue572(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_user().get_repo("PyGithub")
 
     def testIssueAsPullRequest(self):

--- a/tests/Issue823.py
+++ b/tests/Issue823.py
@@ -30,7 +30,7 @@ from . import Framework
 
 class Issue823(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.org = self.g.get_organization("p-society")
         self.team = self.org.get_team(2745783)
         self.pending_invitations = self.team.invitations()

--- a/tests/Issue87.py
+++ b/tests/Issue87.py
@@ -32,7 +32,7 @@ from . import Framework
 
 class Issue87(Framework.TestCase):  # https://github.com/jacquev6/PyGithub/issues/87
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_user().get_repo("PyGithub")
 
     def testCreateIssueWithPercentInTitle(self):

--- a/tests/Issue937.py
+++ b/tests/Issue937.py
@@ -26,7 +26,7 @@ from . import Framework
 
 class Issue937(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.user = self.g.get_user()
         self.repo = self.user.get_repo("PyGithub")
 

--- a/tests/Issue945.py
+++ b/tests/Issue945.py
@@ -27,7 +27,7 @@ from . import Framework
 
 class Issue945(Framework.TestCase):  # https://github.com/PyGithub/PyGithub/issues/945
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_user("openframeworks").get_repo("openFrameworks")
         self.list = self.repo.get_issues()
         self.list_with_headers = self.repo.get_stargazers_with_dates()

--- a/tests/IssueComment.py
+++ b/tests/IssueComment.py
@@ -36,7 +36,7 @@ from . import Framework
 
 class IssueComment(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.comment = (
             self.g.get_user().get_repo("PyGithub").get_issue(28).get_comment(5808311)
         )

--- a/tests/IssueEvent.py
+++ b/tests/IssueEvent.py
@@ -36,7 +36,7 @@ from . import Framework
 
 class IssueEvent(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         repo = self.g.get_repo("PyGithub/PyGithub", lazy=True)
 
         # From Issue #30

--- a/tests/Label.py
+++ b/tests/Label.py
@@ -34,7 +34,7 @@ from . import Framework
 
 class Label(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.label = self.g.get_user().get_repo("PyGithub").get_label("Bug")
 
     def testAttributes(self):

--- a/tests/License.py
+++ b/tests/License.py
@@ -27,7 +27,7 @@ from . import Framework
 
 class License(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.license = self.g.get_license("mit")
 
     def testAttributes(self):

--- a/tests/Markdown.py
+++ b/tests/Markdown.py
@@ -32,7 +32,7 @@ from . import Framework
 
 class Markdown(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.text = "MyTitle\n=======\n\nIssue #1"
         self.repo = self.g.get_user().get_repo("PyGithub")
 

--- a/tests/Migration.py
+++ b/tests/Migration.py
@@ -56,7 +56,7 @@ from . import Framework
 
 class Migration(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.user = self.g.get_user()
         self.migration = self.user.get_migrations()[0]
 

--- a/tests/Milestone.py
+++ b/tests/Milestone.py
@@ -35,7 +35,7 @@ from . import Framework
 
 class Milestone(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.milestone = self.g.get_user().get_repo("PyGithub").get_milestone(1)
 
     def testAttributes(self):

--- a/tests/NamedUser.py
+++ b/tests/NamedUser.py
@@ -38,7 +38,7 @@ from . import Framework
 
 class NamedUser(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.user = self.g.get_user("jacquev6")
 
     def testAttributesOfOtherUser(self):

--- a/tests/Notification.py
+++ b/tests/Notification.py
@@ -33,7 +33,7 @@ from . import Framework
 
 class Notification(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.notification = self.g.get_user().get_notifications()[0]
 
     def testMarkAsRead(self):

--- a/tests/Organization.py
+++ b/tests/Organization.py
@@ -43,7 +43,7 @@ from . import Framework
 
 class Organization(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.org = self.g.get_organization("BeaverSoftware")
 
     def testAttributes(self):

--- a/tests/OrganizationHasInMembers.py
+++ b/tests/OrganizationHasInMembers.py
@@ -28,7 +28,7 @@ from . import Framework
 
 class OrganizationHasInMembers(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.user = self.g.get_user("meneal")
         self.org = self.g.get_organization("RobotWithFeelings")
         self.has_in_members = self.org.has_in_members(self.user)

--- a/tests/PaginatedList.py
+++ b/tests/PaginatedList.py
@@ -36,7 +36,7 @@ from . import Framework
 
 class PaginatedList(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_user("openframeworks").get_repo("openFrameworks")
         self.list = self.repo.get_issues()
 

--- a/tests/Persistence.py
+++ b/tests/Persistence.py
@@ -35,7 +35,7 @@ from . import Framework
 
 class Persistence(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_repo("akfish/PyGithub")
 
         self.dumpedRepo = IO()

--- a/tests/Project.py
+++ b/tests/Project.py
@@ -29,7 +29,7 @@ from . import Framework
 
 class Project(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_user().get_repo("PyGithub")
 
     def testGetProject(self):

--- a/tests/PullRequest.py
+++ b/tests/PullRequest.py
@@ -38,7 +38,7 @@ from . import Framework
 
 class PullRequest(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_user().get_repo("PyGithub")
         self.pull = self.repo.get_pull(31)
 

--- a/tests/PullRequest1168.py
+++ b/tests/PullRequest1168.py
@@ -27,7 +27,7 @@ from . import Framework
 
 class PullRequest1168(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.notifications = self.g.get_repo("PyGithub/PyGithub").get_notifications(
             all=True
         )

--- a/tests/PullRequest1169.py
+++ b/tests/PullRequest1169.py
@@ -27,7 +27,7 @@ from . import Framework
 
 class PullRequest1169(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         ferada_repo = self.g.get_repo("coleslaw-org/coleslaw", lazy=True)
         self.pull = ferada_repo.get_pull(173)
 

--- a/tests/PullRequestComment.py
+++ b/tests/PullRequestComment.py
@@ -36,7 +36,7 @@ from . import Framework
 
 class PullRequestComment(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.comment = (
             self.g.get_user().get_repo("PyGithub").get_pull(31).get_comment(886298)
         )

--- a/tests/PullRequestFile.py
+++ b/tests/PullRequestFile.py
@@ -33,7 +33,7 @@ from . import Framework
 
 class PullRequestFile(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.file = self.g.get_user().get_repo("PyGithub").get_pull(31).get_files()[0]
 
     def testAttributes(self):

--- a/tests/PullRequestReview.py
+++ b/tests/PullRequestReview.py
@@ -33,7 +33,7 @@ from . import Framework
 
 class PullRequestReview(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.repo = self.g.get_repo("PyGithub/PyGithub", lazy=True)
         self.pull = self.repo.get_pull(538)
 

--- a/tests/Reaction.py
+++ b/tests/Reaction.py
@@ -30,7 +30,7 @@ from . import Framework
 
 class Reaction(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.reactions = (
             self.g.get_user("PyGithub")
             .get_repo("PyGithub")

--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -56,7 +56,7 @@ from . import Framework
 
 class Repository(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.user = self.g.get_user()
         self.repo = self.user.get_repo("PyGithub")
 
@@ -1608,7 +1608,7 @@ class Repository(Framework.TestCase):
 
 class LazyRepository(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.user = self.g.get_user()
         self.repository_name = "%s/%s" % (self.user.login, "PyGithub")
 

--- a/tests/RepositoryKey.py
+++ b/tests/RepositoryKey.py
@@ -38,7 +38,7 @@ from . import Framework
 
 class RepositoryKey(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         # When recording test, be sure to create a deploy key for yourself on
         # Github and update it here.
         self.key = self.g.get_user("lra").get_repo("mackup").get_key(21870881)

--- a/tests/RequiredPullRequestReviews.py
+++ b/tests/RequiredPullRequestReviews.py
@@ -27,7 +27,7 @@ from . import Framework
 
 class RequiredPullRequestReviews(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.required_pull_request_reviews = (
             self.g.get_user()
             .get_repo("PyGithub")

--- a/tests/RequiredStatusChecks.py
+++ b/tests/RequiredStatusChecks.py
@@ -27,7 +27,7 @@ from . import Framework
 
 class RequiredStatusChecks(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.required_status_checks = (
             self.g.get_user()
             .get_repo("PyGithub")

--- a/tests/Retry.py
+++ b/tests/Retry.py
@@ -46,7 +46,7 @@ class Retry(Framework.TestCase):
         )
 
         Framework.enableRetry(retry)
-        Framework.TestCase.setUp(self)
+        super().setUp()
 
     def testShouldNotRetryWhenStatusNotOnList(self):
         with self.assertRaises(github.GithubException):

--- a/tests/Search.py
+++ b/tests/Search.py
@@ -31,7 +31,7 @@ from . import Framework
 
 class Search(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
 
     def testSearchUsers(self):
         users = self.g.search_users("vincent", sort="followers", order="desc")

--- a/tests/SourceImport.py
+++ b/tests/SourceImport.py
@@ -27,7 +27,7 @@ from . import Framework
 
 class SourceImport(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.user = self.g.get_user("brix4dayz")
         self.repo = self.user.get_repo("source-import-test")
         self.source_import = self.repo.get_source_import()

--- a/tests/Tag.py
+++ b/tests/Tag.py
@@ -33,7 +33,7 @@ from . import Framework
 
 class Tag(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.tag = self.g.get_user().get_repo("PyGithub").get_tags()[0]
 
     def testAttributes(self):

--- a/tests/Team.py
+++ b/tests/Team.py
@@ -42,7 +42,7 @@ from . import Framework
 
 class Team(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.org = self.g.get_organization("BeaverSoftware")
         self.team = self.org.get_team(189850)
 

--- a/tests/Topic.py
+++ b/tests/Topic.py
@@ -31,7 +31,7 @@ from . import Framework
 
 class Topic(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.topics = list(self.g.search_topics("python"))
 
     def testAllFields(self):

--- a/tests/Traffic.py
+++ b/tests/Traffic.py
@@ -33,7 +33,7 @@ from . import Framework
 
 class Traffic(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.user = self.g.get_user()
         self.repo = self.user.get_repo("PyGithub")
 

--- a/tests/UserKey.py
+++ b/tests/UserKey.py
@@ -34,7 +34,7 @@ from . import Framework
 
 class UserKey(Framework.TestCase):
     def setUp(self):
-        Framework.TestCase.setUp(self)
+        super().setUp()
         self.key = self.g.get_user().get_key(2626650)
 
     def testAttributes(self):


### PR DESCRIPTION
Now that Python 2 support is gone, we can switch to no argument super()
rather than calling our superclass by name.