### PR TITLE
Use pytest to parametrize tests

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,5 +4,5 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party=deprecated,httpretty,jwt,parameterized,requests,setuptools,urllib3
+known_third_party=deprecated,httpretty,jwt,requests,setuptools,urllib3
 known_first_party=github

--- a/setup.py
+++ b/setup.py
@@ -101,5 +101,5 @@ if __name__ == "__main__":
         python_requires=">=3.5",
         install_requires=["deprecated", "pyjwt", "requests>=2.14.0"],
         extras_require={"integrations": ["cryptography"]},
-        tests_require=["cryptography", "httpretty>=0.9.6", "parameterized>=0.7.0"],
+        tests_require=["cryptography", "httpretty>=0.9.6"],
     )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 cryptography
 httpretty>=0.9.6
-parameterized>=0.7.0
 pytest>=5.3
 pytest-cov>=2.8

--- a/tests/Connection.py
+++ b/tests/Connection.py
@@ -24,12 +24,12 @@
 
 
 import itertools
-import unittest
 from io import StringIO
 from unittest.mock import Mock
 
 import httpretty
-from parameterized import parameterized
+
+import pytest
 
 from . import Framework
 
@@ -65,53 +65,52 @@ class RecordingMockConnection(Framework.RecordingConnection):
         super().__init__(file, protocol, host, port)
 
 
-class Connection(unittest.TestCase):
-    @parameterized.expand(itertools.chain(*p) for p in PARAMETERS)
-    def testRecordAndReplay(
-        self, replaying_connection_class, protocol, response_body, expected_recording
-    ):
-        file = StringIO()
-        host = "api.github.com"
-        verb = "GET"
-        url = "/user"
-        headers = {"Authorization": "Basic p4ssw0rd", "User-Agent": "PyGithub/Python"}
+@pytest.mark.parametrize(
+    ("replaying_connection_class", "protocol", "response_body", "expected_recording"),
+    list(tuple(itertools.chain(*p)) for p in PARAMETERS),
+)
+def testRecordAndReplay(
+    replaying_connection_class, protocol, response_body, expected_recording
+):
+    file = StringIO()
+    host = "api.github.com"
+    verb = "GET"
+    url = "/user"
+    headers = {"Authorization": "Basic p4ssw0rd", "User-Agent": "PyGithub/Python"}
 
-        response = Mock()
-        response.status = 200
-        response.getheaders.return_value = {}
-        response.read.return_value = response_body
+    response = Mock()
+    response.status = 200
+    response.getheaders.return_value = {}
+    response.read.return_value = response_body
 
-        connection = Mock()
-        connection.getresponse.return_value = response
+    connection = Mock()
+    connection.getresponse.return_value = response
 
-        # write mock response to buffer
-        recording_connection = RecordingMockConnection(
-            file, protocol, host, None, lambda *args, **kwds: connection
-        )
-        recording_connection.request(verb, url, None, headers)
-        recording_connection.getresponse()
-        recording_connection.close()
+    # write mock response to buffer
+    recording_connection = RecordingMockConnection(
+        file, protocol, host, None, lambda *args, **kwds: connection
+    )
+    recording_connection.request(verb, url, None, headers)
+    recording_connection.getresponse()
+    recording_connection.close()
 
-        # validate contents of buffer
-        file_value_lines = file.getvalue().split("\n")
-        expected_recording_lines = (protocol + expected_recording).split("\n")
-        self.assertEqual(file_value_lines[:5], expected_recording_lines[:5])
-        self.assertEqual(
-            eval(file_value_lines[5]), eval(expected_recording_lines[5])
-        )  # dict literal, so keys not in guaranteed order
-        self.assertEqual(file_value_lines[6:], expected_recording_lines[6:])
+    # validate contents of buffer
+    file_value_lines = file.getvalue().split("\n")
+    expected_recording_lines = (protocol + expected_recording).split("\n")
+    assert file_value_lines[:5] == expected_recording_lines[:5]
+    assert eval(file_value_lines[5]) == eval(expected_recording_lines[5])
+    # dict literal, so keys not in guaranteed order
+    assert file_value_lines[6:] == expected_recording_lines[6:]
 
-        # required for replay to work as expected
-        httpretty.enable(allow_net_connect=False)
+    # required for replay to work as expected
+    httpretty.enable(allow_net_connect=False)
 
-        # rewind buffer and attempt to replay response from it
-        file.seek(0)
-        replaying_connection = replaying_connection_class(
-            self, file, host=host, port=None
-        )
-        replaying_connection.request(verb, url, None, headers)
-        replaying_connection.getresponse()
+    # rewind buffer and attempt to replay response from it
+    file.seek(0)
+    replaying_connection = replaying_connection_class(file, host=host, port=None)
+    replaying_connection.request(verb, url, None, headers)
+    replaying_connection.getresponse()
 
-        # not necessarily required for subsequent tests
-        httpretty.disable()
-        httpretty.reset()
+    # not necessarily required for subsequent tests
+    httpretty.disable()
+    httpretty.reset()

--- a/tests/Framework.py
+++ b/tests/Framework.py
@@ -150,8 +150,7 @@ class RecordingHttpsConnection(RecordingConnection):
 
 
 class ReplayingConnection:
-    def __init__(self, testCase, file, protocol, host, port, *args, **kwds):
-        self.__testCase = testCase
+    def __init__(self, file, protocol, host, port, *args, **kwds):
         self.__file = file
         self.__protocol = protocol
         self.__host = host
@@ -171,25 +170,20 @@ class ReplayingConnection:
 
     def __readNextRequest(self, verb, url, input, headers):
         fixAuthorizationHeader(headers)
-        self.__testCase.assertEqual(self.__protocol, readLine(self.__file))
-        self.__testCase.assertEqual(verb, readLine(self.__file))
-        self.__testCase.assertEqual(self.__host, readLine(self.__file))
-        self.__testCase.assertEqual(str(self.__port), readLine(self.__file))
-        self.__testCase.assertEqual(
-            self.__splitUrl(url), self.__splitUrl(readLine(self.__file))
-        )
-        self.__testCase.assertEqual(headers, eval(readLine(self.__file)))
+        assert self.__protocol == readLine(self.__file)
+        assert verb == readLine(self.__file)
+        assert self.__host == readLine(self.__file)
+        assert str(self.__port) == readLine(self.__file)
+        assert self.__splitUrl(url) == self.__splitUrl(readLine(self.__file))
+        assert headers == eval(readLine(self.__file))
         expectedInput = readLine(self.__file)
         if isinstance(input, str):
             if input.startswith("{"):
-                self.__testCase.assertEqual(
-                    json.loads(input.replace("\n", "").replace("\r", "")),
-                    json.loads(expectedInput),
-                )
+                assert json.loads(
+                    input.replace("\n", "").replace("\r", "")
+                ) == json.loads(expectedInput)
             else:
-                self.__testCase.assertEqual(
-                    input.replace("\n", "").replace("\r", ""), expectedInput
-                )
+                assert input.replace("\n", "").replace("\r", "") == expectedInput
         else:
             # for non-string input (e.g. upload asset), let it pass.
             pass
@@ -198,7 +192,7 @@ class ReplayingConnection:
         splitedUrl = url.split("?")
         if len(splitedUrl) == 1:
             return splitedUrl
-        self.__testCase.assertEqual(len(splitedUrl), 2)
+        assert len(splitedUrl) == 2
         base, qs = splitedUrl
         return (base, sorted(qs.split("&")))
 
@@ -237,15 +231,15 @@ class ReplayingConnection:
 class ReplayingHttpConnection(ReplayingConnection):
     _realConnection = github.Requester.HTTPRequestsConnectionClass
 
-    def __init__(self, testCase, file, *args, **kwds):
-        super().__init__(testCase, file, "http", *args, **kwds)
+    def __init__(self, file, *args, **kwds):
+        super().__init__(file, "http", *args, **kwds)
 
 
 class ReplayingHttpsConnection(ReplayingConnection):
     _realConnection = github.Requester.HTTPSRequestsConnectionClass
 
-    def __init__(self, testCase, file, *args, **kwds):
-        super().__init__(testCase, file, "https", *args, **kwds)
+    def __init__(self, file, *args, **kwds):
+        super().__init__(file, "https", *args, **kwds)
 
 
 class BasicTestCase(unittest.TestCase):
@@ -282,10 +276,10 @@ class BasicTestCase(unittest.TestCase):
         else:
             github.Requester.Requester.injectConnectionClasses(
                 lambda ignored, *args, **kwds: ReplayingHttpConnection(
-                    self, self.__openFile("r"), *args, **kwds
+                    self.__openFile("r"), *args, **kwds
                 ),
                 lambda ignored, *args, **kwds: ReplayingHttpsConnection(
-                    self, self.__openFile("r"), *args, **kwds
+                    self.__openFile("r"), *args, **kwds
                 ),
             )
             self.login = "login"

--- a/tests/Framework.py
+++ b/tests/Framework.py
@@ -178,12 +178,11 @@ class ReplayingConnection:
         assert headers == eval(readLine(self.__file))
         expectedInput = readLine(self.__file)
         if isinstance(input, str):
+            trInput = input.replace("\n", "").replace("\r", "")
             if input.startswith("{"):
-                assert json.loads(
-                    input.replace("\n", "").replace("\r", "")
-                ) == json.loads(expectedInput)
+                assert json.loads(trInput) == json.loads(expectedInput)
             else:
-                assert input.replace("\n", "").replace("\r", "") == expectedInput
+                assert trInput == expectedInput
         else:
             # for non-string input (e.g. upload asset), let it pass.
             pass


### PR DESCRIPTION
Use built-in pytest test case parametrization support over external
'parameterize' package.  The latter is not well maintained, and has
known Python 3.8 failures unsolved since November 2019.

Since pytest fixtures are incompatible with unittest-style tests,
rewrite the relevant test case to use pytest-style asserts.  This also
makes the resulting code simpler, as we no longer have to pass TestCase
to the helper classes.