### PR TITLE
Drop spaces in gh-actions tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
 [gh-actions]
 python =
     3.5: py35
-    3.6: py36, docs, lint
+    3.6: py36,docs,lint
     3.7: py37
     3.8: py38
 


### PR DESCRIPTION
The tox configuration for python 3.6 only runs lint. Drop the spaces in
the envlist to see if that helps run all environments.