### PR TITLE
Unpin sphinx requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.14.0
 pyjwt
-sphinx<1.8
+sphinx
 sphinx-rtd-theme<0.5
 Deprecated


### PR DESCRIPTION
Now that we support Python 3, we can stop pinning sphinx to the last
version with Python 2 support.