### PR TITLE
more flexible header splitting

### DIFF
--- a/github/PaginatedList.py
+++ b/github/PaginatedList.py
@@ -230,7 +230,7 @@ class PaginatedList(PaginatedListBase):
         if "link" in headers:
             linkHeaders = headers["link"].split(", ")
             for linkHeader in linkHeaders:
-                (url, rel) = linkHeader.split("; ")
+                url, rel, *rest = linkHeader.split("; ")
                 url = url[1:-1]
                 rel = rel[5:-1]
                 links[rel] = url

--- a/github/PaginatedList.py
+++ b/github/PaginatedList.py
@@ -230,7 +230,7 @@ class PaginatedList(PaginatedListBase):
         if "link" in headers:
             linkHeaders = headers["link"].split(", ")
             for linkHeader in linkHeaders:
-                url, rel, *rest = linkHeader.split("; ")
+                url, rel, _ = linkHeader.split("; ")
                 url = url[1:-1]
                 rel = rel[5:-1]
                 links[rel] = url

--- a/github/PaginatedList.py
+++ b/github/PaginatedList.py
@@ -230,7 +230,7 @@ class PaginatedList(PaginatedListBase):
         if "link" in headers:
             linkHeaders = headers["link"].split(", ")
             for linkHeader in linkHeaders:
-                url, rel, _ = linkHeader.split("; ")
+                url, rel, *rest = linkHeader.split("; ")
                 url = url[1:-1]
                 rel = rel[5:-1]
                 links[rel] = url


### PR DESCRIPTION
When using get_authorizations() from AuthenticatedUser headers["link"] is:
` '<https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/>; rel="deprecation"; type="text/html"' ` and thus it fails. With this approach, it will just discard `type="text/html"` part and will not affect other calls.