### PR TITLE
Filter the DeprecationWarning in Team tests

### DIFF
--- a/tests/Team.py
+++ b/tests/Team.py
@@ -35,6 +35,7 @@
 ################################################################################
 
 
+import warnings
 from datetime import datetime
 
 from . import Framework
@@ -121,7 +122,10 @@ class Team(Framework.TestCase):
 
     def testRepoPermission(self):
         repo = self.org.get_repo("FatherBeaver")
+        # Ignore the warning since this method is deprecated
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
         self.team.set_repo_permission(repo, "admin")
+        warnings.resetwarnings()
 
     def testUpdateTeamRepository(self):
         repo = self.org.get_repo("FatherBeaver")


### PR DESCRIPTION
With 1c55be51743 merged, Team.set_repo_permission() now raises a
DeprecationWarning, so filter it until the method is removed.