### PR TITLE
Turn on coverage reporting for codecov

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,4 +24,4 @@ jobs:
         if: matrix.python-version == 3.6
         uses: codecov/codecov-action@v1
         with:
-          file: ./.coverage
+          file: ./coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@
 /MANIFEST
 /PyGithub.egg-info/
 /.coverage
+/coverage.xml
 /.idea
 /developer.github.com/
 /gh-pages/

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ python =
 
 [testenv]
 deps = -rtest-requirements.txt
-commands = pytest --cov=github {posargs}
+commands = pytest --cov=github --cov-report=xml {posargs}
 
 [testenv:lint]
 basepython = python3.6


### PR DESCRIPTION
Since we migrated from Travis to GitHub Actions, our coverage on codecov
has been reporting as 0%, since uploading the .coverage file is a
terrible idea. Turn on XML-based reporting, ignore the file and use that
when we upload to codecov.