### PR TITLE
Add delete_branch_on_merge arg to Repository.edit type stub

### DIFF
--- a/github/Repository.pyi
+++ b/github/Repository.pyi
@@ -230,6 +230,7 @@ class Repository(CompletableGithubObject):
         allow_squash_merge: Union[bool, _NotSetType] = ...,
         allow_merge_commit: Union[bool, _NotSetType] = ...,
         allow_rebase_merge: Union[bool, _NotSetType] = ...,
+        delete_branch_on_merge: Union[bool, _NotSetType] = ...,
         archived: Union[bool, _NotSetType] = ...,
     ) -> None: ...
     def enable_automated_security_fixes(self) -> bool: ...


### PR DESCRIPTION
#### example
```python3
from github import Github

Github().get_repo("").edit(
    has_issues=False,
    has_projects=False,
    has_wiki=False,
    default_branch="master",
    allow_squash_merge=False,
    allow_merge_commit=True,
    allow_rebase_merge=False,
    delete_branch_on_merge=False,
)
```

#### before changes
```console
% mypy example.py
example.py:3: error: Unexpected keyword argument "delete_branch_on_merge" for "edit" of "Repository"
github/Repository.pyi:219: note: "edit" of "Repository" defined here
Found 1 error in 1 file (checked 1 source file)
```

#### after changes
```console
% mypy example.py
Success: no issues found in 1 source file
```