### PR TITLE
Correct two attributes in Invitation

### DIFF
--- a/github/Invitation.py
+++ b/github/Invitation.py
@@ -111,11 +111,11 @@ class Invitation(github.GithubObject.CompletableGithubObject):
 
     def _useAttributes(self, attributes):
         if "repository" in attributes:  # pragma no branch
-            self._assignee = self._makeClassAttribute(
+            self._repository = self._makeClassAttribute(
                 github.Repository.Repository, attributes["repository"]
             )
         if "created_at" in attributes:  # pragma no branch
-            self._closed_at = self._makeDatetimeAttribute(attributes["created_at"])
+            self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
         if "invitee" in attributes:  # pragma no branch
             self._invitee = self._makeClassAttribute(
                 github.NamedUser.NamedUser, attributes["invitee"]

--- a/tests/AuthenticatedUser.py
+++ b/tests/AuthenticatedUser.py
@@ -711,8 +711,19 @@ class AuthenticatedUser(Framework.TestCase):
 
     def testGetInvitations(self):
         invitation = self.user.get_invitations()[0]
+        self.assertEqual(repr(invitation), "Invitation(id=17285388)")
         self.assertEqual(invitation.id, 17285388)
         self.assertEqual(invitation.permissions, "write")
+        created_at = datetime.datetime(2019, 6, 27, 11, 47)
+        self.assertEqual(invitation.created_at, created_at)
+        self.assertEqual(
+            invitation.url,
+            "https://api.github.com/user/repository_invitations/17285388",
+        )
+        self.assertEqual(
+            invitation.html_url, "https://github.com/jacquev6/PyGithub/invitations"
+        )
+        self.assertEqual(invitation.repository.name, "PyGithub")
         self.assertEqual(invitation.invitee.login, "foobar-test1")
         self.assertEqual(invitation.inviter.login, "jacquev6")
 


### PR DESCRIPTION
Proving once again that untested code is broken code, correctly set two
attributes during initialization of Invitation. Increase coverage by
checking every attribute.