### PR TITLE
Pin requests to <2.25 as well

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests>=2.14.0
+requests>=2.14.0,<2.25
 pyjwt
 sphinx<3
 sphinx-rtd-theme<0.6

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
             "Topic :: Software Development",
         ],
         python_requires=">=3.5",
-        install_requires=["deprecated", "pyjwt", "requests>=2.14.0"],
+        install_requires=["deprecated", "pyjwt", "requests>=2.14.0,<2.25"],
         extras_require={"integrations": ["cryptography"]},
         tests_require=["cryptography", "httpretty>=0.9.6"],
     )


### PR DESCRIPTION
requests 2.26 and its requirements break httpretty (see
gabrielfalcao/HTTPretty#409), so pin for the time being. Thanks to
Sébastien Besson and Dhruv Manilawala for the debugging assistance.