### PR TITLE
Add GitHub Action workflow for checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,16 @@
+name: check
+on:
+  pull_request:
+  push:
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+      - run: pip install tox -r requirements.txt -r test-requirements.txt
+      - run: tox -elint
+      - run: pytest --cov=github


### PR DESCRIPTION
To integrate better with the GitHub workflow, add a workflow for
checking pushes and PRs. This doesn't remove the Travis configuration,
which is still required for releases.

Co-Authored-By: Christian Clauss <cclauss@me.com>