### PR TITLE
Actually use the Python version in GA workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
+        with:
+          python-version: "${{ matrix.python-version }}"
       - run: pip install tox -r requirements.txt -r test-requirements.txt
       - run: tox -elint
       - run: pytest --cov=github


### PR DESCRIPTION
It appears that the Python versions in our strategy matrix are not used
unless we drag them down into the steps. Do so now.