### PR TITLE
Check for updates to GitHub Actions every weekday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Now that dependabot is native to GitHub and the fact that this project makes use of GitHub actions, I think it would be nice if dependabot were to send automatic PR's of version bumps to outdated GitHub actions.