### PR TITLE
Silence most ResourceWarnings

### DIFF
--- a/github/GithubException.py
+++ b/github/GithubException.py
@@ -41,7 +41,7 @@ class GithubException(Exception):
     """
 
     def __init__(self, status, data):
-        Exception.__init__(self)
+        super().__init__()
         self.__status = status
         self.__data = data
         self.args = [status, data]

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -285,7 +285,7 @@ class NonCompletableGithubObject(GithubObject):
 
 class CompletableGithubObject(GithubObject):
     def __init__(self, requester, headers, attributes, completed):
-        GithubObject.__init__(self, requester, headers, attributes, completed)
+        super().__init__(requester, headers, attributes, completed)
         self.__completed = completed
 
     def __eq__(self, other):

--- a/github/PaginatedList.py
+++ b/github/PaginatedList.py
@@ -131,7 +131,7 @@ class PaginatedList(PaginatedListBase):
         headers=None,
         list_item="items",
     ):
-        PaginatedListBase.__init__(self)
+        super().__init__()
         self.__requester = requester
         self.__contentClass = contentClass
         self.__firstUrl = firstUrl

--- a/tests/AllTests.py
+++ b/tests/AllTests.py
@@ -40,8 +40,6 @@
 #                                                                              #
 ################################################################################
 
-import unittest
-
 from .AuthenticatedUser import AuthenticatedUser
 from .Authentication import Authentication
 from .Authorization import Authorization
@@ -225,7 +223,3 @@ __all__ = [
     Traffic,
     UserKey,
 ]
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/Connection.py
+++ b/tests/Connection.py
@@ -62,7 +62,7 @@ PARAMETERS = itertools.product(
 class RecordingMockConnection(Framework.RecordingConnection):
     def __init__(self, file, protocol, host, port, realConnection):
         self._realConnection = realConnection
-        Framework.RecordingConnection.__init__(self, file, protocol, host, port)
+        super().__init__(file, protocol, host, port)
 
 
 class Connection(unittest.TestCase):

--- a/tests/Framework.py
+++ b/tests/Framework.py
@@ -118,7 +118,6 @@ class RecordingConnection:
         res = self.__cnx.getresponse()
 
         status = res.status
-        print("=>", status)
         headers = res.getheaders()
         output = res.read()
 
@@ -140,14 +139,14 @@ class RecordingHttpConnection(RecordingConnection):
     _realConnection = github.Requester.HTTPRequestsConnectionClass
 
     def __init__(self, file, *args, **kwds):
-        RecordingConnection.__init__(self, file, "http", *args, **kwds)
+        super().__init__(file, "http", *args, **kwds)
 
 
 class RecordingHttpsConnection(RecordingConnection):
     _realConnection = github.Requester.HTTPSRequestsConnectionClass
 
     def __init__(self, file, *args, **kwds):
-        RecordingConnection.__init__(self, file, "https", *args, **kwds)
+        super().__init__(file, "https", *args, **kwds)
 
 
 class ReplayingConnection:
@@ -239,14 +238,14 @@ class ReplayingHttpConnection(ReplayingConnection):
     _realConnection = github.Requester.HTTPRequestsConnectionClass
 
     def __init__(self, testCase, file, *args, **kwds):
-        ReplayingConnection.__init__(self, testCase, file, "http", *args, **kwds)
+        super().__init__(testCase, file, "http", *args, **kwds)
 
 
 class ReplayingHttpsConnection(ReplayingConnection):
     _realConnection = github.Requester.HTTPSRequestsConnectionClass
 
     def __init__(self, testCase, file, *args, **kwds):
-        ReplayingConnection.__init__(self, testCase, file, "https", *args, **kwds)
+        super().__init__(testCase, file, "https", *args, **kwds)
 
 
 class BasicTestCase(unittest.TestCase):
@@ -257,7 +256,7 @@ class BasicTestCase(unittest.TestCase):
     replayDataFolder = os.path.join(os.path.dirname(__file__), "ReplayData")
 
     def setUp(self):
-        unittest.TestCase.setUp(self)
+        super().setUp()
         self.__fileName = ""
         self.__file = None
         if (
@@ -299,7 +298,7 @@ class BasicTestCase(unittest.TestCase):
             httpretty.enable(allow_net_connect=False)
 
     def tearDown(self):
-        unittest.TestCase.tearDown(self)
+        super().tearDown()
         httpretty.disable()
         httpretty.reset()
         self.__closeReplayFileIfNeeded()
@@ -354,7 +353,7 @@ class TestCase(BasicTestCase):
         return lambda requester, obj, frame: self.doCheckFrame(obj, frame)
 
     def setUp(self):
-        BasicTestCase.setUp(self)
+        super().setUp()
 
         # Set up frame debugging
         github.GithubObject.GithubObject.setCheckAfterInitFlag(True)

--- a/tests/GitMembership.py
+++ b/tests/GitMembership.py
@@ -50,7 +50,7 @@ class GitMembership(Framework.TestCase):
 
     def tearDown(self):
         self.org = None
-        Framework.TestCase.tearDown(self)
+        super().tearDown()
 
     def testGetMembership(self):
         octocat = self.g.get_user("octocat")

--- a/tests/GitRelease.py
+++ b/tests/GitRelease.py
@@ -60,6 +60,7 @@ class Release(Framework.TestCase):
             os.remove(self.content_path)
         if os.path.exists(self.artifact_path):
             os.remove(self.artifact_path)
+        super().tearDown()
 
     def testAttributes(self):
         self.release = self.g.get_user().get_repo("PyGithub").get_releases()[0]

--- a/tests/Logging_.py
+++ b/tests/Logging_.py
@@ -70,12 +70,13 @@ class Logging(Framework.BasicTestCase):
             self.output = output
 
     def setUp(self):
+        super().setUp()
         self.logger = self.MockLogger()
         github.Requester.Requester.injectLogger(self.logger)
-        Framework.BasicTestCase.setUp(self)
 
     def tearDown(self):
         github.Requester.Requester.resetLogger()
+        super().tearDown()
 
     def assertLogging(self, verb, url, requestHeaders, responseHeaders, output):
         self.assertEqual(self.logger.verb, verb)

--- a/tests/Persistence.py
+++ b/tests/Persistence.py
@@ -44,6 +44,7 @@ class Persistence(Framework.TestCase):
 
     def tearDown(self):
         self.dumpedRepo.close()
+        super().tearDown()
 
     def testLoad(self):
         loadedRepo = self.g.load(self.dumpedRepo)


### PR DESCRIPTION
A few test classes were failing to call tearDown() of the superclass,
which meant the file descriptors of their replydata files were leaking.
Make sure to call it, and switch every other callsite of superclasses by
name to using argument-less super().

Revert an AllTests change that snuck in during release.