### PR TITLE
Repository.update_file() content also accepts bytes

### DIFF
--- a/github/Repository.pyi
+++ b/github/Repository.pyi
@@ -504,7 +504,7 @@ class Repository(CompletableGithubObject):
         self,
         path: str,
         message: str,
-        content: str,
+        content: Union[bytes, str],
         sha: str,
         branch: Union[_NotSetType, str] = ...,
         committer: Union[_NotSetType, InputGitAuthor] = ...,


### PR DESCRIPTION
The typing information for the update_file() method's content parameter
states it will only accept str, whereas it will accept both str and
bytes.

Fixes #1542