### PR TITLE
Drop unneeded ignore rule for flake8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,4 +29,4 @@ commands = sphinx-build doc build
 [flake8]
 max-line-length = 88
 select = C,E,F,W
-ignore = E203, E266, E501, W503
+ignore = E266, E501, W503


### PR DESCRIPTION
We no longer have code or comments that triggers E203 (no space before
:), so we can drop it.