### PR TITLE
Run black over the entire tree

### DIFF
--- a/github/InputGitTreeElement.py
+++ b/github/InputGitTreeElement.py
@@ -59,9 +59,7 @@ class InputGitTreeElement(object):
             content, str
         ), content
         assert (
-            sha is github.GithubObject.NotSet
-            or sha is None
-            or isinstance(sha, str)
+            sha is github.GithubObject.NotSet or sha is None or isinstance(sha, str)
         ), sha
         self.__path = path
         self.__mode = mode

--- a/github/Team.py
+++ b/github/Team.py
@@ -277,10 +277,7 @@ class Team(github.GithubObject.CompletableGithubObject):
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Team.Team`
         """
         return github.PaginatedList.PaginatedList(
-            github.Team.Team,
-            self._requester,
-            self.url + '/teams',
-            None,
+            github.Team.Team, self._requester, self.url + "/teams", None,
         )
 
     def get_discussions(self):

--- a/tests/Team.py
+++ b/tests/Team.py
@@ -142,9 +142,7 @@ class Team(Framework.TestCase):
     def testGetTeams(self):
         nested_teams = self.team.get_teams()
         self.assertListKeyEqual(
-            nested_teams,
-            lambda t: t.name,
-            ['DummyTeam1', 'DummyTeam2', 'DummyTeam3']
+            nested_teams, lambda t: t.name, ["DummyTeam1", "DummyTeam2", "DummyTeam3"]
         )
         parent = nested_teams[0].parent
         self.assertEqual(self.team.name, parent.name)


### PR DESCRIPTION
It's been a while since black was run over the entire tree, and since CI
still doesn't check it, we can get behind.