### PR TITLE
Use Github action to upload to PyPI on new release

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: "${{ matrix.python-version }}"
       - name: "Install dependencies"
         run: |
-          pip install --upgrade pip
+          python -m pip install --upgrade pip
           pip install tox tox-gh-actions
       - name: Test with tox
         run: tox

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,24 @@
+name: Publish to PyPI
+on:
+  release:
+    types: [created]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*


### PR DESCRIPTION
- Added `secrets.PYPI_PASSWORD` to project settings
- Use twine to build artifact and upload to PyPI on new release

TODO

- [ ] Test twine with new patch release (1.47.1) 