### PR TITLE
Remove older MainClass.get_installation()

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -771,16 +771,6 @@ class Github(object):
         """
         return self.create_from_raw_data(*pickle.load(f))
 
-    def get_installation(self, id):
-        """
-
-        :param id:
-        :return:
-        """
-        return Installation.Installation(
-            self.__requester, headers={}, attributes={"id": id}, completed=True
-        )
-
     def get_oauth_application(self, client_id, client_secret):
         return github.ApplicationOAuth.ApplicationOAuth(
             self.__requester,


### PR DESCRIPTION
There are two get_installation() methods in MainClass, with different
arguments. get_installation(owner, repo) is documented and tested, and
get_installation(id) is neither. Remove it to avoid confusion.