### PR TITLE
PullRequestReview is not a completable object

### DIFF
--- a/github/PullRequestReview.py
+++ b/github/PullRequestReview.py
@@ -30,7 +30,7 @@ import github.GithubObject
 import github.NamedUser
 
 
-class PullRequestReview(github.GithubObject.CompletableGithubObject):
+class PullRequestReview(github.GithubObject.NonCompletableGithubObject):
     """
     This class represents PullRequestReviews. The reference can be found here https://developer.github.com/v3/pulls/reviews/
     """
@@ -43,7 +43,6 @@ class PullRequestReview(github.GithubObject.CompletableGithubObject):
         """
         :type: integer
         """
-        self._completeIfNotSet(self._id)
         return self._id.value
 
     @property
@@ -51,7 +50,6 @@ class PullRequestReview(github.GithubObject.CompletableGithubObject):
         """
         :type: :class:`github.NamedUser.NamedUser`
         """
-        self._completeIfNotSet(self._user)
         return self._user.value
 
     @property
@@ -59,7 +57,6 @@ class PullRequestReview(github.GithubObject.CompletableGithubObject):
         """
         :type: string
         """
-        self._completeIfNotSet(self._body)
         return self._body.value
 
     @property
@@ -67,7 +64,6 @@ class PullRequestReview(github.GithubObject.CompletableGithubObject):
         """
         :type: string
         """
-        self._completeIfNotSet(self._commit_id)
         return self._commit_id.value
 
     @property
@@ -75,23 +71,13 @@ class PullRequestReview(github.GithubObject.CompletableGithubObject):
         """
         :type: string
         """
-        self._completeIfNotSet(self._state)
         return self._state.value
-
-    @property
-    def url(self):
-        """
-        :type: string
-        """
-        self._completeIfNotSet(self._url)
-        return self._url.value
 
     @property
     def html_url(self):
         """
         :type: string
         """
-        self._completeIfNotSet(self._html_url)
         return self._html_url.value
 
     @property
@@ -99,7 +85,6 @@ class PullRequestReview(github.GithubObject.CompletableGithubObject):
         """
         :type: string
         """
-        self._completeIfNotSet(self._pull_request_url)
         return self._pull_request_url.value
 
     @property
@@ -107,7 +92,6 @@ class PullRequestReview(github.GithubObject.CompletableGithubObject):
         """
         :type: datetime.datetime
         """
-        self._completeIfNotSet(self._submitted_at)
         return self._submitted_at.value
 
     def dismiss(self, message):
@@ -129,7 +113,6 @@ class PullRequestReview(github.GithubObject.CompletableGithubObject):
         self._body = github.GithubObject.NotSet
         self._commit_id = github.GithubObject.NotSet
         self._state = github.GithubObject.NotSet
-        self._url = github.GithubObject.NotSet
         self._html_url = github.GithubObject.NotSet
         self._pull_request_url = github.GithubObject.NotSet
         self._submitted_at = github.GithubObject.NotSet
@@ -147,8 +130,6 @@ class PullRequestReview(github.GithubObject.CompletableGithubObject):
             self._commit_id = self._makeStringAttribute(attributes["commit_id"])
         if "state" in attributes:  # pragma no branch
             self._state = self._makeStringAttribute(attributes["state"])
-        if "url" in attributes:  # pragma no branch
-            self._url = self._makeStringAttribute(attributes["url"])
         if "html_url" in attributes:  # pragma no branch
             self._html_url = self._makeStringAttribute(attributes["html_url"])
         if "pull_request_url" in attributes:  # pragma no branch

--- a/tests/PullRequestReview.py
+++ b/tests/PullRequestReview.py
@@ -76,7 +76,7 @@ class PullRequestReview(Framework.TestCase):
         self.assertEqual(
             self.pullreview.submitted_at, datetime.datetime(2017, 3, 22, 19, 6, 59)
         )
-        self.assertIn(self.created_pullreview, self.pullreviews)
+        self.assertIn(self.created_pullreview.id, [r.id for r in self.pullreviews])
         self.assertEqual(
             repr(self.pullreview),
             'PullRequestReview(user=NamedUser(login="jzelinskie"), id=28482091)',


### PR DESCRIPTION
While chasing coverage failures, I discovered PullRequestReview's do not
send back a URL at all, which means firstly, the url property is not
required because it will always be None, and secondly, the object can
never be completed. I'm not certain why this change broke the test, but
it looked brittle, refactor it to be clearer.