### PR TITLE
Drastically increase coverage by checking repr()

### DIFF
--- a/github/RateLimit.py
+++ b/github/RateLimit.py
@@ -50,7 +50,7 @@ class RateLimit(github.GithubObject.NonCompletableGithubObject):
             is present in the rate object.
         """
     )
-    def rate(self):
+    def rate(self):  # pragma: no cover
         """
         (Deprecated) Rate limit for non-search-related API, use `core` instead
 

--- a/tests/AuthenticatedUser.py
+++ b/tests/AuthenticatedUser.py
@@ -77,9 +77,7 @@ class AuthenticatedUser(Framework.TestCase):
         self.assertEqual(self.user.type, "User")
         self.assertEqual(self.user.url, "https://api.github.com/users/jacquev6")
         self.assertEqual(self.user.node_id, "MDQ6VXNlcjMyNzE0Ng==")
-
-        # test __repr__() based on this attributes
-        self.assertEqual(self.user.__repr__(), 'AuthenticatedUser(login="jacquev6")')
+        self.assertEqual(repr(self.user), 'AuthenticatedUser(login="jacquev6")')
 
     def testEditWithoutArguments(self):
         self.user.edit()
@@ -677,6 +675,13 @@ class AuthenticatedUser(Framework.TestCase):
         self.assertEqual(notification.url, None)
         self.assertEqual(notification.subject.url, None)
         self.assertEqual(notification.subject.latest_comment_url, None)
+        self.assertEqual(
+            repr(notification),
+            'Notification(subject=NotificationSubject(title="Feature/coveralls"), id="8406712")',
+        )
+        self.assertEqual(
+            repr(notification.subject), 'NotificationSubject(title="Feature/coveralls")'
+        )
 
     def testGetNotifications(self):
         self.assertListKeyEqual(

--- a/tests/Authorization.py
+++ b/tests/Authorization.py
@@ -59,6 +59,10 @@ class Authorization(Framework.TestCase):
         self.assertEqual(
             self.authorization.url, "https://api.github.com/authorizations/372259"
         )
+        self.assertEqual(repr(self.authorization), "Authorization(scopes=[])")
+        self.assertEqual(
+            repr(self.authorization.app), 'AuthorizationApplication(name="GitHub API")'
+        )
 
     def testEdit(self):
         self.authorization.edit()

--- a/tests/Branch.py
+++ b/tests/Branch.py
@@ -55,10 +55,8 @@ class Branch(Framework.TestCase):
             "https://api.github.com/repos/jacquev6/PyGithub/branches/topic/RewriteWithGeneratedCode/protection",
         )
         self.assertFalse(self.branch.protected)
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.branch.__repr__(), 'Branch(name="topic/RewriteWithGeneratedCode")'
+            repr(self.branch), 'Branch(name="topic/RewriteWithGeneratedCode")'
         )
 
     def testEditProtection(self):

--- a/tests/Commit.py
+++ b/tests/Commit.py
@@ -84,11 +84,8 @@ class Commit(Framework.TestCase):
         self.assertEqual(
             self.commit.commit.tree.sha, "4c6bd50994f0f9823f898b1c6c964ad7d4fa11ab"
         )
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.commit.__repr__(),
-            'Commit(sha="1292bf0e22c796e91cc3d6e24b544aece8c21f2a")',
+            repr(self.commit), 'Commit(sha="1292bf0e22c796e91cc3d6e24b544aece8c21f2a")',
         )
 
     def testGetComments(self):

--- a/tests/CommitCombinedStatus.py
+++ b/tests/CommitCombinedStatus.py
@@ -77,9 +77,7 @@ class CommitCombinedStatus(Framework.TestCase):
             self.combined_status.url,
             "https://api.github.com/repos/edx/edx-platform/commits/74e70119a23fa3ffb3db19d4590eccfebd72b659/status",
         )
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.combined_status.__repr__(),
+            repr(self.combined_status),
             'CommitCombinedStatus(state="success", sha="74e70119a23fa3ffb3db19d4590eccfebd72b659")',
         )

--- a/tests/CommitComment.py
+++ b/tests/CommitComment.py
@@ -63,10 +63,8 @@ class CommitComment(Framework.TestCase):
             "https://api.github.com/repos/jacquev6/PyGithub/comments/1361949",
         )
         self.assertEqual(self.comment.user.login, "jacquev6")
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.comment.__repr__(),
+            repr(self.comment),
             'CommitComment(user=NamedUser(login="jacquev6"), id=1361949)',
         )
 

--- a/tests/CommitStatus.py
+++ b/tests/CommitStatus.py
@@ -66,9 +66,7 @@ class CommitStatus(Framework.TestCase):
             "https://github.com/jacquev6/PyGithub/issues/67",
         )
         self.assertEqual(self.statuses[1].target_url, None)
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.statuses[0].__repr__(),
+            repr(self.statuses[0]),
             'CommitStatus(state="success", id=277040, context="build")',
         )

--- a/tests/ContentFile.py
+++ b/tests/ContentFile.py
@@ -51,6 +51,5 @@ class ContentFile(Framework.TestCase):
             self.file.download_url,
             "https://raw.githubusercontent.com/jacquev6/PyGithub/master/README.md",
         )
-
-        # test __repr__() based on this attributes
-        self.assertEqual(self.file.__repr__(), 'ContentFile(path="ReadMe.md")')
+        self.assertIsNone(self.file.license)
+        self.assertEqual(repr(self.file), 'ContentFile(path="ReadMe.md")')

--- a/tests/Deployment.py
+++ b/tests/Deployment.py
@@ -60,3 +60,7 @@ class Deployment(Framework.TestCase):
             self.deployment.repository_url,
             "https://api.github.com/repos/jacquev6/PyGithub",
         )
+        self.assertEqual(
+            repr(self.deployment),
+            'Deployment(url="https://api.github.com/repos/jacquev6/PyGithub/deployments/201741959", id=201741959)',
+        )

--- a/tests/Download.py
+++ b/tests/Download.py
@@ -67,9 +67,7 @@ class Download(Framework.TestCase):
             self.download.url,
             "https://api.github.com/repos/jacquev6/PyGithub/downloads/242550",
         )
-
-        # test __repr__() based on this attributes
-        self.assertEqual(self.download.__repr__(), "Download(id=242550)")
+        self.assertEqual(repr(self.download), "Download(id=242550)")
 
     def testDelete(self):
         self.download.delete()

--- a/tests/Event.py
+++ b/tests/Event.py
@@ -169,8 +169,4 @@ class Event(Framework.TestCase):
         self.assertTrue(self.event.public)
         self.assertEqual(self.event.repo.name, "jacquev6/PyGithub")
         self.assertEqual(self.event.type, "PushEvent")
-
-        # test __repr__() based on this attributes
-        self.assertEqual(
-            self.event.__repr__(), 'Event(type="PushEvent", id="1556114751")'
-        )
+        self.assertEqual(repr(self.event), 'Event(type="PushEvent", id="1556114751")')

--- a/tests/Gist.py
+++ b/tests/Gist.py
@@ -80,9 +80,10 @@ class Gist(Framework.TestCase):
         self.assertEqual(gist.git_push_url, "https://gist.github.com/6296732.git")
         self.assertEqual(gist.html_url, "https://gist.github.com/6296732")
         self.assertEqual(gist.url, "https://api.github.com/gists/6296732")
-
-        # test __repr__() based on this attributes
-        self.assertEqual(gist.__repr__(), 'Gist(id="6296732")')
+        self.assertEqual(repr(gist), 'Gist(id="6296732")')
+        self.assertEqual(
+            repr(gist.files["GithubAPI.lua"]), 'GistFile(filename="GithubAPI.lua")'
+        )
 
     def testEditWithoutParameters(self):
         gist = self.g.get_gist("2729810")

--- a/tests/GistComment.py
+++ b/tests/GistComment.py
@@ -51,10 +51,8 @@ class GistComment(Framework.TestCase):
             self.comment.url, "https://api.github.com/gists/2729810/comments/323629"
         )
         self.assertEqual(self.comment.user.login, "jacquev6")
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.comment.__repr__(),
+            repr(self.comment),
             'GistComment(user=NamedUser(login="jacquev6"), id=323629)',
         )
 

--- a/tests/GitBlob.py
+++ b/tests/GitBlob.py
@@ -60,9 +60,6 @@ class GitBlob(Framework.TestCase):
             self.blob.url,
             "https://api.github.com/repos/jacquev6/PyGithub/git/blobs/53bce9fa919b4544e67275089b3ec5b44be20667",
         )
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.blob.__repr__(),
-            'GitBlob(sha="53bce9fa919b4544e67275089b3ec5b44be20667")',
+            repr(self.blob), 'GitBlob(sha="53bce9fa919b4544e67275089b3ec5b44be20667")',
         )

--- a/tests/GitCommit.py
+++ b/tests/GitCommit.py
@@ -70,9 +70,8 @@ class GitCommit(Framework.TestCase):
             self.commit.url,
             "https://api.github.com/repos/jacquev6/PyGithub/git/commits/4303c5b90e2216d927155e9609436ccb8984c495",
         )
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.commit.__repr__(),
+            repr(self.commit),
             'GitCommit(sha="4303c5b90e2216d927155e9609436ccb8984c495")',
         )
+        self.assertEqual(repr(self.commit.author), 'GitAuthor(name="Vincent Jacques")')

--- a/tests/GitRef.py
+++ b/tests/GitRef.py
@@ -55,9 +55,12 @@ class GitRef(Framework.TestCase):
             "https://api.github.com/repos/jacquev6/PyGithub/git/refs/heads/BranchCreatedByPyGithub",
         )
 
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.ref.__repr__(), 'GitRef(ref="refs/heads/BranchCreatedByPyGithub")'
+            repr(self.ref), 'GitRef(ref="refs/heads/BranchCreatedByPyGithub")'
+        )
+        self.assertEqual(
+            repr(self.ref.object),
+            'GitObject(sha="1292bf0e22c796e91cc3d6e24b544aece8c21f2a")',
         )
 
     def testEdit(self):

--- a/tests/GitRelease.py
+++ b/tests/GitRelease.py
@@ -99,9 +99,7 @@ class Release(Framework.TestCase):
             self.release.zipball_url,
             "https://api.github.com/repos/edhollandAL/PyGithub/zipball/v1.25.2",
         )
-
-        # test __repr__() based on this attributes
-        self.assertEqual(self.release.__repr__(), 'GitRelease(title="Test")')
+        self.assertEqual(repr(self.release), 'GitRelease(title="Test")')
 
     def testDelete(self):
         self.release = self.g.get_user().get_repo("PyGithub").get_releases()[0]

--- a/tests/GitTag.py
+++ b/tests/GitTag.py
@@ -64,9 +64,7 @@ class GitTag(Framework.TestCase):
             self.tag.url,
             "https://api.github.com/repos/jacquev6/PyGithub/git/tags/f5f37322407b02a80de4526ad88d5f188977bc3c",
         )
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.tag.__repr__(),
+            repr(self.tag),
             'GitTag(tag="v0.6", sha="f5f37322407b02a80de4526ad88d5f188977bc3c")',
         )

--- a/tests/GitTree.py
+++ b/tests/GitTree.py
@@ -71,8 +71,10 @@ class GitTree(Framework.TestCase):
             "https://api.github.com/repos/jacquev6/PyGithub/git/trees/f492784d8ca837779650d1fb406a1a3587a764ad",
         )
 
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.tree.__repr__(),
-            'GitTree(sha="f492784d8ca837779650d1fb406a1a3587a764ad")',
+            repr(self.tree), 'GitTree(sha="f492784d8ca837779650d1fb406a1a3587a764ad")',
+        )
+        self.assertEqual(
+            repr(self.tree.tree[0]),
+            'GitTreeElement(sha="8a9af1462c3f4e3358315c2d2e6ef1e7334c59dd", path=".gitignore")',
         )

--- a/tests/GithubIntegration.py
+++ b/tests/GithubIntegration.py
@@ -154,6 +154,9 @@ class GithubIntegration(unittest.TestCase):
         self.assertEqual(
             auth_obj.expires_at, datetime.datetime(2019, 2, 13, 11, 10, 38)
         )
+        self.assertEqual(
+            repr(auth_obj), "InstallationAuthorization(expires_at=2019-02-13 11:10:38)"
+        )
 
     def test_get_installation(self):
         from github import GithubIntegration

--- a/tests/Github_.py
+++ b/tests/Github_.py
@@ -204,6 +204,7 @@ class Github(Framework.TestCase):
                 ["string", "category_id"],
             ],
         )
+        self.assertEqual(repr(hook), 'HookDescription(name="activecollab")')
 
     def testGetRepoFromFullName(self):
         self.assertEqual(
@@ -307,6 +308,7 @@ class Github(Framework.TestCase):
             t.source,
             "*.py[cod]\n\n# C extensions\n*.so\n\n# Packages\n*.egg\n*.egg-info\ndist\nbuild\neggs\nparts\nbin\nvar\nsdist\ndevelop-eggs\n.installed.cfg\nlib\nlib64\n\n# Installer logs\npip-log.txt\n\n# Unit test / coverage reports\n.coverage\n.tox\nnosetests.xml\n\n# Translations\n*.mo\n\n# Mr Developer\n.mr.developer.cfg\n.project\n.pydevproject\n",
         )
+        self.assertEqual(repr(t), 'GitignoreTemplate(name="Python")')
 
         t = self.g.get_gitignore_template("C++")
         self.assertEqual(t.name, "C++")

--- a/tests/Hook.py
+++ b/tests/Hook.py
@@ -64,11 +64,11 @@ class Hook(Framework.TestCase):
             "https://api.github.com/repos/jacquev6/PyGithub/hooks/257993/pings",
         )
 
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.hook.__repr__(),
+            repr(self.hook),
             'Hook(url="https://api.github.com/repos/jacquev6/PyGithub/hooks/257993", id=257993)',
         )
+        self.assertEqual(repr(self.hook.last_response), 'HookResponse(status="ok")')
 
     def testEditWithMinimalParameters(self):
         self.hook.edit("web", {"url": "http://foobar.com/hook"})

--- a/tests/Issue.py
+++ b/tests/Issue.py
@@ -82,10 +82,8 @@ class Issue(Framework.TestCase):
         )
         self.assertEqual(self.issue.user.login, "jacquev6")
         self.assertEqual(self.issue.repository.name, "PyGithub")
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.issue.__repr__(), 'Issue(title="Issue created by PyGithub", number=28)'
+            repr(self.issue), 'Issue(title="Issue created by PyGithub", number=28)'
         )
 
     def testEditWithoutParameters(self):
@@ -289,6 +287,7 @@ class Issue(Framework.TestCase):
         self.assertEqual("subscribed", first.event)
         self.assertIsNone(first.commit_id)
         self.assertIsNone(first.commit_url)
+        self.assertEqual(repr(first), "TimelineEvent(id=15819975)")
 
         for event in events:
             self.assertIn(event.event, expected_events)
@@ -299,6 +298,10 @@ class Issue(Framework.TestCase):
                 # cross-referenced events don't include an event id or node_id
                 self.assertIsNotNone(event.source)
                 self.assertEqual(event.source.type, "issue")
+                self.assertEqual(event.source.issue.number, 857)
+                self.assertEqual(
+                    repr(event.source), 'TimelineEventSource(type="issue")'
+                )
             else:
                 self.assertIsNotNone(event.id)
                 self.assertIsNotNone(event.node_id)

--- a/tests/IssueComment.py
+++ b/tests/IssueComment.py
@@ -59,10 +59,8 @@ class IssueComment(Framework.TestCase):
             self.comment.html_url,
             "https://github.com/jacquev6/PyGithub/issues/28#issuecomment-5808311",
         )
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.comment.__repr__(),
+            repr(self.comment),
             'IssueComment(user=NamedUser(login="jacquev6"), id=5808311)',
         )
 

--- a/tests/IssueEvent.py
+++ b/tests/IssueEvent.py
@@ -100,8 +100,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_subscribed.rename, None)
         self.assertEqual(self.event_subscribed.dismissed_review, None)
         self.assertEqual(self.event_subscribed.lock_reason, None)
-        # test __repr__() based on this attributes
-        self.assertEqual(self.event_subscribed.__repr__(), "IssueEvent(id=16347479)")
+        self.assertEqual(repr(self.event_subscribed), "IssueEvent(id=16347479)")
 
     def testEvent_assigned_Attributes(self):
         self.assertEqual(self.event_assigned.actor.login, "jacquev6")
@@ -129,8 +128,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_assigned.rename, None)
         self.assertEqual(self.event_assigned.dismissed_review, None)
         self.assertEqual(self.event_assigned.lock_reason, None)
-        # test __repr__() based on this attributes
-        self.assertEqual(self.event_assigned.__repr__(), "IssueEvent(id=16347480)")
+        self.assertEqual(repr(self.event_assigned), "IssueEvent(id=16347480)")
 
     def testEvent_referenced_Attributes(self):
         self.assertEqual(self.event_referenced.actor.login, "jacquev6")
@@ -163,8 +161,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_referenced.rename, None)
         self.assertEqual(self.event_referenced.dismissed_review, None)
         self.assertEqual(self.event_referenced.lock_reason, None)
-        # test __repr__() based on this attributes
-        self.assertEqual(self.event_referenced.__repr__(), "IssueEvent(id=16348656)")
+        self.assertEqual(repr(self.event_referenced), "IssueEvent(id=16348656)")
 
     def testEvent_closed_Attributes(self):
         self.assertEqual(self.event_closed.actor.login, "jacquev6")
@@ -190,8 +187,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_closed.rename, None)
         self.assertEqual(self.event_closed.dismissed_review, None)
         self.assertEqual(self.event_closed.lock_reason, None)
-        # test __repr__() based on this attributes
-        self.assertEqual(self.event_closed.__repr__(), "IssueEvent(id=16351220)")
+        self.assertEqual(repr(self.event_closed), "IssueEvent(id=16351220)")
 
     def testEvent_labeled_Attributes(self):
         self.assertEqual(self.event_labeled.actor.login, "jacquev6")
@@ -217,8 +213,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_labeled.rename, None)
         self.assertEqual(self.event_labeled.dismissed_review, None)
         self.assertEqual(self.event_labeled.lock_reason, None)
-        # test __repr__() based on this attributes
-        self.assertEqual(self.event_labeled.__repr__(), "IssueEvent(id=98136337)")
+        self.assertEqual(repr(self.event_labeled), "IssueEvent(id=98136337)")
 
     def testEvent_mentioned_Attributes(self):
         self.assertEqual(self.event_mentioned.actor.login, "jzelinskie")
@@ -246,8 +241,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_mentioned.rename, None)
         self.assertEqual(self.event_mentioned.dismissed_review, None)
         self.assertEqual(self.event_mentioned.lock_reason, None)
-        # test __repr__() based on this attributes
-        self.assertEqual(self.event_mentioned.__repr__(), "IssueEvent(id=1009034767)")
+        self.assertEqual(repr(self.event_mentioned), "IssueEvent(id=1009034767)")
 
     def testEvent_merged_Attributes(self):
         self.assertEqual(self.event_merged.actor.login, "jzelinskie")
@@ -280,8 +274,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_merged.rename, None)
         self.assertEqual(self.event_merged.dismissed_review, None)
         self.assertEqual(self.event_merged.lock_reason, None)
-        # test __repr__() based on this attributes
-        self.assertEqual(self.event_merged.__repr__(), "IssueEvent(id=1015402964)")
+        self.assertEqual(repr(self.event_merged), "IssueEvent(id=1015402964)")
 
     def testEvent_review_requested_Attributes(self):
         self.assertEqual(self.event_review_requested.actor.login, "jzelinskie")
@@ -315,10 +308,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_review_requested.rename, None)
         self.assertEqual(self.event_review_requested.dismissed_review, None)
         self.assertEqual(self.event_review_requested.lock_reason, None)
-        # test __repr__() based on this attributes
-        self.assertEqual(
-            self.event_review_requested.__repr__(), "IssueEvent(id=1011101309)"
-        )
+        self.assertEqual(repr(self.event_review_requested), "IssueEvent(id=1011101309)")
 
     def testEvent_reopened_Attributes(self):
         self.assertEqual(self.event_reopened.actor.login, "sfdye")
@@ -346,8 +336,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_reopened.rename, None)
         self.assertEqual(self.event_reopened.dismissed_review, None)
         self.assertEqual(self.event_reopened.lock_reason, None)
-        # test __repr__() based on this attributes
-        self.assertEqual(self.event_reopened.__repr__(), "IssueEvent(id=1782463023)")
+        self.assertEqual(repr(self.event_reopened), "IssueEvent(id=1782463023)")
 
     def testEvent_unassigned_Attributes(self):
         self.assertEqual(self.event_unassigned.actor.login, "sfdye")
@@ -375,8 +364,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_unassigned.rename, None)
         self.assertEqual(self.event_unassigned.dismissed_review, None)
         self.assertEqual(self.event_unassigned.lock_reason, None)
-        # test __repr__() based on this attributes
-        self.assertEqual(self.event_unassigned.__repr__(), "IssueEvent(id=1782463379)")
+        self.assertEqual(repr(self.event_unassigned), "IssueEvent(id=1782463379)")
 
     def testEvent_unlabeled_Attributes(self):
         self.assertEqual(self.event_unlabeled.actor.login, "sfdye")
@@ -404,8 +392,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_unlabeled.rename, None)
         self.assertEqual(self.event_unlabeled.dismissed_review, None)
         self.assertEqual(self.event_unlabeled.lock_reason, None)
-        # test __repr__() based on this attributes
-        self.assertEqual(self.event_unlabeled.__repr__(), "IssueEvent(id=1782463917)")
+        self.assertEqual(repr(self.event_unlabeled), "IssueEvent(id=1782463917)")
 
     def testEvent_renamed_Attributes(self):
         self.assertEqual(self.event_renamed.actor.login, "sfdye")
@@ -439,8 +426,7 @@ class IssueEvent(Framework.TestCase):
         )
         self.assertEqual(self.event_renamed.dismissed_review, None)
         self.assertEqual(self.event_renamed.lock_reason, None)
-        # test __repr__() based on this attributes
-        self.assertEqual(self.event_renamed.__repr__(), "IssueEvent(id=1782472556)")
+        self.assertEqual(repr(self.event_renamed), "IssueEvent(id=1782472556)")
 
     def testEvent_base_ref_changed_Attributes(self):
         self.assertEqual(self.event_base_ref_changed.actor.login, "allevin")
@@ -470,10 +456,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_head_ref_deleted.rename, None)
         self.assertEqual(self.event_base_ref_changed.dismissed_review, None)
         self.assertEqual(self.event_base_ref_changed.lock_reason, None)
-        # test __repr__() based on this attributes
-        self.assertEqual(
-            self.event_base_ref_changed.__repr__(), "IssueEvent(id=1782915693)"
-        )
+        self.assertEqual(repr(self.event_base_ref_changed), "IssueEvent(id=1782915693)")
 
     def testEvent_head_ref_deleted_Attributes(self):
         self.assertEqual(self.event_head_ref_deleted.actor.login, "allevin")
@@ -503,10 +486,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_head_ref_deleted.rename, None)
         self.assertEqual(self.event_head_ref_deleted.dismissed_review, None)
         self.assertEqual(self.event_head_ref_deleted.lock_reason, None)
-        # test __repr__() based on this attributes
-        self.assertEqual(
-            self.event_head_ref_deleted.__repr__(), "IssueEvent(id=1782917185)"
-        )
+        self.assertEqual(repr(self.event_head_ref_deleted), "IssueEvent(id=1782917185)")
 
     def testEvent_head_ref_restored_Attributes(self):
         self.assertEqual(self.event_head_ref_restored.actor.login, "allevin")
@@ -536,9 +516,8 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_head_ref_deleted.rename, None)
         self.assertEqual(self.event_head_ref_restored.dismissed_review, None)
         self.assertEqual(self.event_head_ref_deleted.lock_reason, None)
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.event_head_ref_restored.__repr__(), "IssueEvent(id=1782917299)"
+            repr(self.event_head_ref_restored), "IssueEvent(id=1782917299)"
         )
 
     def testEvent_milestoned_Attributes(self):
@@ -567,8 +546,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_milestoned.rename, None)
         self.assertEqual(self.event_milestoned.dismissed_review, None)
         self.assertEqual(self.event_milestoned.lock_reason, None)
-        # test __repr__() based on this attributes
-        self.assertEqual(self.event_milestoned.__repr__(), "IssueEvent(id=1783596418)")
+        self.assertEqual(repr(self.event_milestoned), "IssueEvent(id=1783596418)")
 
     def testEvent_demilestoned_Attributes(self):
         self.assertEqual(self.event_demilestoned.actor.login, "sfdye")
@@ -598,10 +576,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_demilestoned.rename, None)
         self.assertEqual(self.event_demilestoned.dismissed_review, None)
         self.assertEqual(self.event_demilestoned.lock_reason, None)
-        # test __repr__() based on this attributes
-        self.assertEqual(
-            self.event_demilestoned.__repr__(), "IssueEvent(id=1783596452)"
-        )
+        self.assertEqual(repr(self.event_demilestoned), "IssueEvent(id=1783596452)")
 
     def testEvent_locked_Attributes(self):
         self.assertEqual(self.event_locked.actor.login, "PyGithub")
@@ -629,8 +604,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_locked.rename, None)
         self.assertEqual(self.event_locked.dismissed_review, None)
         self.assertEqual(self.event_locked.lock_reason, "too heated")
-        ###        # test __repr__() based on this attributes
-        self.assertEqual(self.event_locked.__repr__(), "IssueEvent(id=1783596743)")
+        self.assertEqual(repr(self.event_locked), "IssueEvent(id=1783596743)")
 
     def testEvent_unlocked_Attributes(self):
         self.assertEqual(self.event_unlocked.actor.login, "PyGithub")
@@ -658,8 +632,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_unlocked.rename, None)
         self.assertEqual(self.event_unlocked.dismissed_review, None)
         self.assertEqual(self.event_unlocked.lock_reason, None)
-        # test __repr__() based on this attributes
-        self.assertEqual(self.event_unlocked.__repr__(), "IssueEvent(id=1783596818)")
+        self.assertEqual(repr(self.event_unlocked), "IssueEvent(id=1783596818)")
 
     def testEvent_review_dismissed_Attributes(self):
         self.assertEqual(self.event_review_dismissed.actor.login, "sfdye")
@@ -696,10 +669,7 @@ class IssueEvent(Framework.TestCase):
             },
         )
         self.assertEqual(self.event_review_dismissed.lock_reason, None)
-        # test __repr__() based on this attributes
-        self.assertEqual(
-            self.event_review_dismissed.__repr__(), "IssueEvent(id=1783605084)"
-        )
+        self.assertEqual(repr(self.event_review_dismissed), "IssueEvent(id=1783605084)")
 
     def testEvent_review_request_removed_Attributes(self):
         self.assertEqual(self.event_review_request_removed.actor.login, "sfdye")
@@ -735,9 +705,8 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_review_request_removed.rename, None)
         self.assertEqual(self.event_review_request_removed.dismissed_review, None)
         self.assertEqual(self.event_review_request_removed.lock_reason, None)
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.event_review_request_removed.__repr__(), "IssueEvent(id=1783779835)"
+            repr(self.event_review_request_removed), "IssueEvent(id=1783779835)"
         )
 
     def testEvent_marked_as_duplicate_Attributes(self):
@@ -768,9 +737,8 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_marked_as_duplicate.rename, None)
         self.assertEqual(self.event_marked_as_duplicate.dismissed_review, None)
         self.assertEqual(self.event_marked_as_duplicate.lock_reason, None)
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.event_marked_as_duplicate.__repr__(), "IssueEvent(id=1783779725)"
+            repr(self.event_marked_as_duplicate), "IssueEvent(id=1783779725)"
         )
 
     def testEvent_unmarked_as_duplicate_Attributes(self):
@@ -803,9 +771,8 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_unmarked_as_duplicate.rename, None)
         self.assertEqual(self.event_unmarked_as_duplicate.dismissed_review, None)
         self.assertEqual(self.event_unmarked_as_duplicate.lock_reason, None)
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.event_unmarked_as_duplicate.__repr__(), "IssueEvent(id=1789228962)"
+            repr(self.event_unmarked_as_duplicate), "IssueEvent(id=1789228962)"
         )
 
     def testEvent_added_to_project_Attributes(self):
@@ -836,10 +803,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_added_to_project.rename, None)
         self.assertEqual(self.event_added_to_project.dismissed_review, None)
         self.assertEqual(self.event_added_to_project.lock_reason, None)
-        # test __repr__() based on this attributes
-        self.assertEqual(
-            self.event_added_to_project.__repr__(), "IssueEvent(id=1791766828)"
-        )
+        self.assertEqual(repr(self.event_added_to_project), "IssueEvent(id=1791766828)")
 
     def testEvent_moved_columns_in_project_Attributes(self):
         self.assertEqual(self.event_moved_columns_in_project.actor.login, "sfdye")
@@ -871,9 +835,8 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_moved_columns_in_project.rename, None)
         self.assertEqual(self.event_moved_columns_in_project.dismissed_review, None)
         self.assertEqual(self.event_moved_columns_in_project.lock_reason, None)
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.event_moved_columns_in_project.__repr__(), "IssueEvent(id=1791767766)"
+            repr(self.event_moved_columns_in_project), "IssueEvent(id=1791767766)"
         )
 
     def testEvent_removed_from_project_Attributes(self):
@@ -904,9 +867,8 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_removed_from_project.rename, None)
         self.assertEqual(self.event_removed_from_project.dismissed_review, None)
         self.assertEqual(self.event_removed_from_project.lock_reason, None)
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.event_removed_from_project.__repr__(), "IssueEvent(id=1791768212)"
+            repr(self.event_removed_from_project), "IssueEvent(id=1791768212)"
         )
 
     def testEvent_converted_note_to_issue_Attributes(self):
@@ -939,7 +901,6 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_converted_note_to_issue.rename, None)
         self.assertEqual(self.event_converted_note_to_issue.dismissed_review, None)
         self.assertEqual(self.event_converted_note_to_issue.lock_reason, None)
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.event_converted_note_to_issue.__repr__(), "IssueEvent(id=1791769149)"
+            repr(self.event_converted_note_to_issue), "IssueEvent(id=1791769149)"
         )

--- a/tests/Label.py
+++ b/tests/Label.py
@@ -44,9 +44,7 @@ class Label(Framework.TestCase):
         self.assertEqual(
             self.label.url, "https://api.github.com/repos/jacquev6/PyGithub/labels/Bug"
         )
-
-        # test __repr__() based on this attributes
-        self.assertEqual(self.label.__repr__(), 'Label(name="Bug")')
+        self.assertEqual(repr(self.label), 'Label(name="Bug")')
 
     def testEdit(self):
         self.label.edit(

--- a/tests/License.py
+++ b/tests/License.py
@@ -48,3 +48,12 @@ class License(Framework.TestCase):
         )
         self.assertEqual(self.license.conditions, ["include-copyright"])
         self.assertEqual(self.license.limitations, ["liability", "warranty"])
+        self.assertEqual(self.license.url, "https://api.github.com/licenses/mit")
+        self.assertEqual(
+            self.license.html_url, "http://choosealicense.com/licenses/mit/"
+        )
+        self.assertEqual(
+            self.license.implementation,
+            """Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders.""",
+        )
+        self.assertEqual(repr(self.license), 'License(name="MIT License")')

--- a/tests/Migration.py
+++ b/tests/Migration.py
@@ -78,6 +78,10 @@ class Migration(Framework.TestCase):
         self.assertEqual(
             self.migration.updated_at, datetime.datetime(2018, 9, 14, 1, 35, 46)
         )
+        self.assertEqual(
+            repr(self.migration),
+            'Migration(url="https://api.github.com/user/migrations/25320", state="exported")',
+        )
 
     def testGetArchiveUrlWhenNotExported(self):
         self.assertRaises(

--- a/tests/Milestone.py
+++ b/tests/Milestone.py
@@ -55,10 +55,8 @@ class Milestone(Framework.TestCase):
             "https://api.github.com/repos/jacquev6/PyGithub/milestones/1",
         )
         self.assertEqual(self.milestone.creator.login, "jacquev6")
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.milestone.__repr__(), 'Milestone(title="Version 0.4", number=1)'
+            repr(self.milestone), 'Milestone(title="Version 0.4", number=1)'
         )
 
     def testEditWithMinimalParameters(self):

--- a/tests/NamedUser.py
+++ b/tests/NamedUser.py
@@ -75,9 +75,7 @@ class NamedUser(Framework.TestCase):
         self.assertEqual(self.user.type, "User")
         self.assertEqual(self.user.url, "https://api.github.com/users/nvie")
         self.assertEqual(self.user.node_id, "MDQ6VXNlcjgzODQ0")
-
-        # test __repr__() based on this attributes
-        self.assertEqual(self.user.__repr__(), 'NamedUser(login="nvie")')
+        self.assertEqual(repr(self.user), 'NamedUser(login="nvie")')
 
     def testAttributesOfSelf(self):
         self.assertEqual(
@@ -115,9 +113,8 @@ class NamedUser(Framework.TestCase):
         self.assertEqual(self.user.type, "User")
         self.assertEqual(self.user.url, "https://api.github.com/users/jacquev6")
         self.assertEqual(self.user.node_id, "MDQ6VXNlcjMyNzE0Ng==")
-
-        # test __repr__() based on this attributes
-        self.assertEqual(self.user.__repr__(), 'NamedUser(login="jacquev6")')
+        self.assertEqual(repr(self.user), 'NamedUser(login="jacquev6")')
+        self.assertEqual(repr(self.user.plan), 'Plan(name="micro")')
 
     def testGetGists(self):
         self.assertListKeyEqual(

--- a/tests/Organization.py
+++ b/tests/Organization.py
@@ -89,9 +89,7 @@ class Organization(Framework.TestCase):
         self.assertEqual(self.org.two_factor_requirement_enabled, None)
         self.assertEqual(self.org.type, "Organization")
         self.assertEqual(self.org.url, "https://api.github.com/orgs/BeaverSoftware")
-
-        # test __repr__() based on this attributes
-        self.assertEqual(self.org.__repr__(), 'Organization(login="BeaverSoftware")')
+        self.assertEqual(repr(self.org), 'Organization(login="BeaverSoftware")')
 
     def testAddMembersDefaultRole(self):
         lyloa = self.g.get_user("lyloa")

--- a/tests/Project.py
+++ b/tests/Project.py
@@ -37,6 +37,7 @@ class Project(Framework.TestCase):
         proj = self.g.get_project(pid)
         self.assertEqual(proj.id, pid)
         self.assertEqual(proj.name, "TestProject")
+        self.assertEqual(repr(proj), 'Project(name="TestProject")')
 
     def testGetOrganizationProjects(self):
         expectedProjects = ["Project1", "Project2", "Project3"]
@@ -93,6 +94,7 @@ class Project(Framework.TestCase):
         )
         self.assertEqual(col.created_at.year, 2018)
         self.assertTrue(col.updated_at >= col.created_at)
+        self.assertEqual(repr(col), 'ProjectColumn(name="To Do")')
 
     # See https://developer.github.com/v3/projects/cards/#get-a-project-card
     def testProjectCardAttributes(self):
@@ -115,6 +117,7 @@ class Project(Framework.TestCase):
         self.assertEqual(card.created_at.year, 2018)
         self.assertTrue(card.updated_at >= card.created_at)
         self.assertFalse(card.archived)
+        self.assertEqual(repr(card), "ProjectCard(id=11780055)")
 
     def testGetProjectCardContent(self):
         proj = self.g.get_project(1682941)

--- a/tests/PullRequest.py
+++ b/tests/PullRequest.py
@@ -138,11 +138,12 @@ class PullRequest(Framework.TestCase):
         self.assertEqual(self.pull.user.login, "jacquev6")
         self.assertEqual(self.pull.draft, None)
         self.assertEqual(self.pull.maintainer_can_modify, None)
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.pull.__repr__(),
-            'PullRequest(title="Title edited by PyGithub", number=31)',
+            repr(self.pull), 'PullRequest(title="Title edited by PyGithub", number=31)',
+        )
+        self.assertEqual(
+            repr(self.pull.base),
+            'PullRequestPart(sha="ed866fc43833802ab553e5ff8581c81bb00dd433")',
         )
 
     def testCreateComment(self):
@@ -365,6 +366,10 @@ class PullRequest(Framework.TestCase):
         self.assertTrue(status.merged)
         self.assertEqual(status.message, "Pull Request successfully merged")
         self.assertTrue(self.pull.is_merged())
+        self.assertEqual(
+            repr(status),
+            'PullRequestMergeStatus(sha="688208b1a5a074871d0e9376119556897439697d", merged=True)',
+        )
 
     def testMergeWithCommitMessage(self):
         self.g.get_user().get_repo("PyGithub").get_pull(39).merge(

--- a/tests/PullRequestComment.py
+++ b/tests/PullRequestComment.py
@@ -68,10 +68,8 @@ class PullRequestComment(Framework.TestCase):
             self.comment.html_url,
             "https://github.com/jacquev6/PyGithub/pull/170#issuecomment-18637907",
         )
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.comment.__repr__(),
+            repr(self.comment),
             'PullRequestComment(user=NamedUser(login="jacquev6"), id=886298)',
         )
 

--- a/tests/PullRequestFile.py
+++ b/tests/PullRequestFile.py
@@ -55,9 +55,7 @@ class PullRequestFile(Framework.TestCase):
         )
         self.assertEqual(self.file.sha, "8a4f306d4b223682dd19410d4a9150636ebe4206")
         self.assertEqual(self.file.status, "modified")
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.file.__repr__(),
+            repr(self.file),
             'File(sha="8a4f306d4b223682dd19410d4a9150636ebe4206", filename="codegen/templates/GithubObject.py")',
         )

--- a/tests/PullRequestReview.py
+++ b/tests/PullRequestReview.py
@@ -77,9 +77,7 @@ class PullRequestReview(Framework.TestCase):
             self.pullreview.submitted_at, datetime.datetime(2017, 3, 22, 19, 6, 59)
         )
         self.assertIn(self.created_pullreview, self.pullreviews)
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.pullreview.__repr__(),
+            repr(self.pullreview),
             'PullRequestReview(user=NamedUser(login="jzelinskie"), id=28482091)',
         )

--- a/tests/RateLimiting.py
+++ b/tests/RateLimiting.py
@@ -46,6 +46,10 @@ class RateLimiting(Framework.TestCase):
     def testGetRateLimit(self):
         rateLimit = self.g.get_rate_limit()
         self.assertEqual(
+            repr(rateLimit),
+            "RateLimit(core=Rate(reset=2018-09-05 04:55:56, remaining=4929, limit=5000))",
+        )
+        self.assertEqual(
             repr(rateLimit.core),
             "Rate(reset=2018-09-05 04:55:56, remaining=4929, limit=5000)",
         )

--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -112,10 +112,9 @@ class Repository(Framework.TestCase):
             self.repo.url, "https://api.github.com/repos/jacquev6/PyGithub"
         )
         self.assertEqual(self.repo.watchers, 15)
-
-        # test __repr__() based on this attributes
+        self.assertEqual(repr(self.repo), 'Repository(full_name="jacquev6/PyGithub")')
         self.assertEqual(
-            self.repo.__repr__(), 'Repository(full_name="jacquev6/PyGithub")'
+            repr(self.repo.permissions), "Permissions(push=True, pull=True, admin=True)"
         )
 
     def testEditWithoutArguments(self):
@@ -1075,8 +1074,9 @@ class Repository(Framework.TestCase):
 
     def testGetStargazersWithDates(self):
         repo = self.g.get_user("danvk").get_repo("comparea")
+        stargazers = repo.get_stargazers_with_dates()
         self.assertListKeyEqual(
-            repo.get_stargazers_with_dates(),
+            stargazers,
             lambda stargazer: (stargazer.starred_at, stargazer.user.login),
             [
                 (datetime.datetime(2014, 8, 13, 19, 22, 5), u"sAlexander"),
@@ -1087,6 +1087,7 @@ class Repository(Framework.TestCase):
                 (datetime.datetime(2015, 5, 9, 19, 14, 45), u"JoePython1"),
             ],
         )
+        self.assertEqual(repr(stargazers[0]), 'Stargazer(user="sAlexander")')
 
     def testGetSubscribers(self):
         self.assertListKeyEqual(
@@ -1225,17 +1226,17 @@ class Repository(Framework.TestCase):
     def testCreateFile(self):
         newFile = "doc/testCreateUpdateDeleteFile.md"
         content = "Hello world".encode()
+        author = github.InputGitAuthor(
+            "Enix Yu", "enix223@163.com", "2016-01-15T16:13:30+12:00"
+        )
+        self.assertEqual(repr(author), 'InputGitAuthor(name="Enix Yu")')
         self.repo.create_file(
             path=newFile,
             message="Create file for testCreateFile",
             content=content,
             branch="master",
-            committer=github.InputGitAuthor(
-                "Enix Yu", "enix223@163.com", "2016-01-15T16:13:30+12:00"
-            ),
-            author=github.InputGitAuthor(
-                "Enix Yu", "enix223@163.com", "2016-01-15T16:13:30+12:00"
-            ),
+            committer=author,
+            author=author,
         )
 
     def testUpdateFile(self):

--- a/tests/RepositoryKey.py
+++ b/tests/RepositoryKey.py
@@ -55,10 +55,8 @@ class RepositoryKey(Framework.TestCase):
         )
         self.assertEqual(self.key.created_at, datetime.datetime(2017, 2, 22, 8, 16, 23))
         self.assertTrue(self.key.verified)
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.key.__repr__(), 'RepositoryKey(title="PyGithub Test Key", id=21870881)'
+            repr(self.key), 'RepositoryKey(title="PyGithub Test Key", id=21870881)'
         )
 
     def testDelete(self):

--- a/tests/Tag.py
+++ b/tests/Tag.py
@@ -47,9 +47,7 @@ class Tag(Framework.TestCase):
         self.assertEqual(
             self.tag.zipball_url, "https://github.com/jacquev6/PyGithub/zipball/v0.3"
         )
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.tag.__repr__(),
+            repr(self.tag),
             'Tag(name="v0.3", commit=Commit(sha="636e6112deb72277b3bffcc3303cd7e8a7431a5d"))',
         )

--- a/tests/Team.py
+++ b/tests/Team.py
@@ -56,10 +56,8 @@ class Team(Framework.TestCase):
         self.assertEqual(self.team.organization, self.org)
         self.assertEqual(self.team.privacy, "closed")
         self.assertEqual(self.team.parent, None)
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.team.__repr__(), 'Team(name="Team created by PyGithub", id=189850)'
+            repr(self.team), 'Team(name="Team created by PyGithub", id=189850)'
         )
 
     def testDiscussions(self):
@@ -89,6 +87,7 @@ class Team(Framework.TestCase):
         self.assertEqual(d.title, "TITLE")
         self.assertEqual(d.updated_at, datetime(2019, 10, 8, 21, 3, 36))
         self.assertEqual(d.url, "https://api.github.com/teams/189850/discussions/1")
+        self.assertEqual(repr(d), 'TeamDiscussion(title="TITLE", number=1)')
 
     def testMembers(self):
         user = self.g.get_user("jacquev6")

--- a/tests/Traffic.py
+++ b/tests/Traffic.py
@@ -43,6 +43,10 @@ class Traffic(Framework.TestCase):
         self.assertEqual(referrerResponse[0].uniques, 1)
         self.assertEqual(referrerResponse[0].referrer, "github.com")
         self.assertEqual(referrerResponse[0].count, 5)
+        self.assertEqual(
+            repr(referrerResponse[0]),
+            'Referrer(uniques=1, referrer="github.com", count=5)',
+        )
 
     def testGetPaths(self):
         pathsResponse = self.repo.get_top_paths()
@@ -54,6 +58,10 @@ class Traffic(Framework.TestCase):
             pathsResponse[0].title,
             "jkufro/PyGithub: Typed interactions with the GitHub API v3",
         )
+        self.assertEqual(
+            repr(pathsResponse[0]),
+            'Path(uniques=4, title="jkufro/PyGithub: Typed interactions with the GitHub API v3", path="/jkufro/PyGithub", count=23)',
+        )
 
     def testGetViews(self):
         viewsResponse = self.repo.get_views_traffic()
@@ -64,6 +72,9 @@ class Traffic(Framework.TestCase):
         self.assertEqual(view_obj.uniques, 4)
         self.assertEqual(view_obj.timestamp, datetime.datetime(2018, 11, 27, 0, 0))
         self.assertEqual(view_obj.count, 56)
+        self.assertEqual(
+            repr(view_obj), "View(uniques=4, timestamp=2018-11-27 00:00:00, count=56)"
+        )
 
     def testGetClones(self):
         clonesResponse = self.repo.get_clones_traffic()
@@ -74,3 +85,6 @@ class Traffic(Framework.TestCase):
         self.assertEqual(clone_obj.uniques, 4)
         self.assertEqual(clone_obj.timestamp, datetime.datetime(2018, 11, 27, 0, 0))
         self.assertEqual(clone_obj.count, 4)
+        self.assertEqual(
+            repr(clone_obj), "Clones(uniques=4, timestamp=2018-11-27 00:00:00, count=4)"
+        )

--- a/tests/UserKey.py
+++ b/tests/UserKey.py
@@ -46,11 +46,8 @@ class UserKey(Framework.TestCase):
         self.assertEqual(self.key.title, "Key added through PyGithub")
         self.assertEqual(self.key.url, "https://api.github.com/user/keys/2626650")
         self.assertTrue(self.key.verified)
-
-        # test __repr__() based on this attributes
         self.assertEqual(
-            self.key.__repr__(),
-            'UserKey(title="Key added through PyGithub", id=2626650)',
+            repr(self.key), 'UserKey(title="Key added through PyGithub", id=2626650)',
         )
 
     def testDelete(self):


### PR DESCRIPTION
A lot of our missing coverage is caused by not checking repr(), which is
trivial enough to test against -- do so, and also clean up existing repr
tests to look the same by calling repr(). Where it was trivial, add a
few assertions about missing attributes.