### PR TITLE
Unpin coverage to 5.0.3 only

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 cryptography
 httpretty>=0.9.6
 parameterized>=0.7.0
-coverage==5.0.3
+coverage>=5.0.3


### PR DESCRIPTION
To not force distributions to patch our requirements, loosen the
coverage test dependency.