### PR TITLE
Correct type hint for InputGitTreeElement.sha

### DIFF
--- a/github/InputGitTreeElement.pyi
+++ b/github/InputGitTreeElement.pyi
@@ -9,7 +9,7 @@ class InputGitTreeElement:
         mode: str,
         type: str,
         content: Union[str, _NotSetType] = ...,
-        sha: Union[str, _NotSetType] = ...,
+        sha: Union[str, _NotSetType, None] = ...,
     ) -> None: ...
     @property
     def _identity(self) -> Dict[str, str]: ...


### PR DESCRIPTION
InputGitTreeElement.sha was previously updated to accept None to allow
files to be deleted, but the type hint was not updated.

Fixes #1707