### PR TITLE
Fixed formatting of two docstrings

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -981,6 +981,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         """
         Convenience function that calls :meth:`Repository.create_git_tag` and
         :meth:`Repository.create_git_release`.
+
         :param tag: string
         :param tag_message: string
         :param release_name: string

--- a/github/StatsPunchCard.py
+++ b/github/StatsPunchCard.py
@@ -38,6 +38,7 @@ class StatsPunchCard(github.GithubObject.NonCompletableGithubObject):
     def get(self, day, hour):
         """
         Get a specific element
+
         :param day: int
         :param hour: int
         :rtype: int


### PR DESCRIPTION
The docstrings for `Repository.create_git_tag_and_release()` and `StatsPunchCard` were missing blank lines between the explanatory text at the top and the `:param:` entries below. That resulted in incorrect formatting by Sphinx.

See, for example, [https://pygithub.readthedocs.io/en/latest/github_objects/StatsPunchCard.html](https://pygithub.readthedocs.io/en/latest/github_objects/StatsPunchCard.html)

This PR should fix that.