### PR TITLE
Remove unneeded duplicate string checks in Branch

### DIFF
--- a/github/Branch.py
+++ b/github/Branch.py
@@ -143,18 +143,16 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         """
         assert strict is github.GithubObject.NotSet or isinstance(strict, bool), strict
         assert contexts is github.GithubObject.NotSet or all(
-            isinstance(element, str) or isinstance(element, str) for element in contexts
+            isinstance(element, str) for element in contexts
         ), contexts
         assert enforce_admins is github.GithubObject.NotSet or isinstance(
             enforce_admins, bool
         ), enforce_admins
         assert dismissal_users is github.GithubObject.NotSet or all(
-            isinstance(element, str) or isinstance(element, str)
-            for element in dismissal_users
+            isinstance(element, str) for element in dismissal_users
         ), dismissal_users
         assert dismissal_teams is github.GithubObject.NotSet or all(
-            isinstance(element, str) or isinstance(element, str)
-            for element in dismissal_teams
+            isinstance(element, str) for element in dismissal_teams
         ), dismissal_teams
         assert dismiss_stale_reviews is github.GithubObject.NotSet or isinstance(
             dismiss_stale_reviews, bool
@@ -277,7 +275,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         """
         assert strict is github.GithubObject.NotSet or isinstance(strict, bool), strict
         assert contexts is github.GithubObject.NotSet or all(
-            isinstance(element, str) or isinstance(element, str) for element in contexts
+            isinstance(element, str) for element in contexts
         ), contexts
 
         post_parameters = {}
@@ -330,12 +328,10 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         :required_approving_review_count: int
         """
         assert dismissal_users is github.GithubObject.NotSet or all(
-            isinstance(element, str) or isinstance(element, str)
-            for element in dismissal_users
+            isinstance(element, str) for element in dismissal_users
         ), dismissal_users
         assert dismissal_teams is github.GithubObject.NotSet or all(
-            isinstance(element, str) or isinstance(element, str)
-            for element in dismissal_teams
+            isinstance(element, str) for element in dismissal_teams
         ), dismissal_teams
         assert dismiss_stale_reviews is github.GithubObject.NotSet or isinstance(
             dismiss_stale_reviews, bool
@@ -433,9 +429,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         :calls: `POST /repos/:owner/:repo/branches/:branch/protection/restrictions/users <https://developer.github.com/v3/repos/branches>`_
         :users: list of strings (user names)
         """
-        assert all(
-            isinstance(element, str) or isinstance(element, str) for element in users
-        ), users
+        assert all(isinstance(element, str) for element in users), users
 
         headers, data = self._requester.requestJsonAndCheck(
             "POST", self.protection_url + "/restrictions/users", input=users
@@ -446,9 +440,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         :calls: `PUT /repos/:owner/:repo/branches/:branch/protection/restrictions/users <https://developer.github.com/v3/repos/branches>`_
         :users: list of strings (user names)
         """
-        assert all(
-            isinstance(element, str) or isinstance(element, str) for element in users
-        ), users
+        assert all(isinstance(element, str) for element in users), users
 
         headers, data = self._requester.requestJsonAndCheck(
             "PUT", self.protection_url + "/restrictions/users", input=users
@@ -459,9 +451,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         :calls: `DELETE /repos/:owner/:repo/branches/:branch/protection/restrictions/users <https://developer.github.com/v3/repos/branches>`_
         :users: list of strings (user names)
         """
-        assert all(
-            isinstance(element, str) or isinstance(element, str) for element in users
-        ), users
+        assert all(isinstance(element, str) for element in users), users
 
         headers, data = self._requester.requestJsonAndCheck(
             "DELETE", self.protection_url + "/restrictions/users", input=users
@@ -472,9 +462,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         :calls: `POST /repos/:owner/:repo/branches/:branch/protection/restrictions/teams <https://developer.github.com/v3/repos/branches>`_
         :teams: list of strings (team slugs)
         """
-        assert all(
-            isinstance(element, str) or isinstance(element, str) for element in teams
-        ), teams
+        assert all(isinstance(element, str) for element in teams), teams
 
         headers, data = self._requester.requestJsonAndCheck(
             "POST", self.protection_url + "/restrictions/teams", input=teams
@@ -485,9 +473,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         :calls: `PUT /repos/:owner/:repo/branches/:branch/protection/restrictions/teams <https://developer.github.com/v3/repos/branches>`_
         :teams: list of strings (team slugs)
         """
-        assert all(
-            isinstance(element, str) or isinstance(element, str) for element in teams
-        ), teams
+        assert all(isinstance(element, str) for element in teams), teams
 
         headers, data = self._requester.requestJsonAndCheck(
             "PUT", self.protection_url + "/restrictions/teams", input=teams
@@ -498,9 +484,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         :calls: `DELETE /repos/:owner/:repo/branches/:branch/protection/restrictions/teams <https://developer.github.com/v3/repos/branches>`_
         :teams: list of strings (team slugs)
         """
-        assert all(
-            isinstance(element, str) or isinstance(element, str) for element in teams
-        ), teams
+        assert all(isinstance(element, str) for element in teams), teams
 
         headers, data = self._requester.requestJsonAndCheck(
             "DELETE", self.protection_url + "/restrictions/teams", input=teams


### PR DESCRIPTION
There were multiple calls checking if an element of a list was a string
or a string -- I suspect this pre-dates use of six in the code base, but
let's clean it up.