### PR TITLE
Raise a FutureWarning on use of client_{id,secret}

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -51,6 +51,7 @@
 import datetime
 import pickle
 import time
+import warnings
 
 import jwt
 import requests
@@ -132,6 +133,12 @@ class Github(object):
             or isinstance(retry, (int))
             or isinstance(retry, (urllib3.util.Retry))
         )
+        if client_id is not None or client_secret is not None:
+            warnings.warn(
+                "client_id and client_secret are deprecated and will be removed in a future release, switch to token authentication",
+                FutureWarning,
+                stacklevel=2,
+            )
         self.__requester = Requester(
             login_or_token,
             password,


### PR DESCRIPTION
client_id and client_secret are sent to GitHub encoded on the query
string, which GitHub has firmly deprecated, so much so as to email
people who are doing so. To discourage its use, raise a FutureWarning if
they are specified.

Fixes #1500