### PR TITLE
Fix GitMembership with a hammer

### DIFF
--- a/tests/AllTests.py
+++ b/tests/AllTests.py
@@ -65,6 +65,7 @@ from .GitBlob import GitBlob
 from .GitCommit import GitCommit
 from .Github_ import Github
 from .GithubIntegration import GithubIntegration
+from .GitMembership import GitMembership
 from .GitRef import GitRef
 from .GitRelease import Release
 from .GitReleaseAsset import ReleaseAsset
@@ -155,6 +156,7 @@ __all__ = [
     GistComment,
     GitBlob,
     GitCommit,
+    GitMembership,
     Github,
     GithubIntegration,
     GitRef,

--- a/tests/GitMembership.py
+++ b/tests/GitMembership.py
@@ -48,13 +48,10 @@ class GitMembership(Framework.TestCase):
         super().setUp()
         self.org = self.g.get_organization("github")
 
-    def tearDown(self):
-        self.org = None
-        super().tearDown()
-
     def testGetMembership(self):
-        octocat = self.g.get_user("octocat")
+        octocat = self.g.get_user()
+        self.assertEqual(octocat.login, "octocat")
         membership_data = octocat.get_organization_membership(self.org.id)
-        self.assertEqual("octocat", membership_data.user.login)
-        self.assertEqual("admin", membership_data.role)
-        self.assertEqual("github", membership_data.organization.login)
+        self.assertEqual(membership_data.user.login, "octocat")
+        self.assertEqual(membership_data.role, "admin")
+        self.assertEqual(membership_data.organization.login, "github")

--- a/tests/ReplayData/GitMembership.testGetMembership.txt
+++ b/tests/ReplayData/GitMembership.testGetMembership.txt
@@ -2,7 +2,7 @@ https
 GET
 api.github.com
 None
-/users/octocat
+/user
 {'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 null
 200


### PR DESCRIPTION
While investigating pytest, I discovered this test class was not
imported in AllTests, so it never ran, and worse, it would always fail
because it would get a NamedUser, and not an AuthenticatedUser. Add it
in it, and hit it with a hammer until it passes.