### PR TITLE
Remove "api_preview" parameter from type stubs and docstrings

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -115,7 +115,6 @@ class Github(object):
         :param client_secret: string
         :param user_agent: string
         :param per_page: int
-        :param api_preview: bool
         :param verify: boolean or string
         :param retry: int or urllib3.util.retry.Retry object
         """

--- a/github/MainClass.pyi
+++ b/github/MainClass.pyi
@@ -38,7 +38,6 @@ class Github:
         client_secret: Optional[str] = ...,
         user_agent: str = ...,
         per_page: int = ...,
-        api_preview: bool = ...,
         verify: bool = ...,
         retry: Any = ...,
     ) -> None: ...

--- a/github/Requester.pyi
+++ b/github/Requester.pyi
@@ -104,7 +104,6 @@ class Requester:
         client_secret: Optional[str],
         user_agent: str,
         per_page: int,
-        api_preview: bool,
         verify: bool,
         retry: Any,
     ) -> None: ...


### PR DESCRIPTION
mypy complains about the `api_preview` parameter but it does not exist anymore.