### PR TITLE
Filter FutureWarning for 2 test cases

### DIFF
--- a/tests/Authentication.py
+++ b/tests/Authentication.py
@@ -28,6 +28,8 @@
 #                                                                              #
 ################################################################################
 
+import warnings
+
 import github
 
 from . import Framework
@@ -52,12 +54,15 @@ class Authentication(Framework.BasicTestCase):
 
     # Warning: I don't have a secret key, so the requests for this test are forged
     def testSecretKeyAuthentication(self):
+        # Ignore the warning since client_{id,secret} are deprecated
+        warnings.filterwarnings("ignore", category=FutureWarning)
         g = github.Github(client_id=self.client_id, client_secret=self.client_secret)
         self.assertListKeyEqual(
             g.get_organization("BeaverSoftware").get_repos("public"),
             lambda r: r.name,
             ["FatherBeaver", "PyGithub"],
         )
+        warnings.resetwarnings()
 
     def testUserAgent(self):
         g = github.Github(user_agent="PyGithubTester")

--- a/tests/Issue158.py
+++ b/tests/Issue158.py
@@ -25,12 +25,23 @@
 #                                                                              #
 ################################################################################
 
+import warnings
+
 import github
 
 from . import Framework
 
 
 class Issue158(Framework.TestCase):  # https://github.com/jacquev6/PyGithub/issues/158
+    def setUp(self):
+        super().setUp()
+        # Ignore the warning since client_{id,secret} are deprecated
+        warnings.filterwarnings("ignore", category=FutureWarning)
+
+    def tearDown(self):
+        super().tearDown()
+        warnings.resetwarnings()
+
     # Warning: I don't have a scret key, so the requests for this test are forged
     def testPaginationWithSecretKeyAuthentication(self):
         g = github.Github(client_id=self.client_id, client_secret=self.client_secret)


### PR DESCRIPTION
There are two test cases that explicitly test with client_id and
client_secret, which means pytest helpfully tells us about them after
the test run concludes. We don't need to see them every run until we
drop the arguments, so filter them out for now.