### PR TITLE
Remove RateLimit.rate

### DIFF
--- a/github/RateLimit.py
+++ b/github/RateLimit.py
@@ -27,8 +27,6 @@
 #                                                                              #
 ################################################################################
 
-from deprecated import deprecated
-
 import github.GithubObject
 import github.Rate
 
@@ -40,23 +38,6 @@ class RateLimit(github.GithubObject.NonCompletableGithubObject):
 
     def __repr__(self):
         return self.get__repr__({"core": self._core.value})
-
-    @property
-    @deprecated(
-        reason="""
-            The rate object is deprecated. If you're writing new API client code
-            or updating existing code, you should use the core object instead of
-            the rate object. The core object contains the same information that
-            is present in the rate object.
-        """
-    )
-    def rate(self):  # pragma: no cover
-        """
-        (Deprecated) Rate limit for non-search-related API, use `core` instead
-
-        :type: class:`github.Rate.Rate`
-        """
-        return self._core.value
 
     @property
     def core(self):


### PR DESCRIPTION
RateLimit.rate was first deprecated in v1.43.2, which was released 20
months ago. As that's a fairly generous deprecation period, remove it.