### PR TITLE
Fix two deprecation warnings

### DIFF
--- a/tests/Connection.py
+++ b/tests/Connection.py
@@ -95,11 +95,11 @@ class Connection(unittest.TestCase):
         # validate contents of buffer
         file_value_lines = file.getvalue().split("\n")
         expected_recording_lines = (protocol + expected_recording).split("\n")
-        self.assertEquals(file_value_lines[:5], expected_recording_lines[:5])
-        self.assertEquals(
+        self.assertEqual(file_value_lines[:5], expected_recording_lines[:5])
+        self.assertEqual(
             eval(file_value_lines[5]), eval(expected_recording_lines[5])
         )  # dict literal, so keys not in guaranteed order
-        self.assertEquals(file_value_lines[6:], expected_recording_lines[6:])
+        self.assertEqual(file_value_lines[6:], expected_recording_lines[6:])
 
         # required for replay to work as expected
         httpretty.enable(allow_net_connect=False)

--- a/tests/GithubIntegration.py
+++ b/tests/GithubIntegration.py
@@ -135,7 +135,7 @@ class GithubIntegration(unittest.TestCase):
         integration = GithubIntegration(25216, private_key)
         token = integration.create_jwt()
         payload = jwt.decode(
-            token, key=public_key, algorithm="RS256", options={"verify_exp": False},
+            token, key=public_key, algorithms=["RS256"], options={"verify_exp": False},
         )
         self.assertDictEqual(
             payload, {"iat": 1550055331, "exp": 1550055391, "iss": 25216}


### PR DESCRIPTION
Sort out two deprecation warnings to help silence the test suite.