### PR TITLE
Add py39 env to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint,
-    py{35,36,37,38},
+    py{35,36,37,38,39},
     docs
 
 [gh-actions]
@@ -10,6 +10,7 @@ python =
     3.6: py36, docs, lint
     3.7: py37
     3.8: py38
+    3.9: py39
 
 [testenv]
 deps = -rtest-requirements.txt


### PR DESCRIPTION
An earlier commit added Python 3.9 support to CI, but neglected to
change tox.ini to support an environment, do so here.