### PR TITLE
Fix Branch protection status in the examples

### DIFF
--- a/doc/examples/Branch.rst
+++ b/doc/examples/Branch.rst
@@ -38,7 +38,7 @@ Get protection status of a branch
 .. code-block:: python
 
     >>> branch = g.get_repo("PyGithub/PyGithub").get_branch("master")
-    >>> branch.protection
+    >>> branch.protected
     True
 
 See required status checks of a branch


### PR DESCRIPTION
A long time ago when branch protection was changed, the example of
checking if a branch is protected wasn't changed in the examples.

Fixes #1724