### PR TITLE
Make scripts/add_attribute.py work with python3

### DIFF
--- a/scripts/add_attribute.py
+++ b/scripts/add_attribute.py
@@ -136,6 +136,6 @@ while i < len(lines):
     i += 1
     newLines.append(line)
 
-with open(fileName, "wb") as f:
+with open(fileName, "w") as f:
     for line in newLines:
         f.write(line + "\n")


### PR DESCRIPTION
In python3 you can't write text to a file that was opened in binary mode. This PR opens the target file in text mode, which is what we actually want.