### PR TITLE
Fix Repository.create_repository_dispatch type signature

### DIFF
--- a/github/Repository.pyi
+++ b/github/Repository.pyi
@@ -185,7 +185,7 @@ class Repository(CompletableGithubObject):
     @overload
     def create_pull(self, title: _NotSetType, body: _NotSetType, base: str, head: str, maintainer_can_modify: _NotSetType, issue: Issue) -> PullRequest: ...
     def create_repository_dispatch(
-        self, event_type: str, client_payload: Dict[str, str]
+        self, event_type: str, client_payload: Dict[str, object]
     ) -> bool: ...
     def create_source_import(
         self,

--- a/github/Repository.pyi
+++ b/github/Repository.pyi
@@ -185,7 +185,7 @@ class Repository(CompletableGithubObject):
     @overload
     def create_pull(self, title: _NotSetType, body: _NotSetType, base: str, head: str, maintainer_can_modify: _NotSetType, issue: Issue) -> PullRequest: ...
     def create_repository_dispatch(
-        self, event_type: str, client_payload: Dict[str, object]
+        self, event_type: str, client_payload: Dict[str, Any]
     ) -> bool: ...
     def create_source_import(
         self,


### PR DESCRIPTION
Not really sure why I initially thought this had to be `str -> str`. The endpoint accepts anything that can be encoded into JSON. Technically it accepts numbers, bools, and None as keys too, so perhaps the key type should be a Union... but 99% of people will only use strings so maybe this is ok. 