### PR TITLE
PaginatedList's totalCount is 0 if no last page

### DIFF
--- a/github/PaginatedList.py
+++ b/github/PaginatedList.py
@@ -163,7 +163,10 @@ class PaginatedList(PaginatedListBase):
             else:
                 links = self.__parseLinkHeader(headers)
                 lastUrl = links.get("last")
-                self.__totalCount = int(parse_qs(lastUrl)["page"][0])
+                if lastUrl:
+                    self.__totalCount = int(parse_qs(lastUrl)["page"][0])
+                else:
+                    self.__totalCount = 0
         return self.__totalCount
 
     def _getLastPageUrl(self):

--- a/tests/PaginatedList.py
+++ b/tests/PaginatedList.py
@@ -270,6 +270,11 @@ class PaginatedList(Framework.TestCase):
             if count == 75:
                 break
 
+    def testTotalCountWithNoLastPage(self):
+        # Fudged replay data, we don't need the data, only the headers
+        repos = self.g.get_repos()
+        self.assertEqual(0, repos.totalCount)
+
     def testCustomPerPage(self):
         self.assertEqual(self.g.per_page, 30)
         self.g.per_page = 100

--- a/tests/ReplayData/PaginatedList.testTotalCountWithNoLastPage.txt
+++ b/tests/ReplayData/PaginatedList.testTotalCountWithNoLastPage.txt
@@ -1,0 +1,11 @@
+https
+GET
+api.github.com
+None
+/repositories?per_page=1
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+None
+200
+[('Date', 'Mon, 03 Aug 2020 09:02:17 GMT'), ('Content-Type', 'application/json; charset=utf-8'), ('Transfer-Encoding', 'chunked'), ('Server', 'GitHub.com'), ('Status', '200 OK'), ('X-RateLimit-Limit', '5000'), ('X-RateLimit-Remaining', '4996'), ('X-RateLimit-Reset', '1596448362'), ('Cache-Control', 'private, max-age=60, s-maxage=60'), ('Vary', 'Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept, X-Requested-With, Accept-Encoding'), ('ETag', 'W/"d773714fdca21c9206d9d35e50fcd1ff"'), ('X-OAuth-Scopes', 'admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete:packages, delete_repo, gist, notifications, read:packages, repo, user, workflow, write:discussion, write:packages'), ('X-Accepted-OAuth-Scopes', ''), ('X-GitHub-Media-Type', 'github.v3; format=json'), ('Link', '<https://api.github.com/repositories?per_page=1&since=369>; rel="next", <https://api.github.com/repositories{?since}>; rel="first"'), ('Access-Control-Expose-Headers', 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset'), ('Access-Control-Allow-Origin', '*'), ('Strict-Transport-Security', 'max-age=31536000; includeSubdomains; preload'), ('X-Frame-Options', 'deny'), ('X-Content-Type-Options', 'nosniff'), ('X-XSS-Protection', '1; mode=block'), ('Referrer-Policy', 'origin-when-cross-origin, strict-origin-when-cross-origin'), ('Content-Security-Policy', "default-src 'none'"), ('Content-Encoding', 'gzip'), ('X-GitHub-Request-Id', 'C662:025B:26F607:2FDFF2:5F27D299')]
+[]
+


### PR DESCRIPTION
When calculating totalCount for PaginatedList, if the links data does
not contain a last page, we can't know how many elements are contained
in the list. Set it to 0 in that case.

Fixes #1614 