### PR TITLE
Create a tox docs environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ pip install --editable path/to/project
 
 You may also want to investigate `tox` to run tests:
 
-``
+```
 pip install tox
 tox -epy36,flake8,black,isort
 ```
@@ -114,4 +114,10 @@ tox -epy36,flake8,black,isort
 ```
 pip install -r requirements.txt
 sphinx-build doc build
+```
+
+If you use tox:
+
+```
+tox -edocs
 ```

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,12 @@ commands =
     isort -rc github tests scripts setup.py
     black github tests scripts setup.py
 
+[testenv:docs]
+basepython = python3.6
+skip_install = true
+deps = -rrequirements.txt
+commands = sphinx-build doc build
+
 [flake8]
 max-line-length = 88
 select = C,E,F,W


### PR DESCRIPTION
To make it easier to build documentation locally, add a new tox
environment that installs our requirements and runs Sphinx.