### PR TITLE
Small documentation correction in Repository.py

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1939,7 +1939,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         """
         :calls: `GET /repos/:owner/:repo/traffic/clones <https://developer.github.com/v3/repos/traffic/>`_
         :param per: string, must be one of day or week, day by default
-        :rtype: None or list of :class:`github.Clone.Clone`
+        :rtype: None or list of :class:`github.Clones.Clones`
         """
         assert per is github.GithubObject.NotSet or (
             isinstance(per, str) and (per == "day" or per == "week")


### PR DESCRIPTION
Class `github.Clone.Clone` doesn't exist and should reference `github.Clones.Clones` instead.

Short and simple PR, fixing this makes the documentation more accurate, and makes navigation in readthedocs easier.