### PR TITLE
Do not check reaction_type before sending

### DIFF
--- a/github/CommitComment.py
+++ b/github/CommitComment.py
@@ -177,16 +177,7 @@ class CommitComment(github.GithubObject.CompletableGithubObject):
         :param reaction_type: string
         :rtype: :class:`github.Reaction.Reaction`
         """
-        assert isinstance(reaction_type, str), "reaction type should be a string"
-        assert reaction_type in [
-            "+1",
-            "-1",
-            "laugh",
-            "confused",
-            "heart",
-            "hooray",
-        ], "Invalid reaction type (https://developer.github.com/v3/reactions/#reaction-types)"
-
+        assert isinstance(reaction_type, str), reaction_type
         post_parameters = {
             "content": reaction_type,
         }

--- a/github/Issue.py
+++ b/github/Issue.py
@@ -573,16 +573,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
         :param reaction_type: string
         :rtype: :class:`github.Reaction.Reaction`
         """
-        assert isinstance(reaction_type, str), "reaction type should be a string"
-        assert reaction_type in [
-            "+1",
-            "-1",
-            "laugh",
-            "confused",
-            "heart",
-            "hooray",
-        ], "Invalid reaction type (https://developer.github.com/v3/reactions/#reaction-types)"
-
+        assert isinstance(reaction_type, str), reaction_type
         post_parameters = {
             "content": reaction_type,
         }

--- a/github/IssueComment.py
+++ b/github/IssueComment.py
@@ -154,16 +154,7 @@ class IssueComment(github.GithubObject.CompletableGithubObject):
         :param reaction_type: string
         :rtype: :class:`github.Reaction.Reaction`
         """
-        assert isinstance(reaction_type, str), "reaction type should be a string"
-        assert reaction_type in [
-            "+1",
-            "-1",
-            "laugh",
-            "confused",
-            "heart",
-            "hooray",
-        ], "Invalid reaction type (https://developer.github.com/v3/reactions/#reaction-types)"
-
+        assert isinstance(reaction_type, str), reaction_type
         post_parameters = {
             "content": reaction_type,
         }

--- a/github/PullRequestComment.py
+++ b/github/PullRequestComment.py
@@ -211,16 +211,7 @@ class PullRequestComment(github.GithubObject.CompletableGithubObject):
         :param reaction_type: string
         :rtype: :class:`github.Reaction.Reaction`
         """
-        assert isinstance(reaction_type, str), "reaction type should be a string"
-        assert reaction_type in [
-            "+1",
-            "-1",
-            "laugh",
-            "confused",
-            "heart",
-            "hooray",
-        ], "Invalid reaction type (https://developer.github.com/v3/reactions/#reaction-types)"
-
+        assert isinstance(reaction_type, str), reaction_type
         post_parameters = {
             "content": reaction_type,
         }


### PR DESCRIPTION
There is a bunch of repeated code checking reactions which has the issue
that it can easily get out of date with what GitHub accepts. Drop the
check, and rely on GitHub returning an error.

Fixes #1554