### PR TITLE
Format with new black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 20.8b1
     hooks:
       - id: black
         language_version: python3.6

--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -479,7 +479,10 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         else:
             request_header = None
         headers, data = self._requester.requestJsonAndCheck(
-            "POST", "/authorizations", input=post_parameters, headers=request_header,
+            "POST",
+            "/authorizations",
+            input=post_parameters,
+            headers=request_header,
         )
         return github.Authorization.Authorization(
             self._requester, headers, data, completed=True

--- a/github/Branch.py
+++ b/github/Branch.py
@@ -163,7 +163,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         assert (
             required_approving_review_count is github.GithubObject.NotSet
             or isinstance(required_approving_review_count, int)
-        ), required_approving_review_count
+        ), (required_approving_review_count)
 
         post_parameters = {}
         if (
@@ -250,7 +250,8 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         :calls: `DELETE /repos/:owner/:repo/branches/:branch/protection <https://developer.github.com/v3/repos/branches>`_
         """
         headers, data = self._requester.requestJsonAndCheck(
-            "DELETE", self.protection_url,
+            "DELETE",
+            self.protection_url,
         )
 
     def get_required_status_checks(self):
@@ -342,7 +343,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         assert (
             required_approving_review_count is github.GithubObject.NotSet
             or isinstance(required_approving_review_count, int)
-        ), required_approving_review_count
+        ), (required_approving_review_count)
 
         post_parameters = {}
         if dismissal_users is not github.GithubObject.NotSet:

--- a/github/Deployment.py
+++ b/github/Deployment.py
@@ -194,7 +194,9 @@ class Deployment(github.GithubObject.CompletableGithubObject):
         if description is not github.GithubObject.NotSet:
             post_parameters["description"] = description
         headers, data = self._requester.requestJsonAndCheck(
-            "POST", self.url + "/statuses", input=post_parameters,
+            "POST",
+            self.url + "/statuses",
+            input=post_parameters,
         )
         return github.DeploymentStatus.DeploymentStatus(
             self._requester, headers, data, completed=True

--- a/github/Notification.py
+++ b/github/Notification.py
@@ -118,7 +118,10 @@ class Notification(github.GithubObject.CompletableGithubObject):
         """
         :calls: `PATCH /notifications/threads/:id <https://developer.github.com/v3/activity/notifications/>`_
         """
-        headers, data = self._requester.requestJsonAndCheck("PATCH", self.url,)
+        headers, data = self._requester.requestJsonAndCheck(
+            "PATCH",
+            self.url,
+        )
 
     def get_pull_request(self):
         """

--- a/github/ProjectCard.py
+++ b/github/ProjectCard.py
@@ -168,7 +168,9 @@ class ProjectCard(github.GithubObject.CompletableGithubObject):
         :rtype: bool
         """
         status, _, _ = self._requester.requestJson(
-            "DELETE", self.url, headers={"Accept": Consts.mediaTypeProjectsPreview},
+            "DELETE",
+            self.url,
+            headers={"Accept": Consts.mediaTypeProjectsPreview},
         )
         return status == 204
 

--- a/github/ProjectColumn.py
+++ b/github/ProjectColumn.py
@@ -170,7 +170,9 @@ class ProjectColumn(github.GithubObject.CompletableGithubObject):
         :rtype: bool
         """
         status, _, _ = self._requester.requestJson(
-            "DELETE", self.url, headers={"Accept": Consts.mediaTypeProjectsPreview},
+            "DELETE",
+            self.url,
+            headers={"Accept": Consts.mediaTypeProjectsPreview},
         )
         return status == 204
 

--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -713,7 +713,8 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
         """
         assert isinstance(id, int), id
         headers, data = self._requester.requestJsonAndCheck(
-            "GET", self.url + "/reviews/" + str(id),
+            "GET",
+            self.url + "/reviews/" + str(id),
         )
         return github.PullRequestReview.PullRequestReview(
             self._requester, headers, data, completed=True

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -844,7 +844,8 @@ class Repository(github.GithubObject.CompletableGithubObject):
         if isinstance(collaborator, github.NamedUser.NamedUser):
             collaborator = collaborator._identity
         headers, data = self._requester.requestJsonAndCheck(
-            "GET", self.url + "/collaborators/" + collaborator + "/permission",
+            "GET",
+            self.url + "/collaborators/" + collaborator + "/permission",
         )
         return data["permission"]
 
@@ -1876,7 +1877,9 @@ class Repository(github.GithubObject.CompletableGithubObject):
         if description is not github.GithubObject.NotSet:
             post_parameters["description"] = description
         headers, data = self._requester.requestJsonAndCheck(
-            "POST", self.url + "/deployments", input=post_parameters,
+            "POST",
+            self.url + "/deployments",
+            input=post_parameters,
         )
         return github.Deployment.Deployment(
             self._requester, headers, data, completed=True
@@ -2245,7 +2248,9 @@ class Repository(github.GithubObject.CompletableGithubObject):
         if organization is not github.GithubObject.NotSet:
             post_parameters["organization"] = organization
         headers, data = self._requester.requestJsonAndCheck(
-            "POST", self.url + "/forks", input=post_parameters,
+            "POST",
+            self.url + "/forks",
+            input=post_parameters,
         )
         return Repository(self._requester, headers, data, completed=True)
 
@@ -2790,7 +2795,9 @@ class Repository(github.GithubObject.CompletableGithubObject):
         """
         import_header = {"Accept": Consts.mediaTypeImportPreview}
         headers, data = self._requester.requestJsonAndCheck(
-            "GET", self.url + "/import", headers=import_header,
+            "GET",
+            self.url + "/import",
+            headers=import_header,
         )
         if not data:
             return None

--- a/github/Team.py
+++ b/github/Team.py
@@ -319,7 +319,10 @@ class Team(github.GithubObject.CompletableGithubObject):
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Team.Team`
         """
         return github.PaginatedList.PaginatedList(
-            github.Team.Team, self._requester, self.url + "/teams", None,
+            github.Team.Team,
+            self._requester,
+            self.url + "/teams",
+            None,
         )
 
     def get_discussions(self):

--- a/tests/Commit.py
+++ b/tests/Commit.py
@@ -85,7 +85,8 @@ class Commit(Framework.TestCase):
             self.commit.commit.tree.sha, "4c6bd50994f0f9823f898b1c6c964ad7d4fa11ab"
         )
         self.assertEqual(
-            repr(self.commit), 'Commit(sha="1292bf0e22c796e91cc3d6e24b544aece8c21f2a")',
+            repr(self.commit),
+            'Commit(sha="1292bf0e22c796e91cc3d6e24b544aece8c21f2a")',
         )
 
     def testGetComments(self):

--- a/tests/DeploymentStatus.py
+++ b/tests/DeploymentStatus.py
@@ -58,7 +58,8 @@ class DeploymentStatus(Framework.TestCase):
             "https://api.github.com/repos/colbygallup/PyGithub/deployments/242997115/statuses/344110026",
         )
         self.assertEqual(
-            self.status.node_id, "MDE2OkRlcGxveW1lbnRTdGF0dXMzNDQxMTAwMjY=",
+            self.status.node_id,
+            "MDE2OkRlcGxveW1lbnRTdGF0dXMzNDQxMTAwMjY=",
         )
         self.assertEqual(
             repr(self.status),

--- a/tests/GitBlob.py
+++ b/tests/GitBlob.py
@@ -61,5 +61,6 @@ class GitBlob(Framework.TestCase):
             "https://api.github.com/repos/jacquev6/PyGithub/git/blobs/53bce9fa919b4544e67275089b3ec5b44be20667",
         )
         self.assertEqual(
-            repr(self.blob), 'GitBlob(sha="53bce9fa919b4544e67275089b3ec5b44be20667")',
+            repr(self.blob),
+            'GitBlob(sha="53bce9fa919b4544e67275089b3ec5b44be20667")',
         )

--- a/tests/GitTree.py
+++ b/tests/GitTree.py
@@ -72,7 +72,8 @@ class GitTree(Framework.TestCase):
         )
 
         self.assertEqual(
-            repr(self.tree), 'GitTree(sha="f492784d8ca837779650d1fb406a1a3587a764ad")',
+            repr(self.tree),
+            'GitTree(sha="f492784d8ca837779650d1fb406a1a3587a764ad")',
         )
         self.assertEqual(
             repr(self.tree.tree[0]),

--- a/tests/GithubApp.py
+++ b/tests/GithubApp.py
@@ -110,7 +110,8 @@ class GithubApp(Framework.TestCase):
         self.assertEqual(app.created_at, datetime(2020, 8, 1, 17, 23, 46))
         self.assertEqual(app.description, "Sample App to test PyGithub")
         self.assertListEqual(
-            app.events, ["check_run", "check_suite", "label", "member", "public"],
+            app.events,
+            ["check_run", "check_suite", "label", "member", "public"],
         )
         self.assertEqual(app.external_url, "https://pygithub.readthedocs.io")
         self.assertEqual(app.html_url, "https://github.com/apps/pygithubtest")

--- a/tests/GithubIntegration.py
+++ b/tests/GithubIntegration.py
@@ -135,7 +135,10 @@ class GithubIntegration(unittest.TestCase):
         integration = GithubIntegration(25216, private_key)
         token = integration.create_jwt()
         payload = jwt.decode(
-            token, key=public_key, algorithms=["RS256"], options={"verify_exp": False},
+            token,
+            key=public_key,
+            algorithms=["RS256"],
+            options={"verify_exp": False},
         )
         self.assertDictEqual(
             payload, {"iat": 1550055331, "exp": 1550055391, "iss": 25216}

--- a/tests/NamedUser1430.py
+++ b/tests/NamedUser1430.py
@@ -32,5 +32,7 @@ class NamedUser1430(Framework.TestCase):
 
     def testGetProjects(self):
         self.assertListKeyBegin(
-            self.user.get_projects(state="all"), lambda e: e.id, [4083095],
+            self.user.get_projects(state="all"),
+            lambda e: e.id,
+            [4083095],
         )

--- a/tests/Organization.py
+++ b/tests/Organization.py
@@ -239,10 +239,14 @@ class Organization(Framework.TestCase):
     def testGetReposSorted(self):
         repos = self.org.get_repos(sort="updated", direction="desc")
         self.assertListKeyEqual(
-            repos, lambda r: r.name, ["TestPyGithub", "FatherBeaver"],
+            repos,
+            lambda r: r.name,
+            ["TestPyGithub", "FatherBeaver"],
         )
         self.assertListKeyEqual(
-            repos, lambda r: r.has_pages, [False, True],
+            repos,
+            lambda r: r.has_pages,
+            [False, True],
         )
 
     def testGetReposWithType(self):

--- a/tests/Project.py
+++ b/tests/Project.py
@@ -171,14 +171,18 @@ class Project(Framework.TestCase):
         project = self.repo.create_project(
             "Project created by PyGithub", "Project Body"
         )
-        column = project.create_column("Project Column created by PyGithub",)
+        column = project.create_column(
+            "Project Column created by PyGithub",
+        )
         self.assertEqual(column.id, 3999333)
 
     def testCreateCardWithNote(self):
         project = self.repo.create_project(
             "Project created by PyGithub", "Project Body"
         )
-        column = project.create_column("Project Column created by PyGithub",)
+        column = project.create_column(
+            "Project Column created by PyGithub",
+        )
         card1 = column.create_card(note="Project Card")
         self.assertEqual(card1.id, 16039019)
 
@@ -186,7 +190,9 @@ class Project(Framework.TestCase):
         project = self.repo.create_project(
             "Project created by PyGithub", "Project Body"
         )
-        column = project.create_column("Project Column created by PyGithub",)
+        column = project.create_column(
+            "Project Column created by PyGithub",
+        )
         issue = self.repo.create_issue(title="Issue created by PyGithub")
         card2 = column.create_card(content_id=issue.id, content_type="Issue")
         self.assertEqual(card2.id, 16039106)

--- a/tests/PullRequest.py
+++ b/tests/PullRequest.py
@@ -139,7 +139,8 @@ class PullRequest(Framework.TestCase):
         self.assertEqual(self.pull.draft, None)
         self.assertEqual(self.pull.maintainer_can_modify, None)
         self.assertEqual(
-            repr(self.pull), 'PullRequest(title="Title edited by PyGithub", number=31)',
+            repr(self.pull),
+            'PullRequest(title="Title edited by PyGithub", number=31)',
         )
         self.assertEqual(
             repr(self.pull.base),

--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -300,7 +300,14 @@ class Repository(Framework.TestCase):
 
     def testCreateGitTreeWithNullSha(self):
         tree = self.repo.create_git_tree(
-            [github.InputGitTreeElement("Baz.bar", "100644", "blob", sha=None,)]
+            [
+                github.InputGitTreeElement(
+                    "Baz.bar",
+                    "100644",
+                    "blob",
+                    sha=None,
+                )
+            ]
         )
         self.assertEqual(tree.sha, "9b8166fc80d0f0fe9192d4bf1dbaa87f194e012f")
 

--- a/tests/UserKey.py
+++ b/tests/UserKey.py
@@ -47,7 +47,8 @@ class UserKey(Framework.TestCase):
         self.assertEqual(self.key.url, "https://api.github.com/user/keys/2626650")
         self.assertTrue(self.key.verified)
         self.assertEqual(
-            repr(self.key), 'UserKey(title="Key added through PyGithub", id=2626650)',
+            repr(self.key),
+            'UserKey(title="Key added through PyGithub", id=2626650)',
         )
 
     def testDelete(self):


### PR DESCRIPTION
Black is very opinionated, but sometimes those opinions change. Run the
new black version across the codebase, and lock down the version used by
pre-commit so we don't get surprised like this again.