### PR TITLE
Drop use of shadow-cat for draft PRs

### DIFF
--- a/github/Consts.py
+++ b/github/Consts.py
@@ -118,8 +118,5 @@ updateBranchPreview = "application/vnd.github.lydian-preview+json"
 # https://developer.github.com/changes/2016-05-23-timeline-preview-api/
 issueTimelineEventsPreview = "application/vnd.github.mockingbird-preview"
 
-# https://developer.github.com/changes/2019-02-14-draft-pull-requests/
-draftPullRequestPreview = "application/vnd.github.shadow-cat-preview+json"
-
 # https://developer.github.com/v3/teams/#check-if-a-team-manages-a-repository
 teamRepositoryPermissions = "application/vnd.github.v3.repository+json"

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1364,10 +1364,9 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def __create_pull(self, **kwds):
         post_parameters = kwds
-        import_header = {"Accept": Consts.draftPullRequestPreview}
 
         headers, data = self._requester.requestJsonAndCheck(
-            "POST", self.url + "/pulls", input=post_parameters, headers=import_header
+            "POST", self.url + "/pulls", input=post_parameters
         )
         return github.PullRequest.PullRequest(
             self._requester, headers, data, completed=True

--- a/tests/ReplayData/Repository.testCreatePull.txt
+++ b/tests/ReplayData/Repository.testCreatePull.txt
@@ -3,7 +3,7 @@ POST
 api.github.com
 None
 /repos/jacquev6/PyGithub/pulls
-{'Accept': 'application/vnd.github.shadow-cat-preview+json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python', 'Content-Type': 'application/json'}
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python', 'Content-Type': 'application/json'}
 {"body": "Body of the pull request", "head": "BeaverSoftware:master", "base": "topic/RewriteWithGeneratedCode", "maintainer_can_modify": true, "draft": false, "title": "Pull request created by PyGithub"}
 201
 [('status', '201 Created'), ('x-ratelimit-remaining', '4963'), ('content-length', '4486'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"1e069be7c3e3eb8b12afb1e1f5343dc9"'), ('date', 'Sun, 27 May 2012 09:25:37 GMT'), ('content-type', 'application/json; charset=utf-8'), ('location', 'https://api.github.com/repos/jacquev6/PyGithub/pulls/31')]

--- a/tests/ReplayData/Repository.testCreatePullFromIssue.txt
+++ b/tests/ReplayData/Repository.testCreatePullFromIssue.txt
@@ -14,7 +14,7 @@ POST
 api.github.com
 None
 /repos/jacquev6/PyGithub/pulls
-{'Accept': 'application/vnd.github.shadow-cat-preview+json', 'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+{'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 {"head": "BeaverSoftware:master", "base": "topic/RewriteWithGeneratedCode", "issue": 32}
 201
 [('status', '201 Created'), ('x-ratelimit-remaining', '4933'), ('content-length', '4501'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"2b035f5260fe63dd611156fea3049af0"'), ('date', 'Sun, 27 May 2012 10:58:42 GMT'), ('content-type', 'application/json; charset=utf-8'), ('location', 'https://api.github.com/repos/jacquev6/PyGithub/pulls/32')]


### PR DESCRIPTION
The draft attribute for PRs has graduated, so we can drop the constant
and its use.

Fixes #1460