### PR TITLE
Drop documentation for len() of PaginatedList

### DIFF
--- a/github/PaginatedList.py
+++ b/github/PaginatedList.py
@@ -104,7 +104,6 @@ class PaginatedList(PaginatedListBase):
     If you want to know the total number of items in the list::
 
         print(user.get_repos().totalCount)
-        print(len(user.get_repos()))
 
     You can also index them or take slices::
 


### PR DESCRIPTION
PaginatedList does not support len(), so stop mentioning it in the
docstring.

Fixes #1462