### PR TITLE
Revert "Pin requests to <2.25 as well (#1757)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests>=2.14.0,<2.25
+requests>=2.14.0
 pyjwt
 sphinx<3
 sphinx-rtd-theme<0.6

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
             "Topic :: Software Development",
         ],
         python_requires=">=3.5",
-        install_requires=["deprecated", "pyjwt", "requests>=2.14.0,<2.25"],
+        install_requires=["deprecated", "pyjwt", "requests>=2.14.0"],
         extras_require={"integrations": ["cryptography"]},
         tests_require=["cryptography", "httpretty>=0.9.6"],
     )

--- a/setup.py
+++ b/setup.py
@@ -102,5 +102,5 @@ if __name__ == "__main__":
         python_requires=">=3.5",
         install_requires=["deprecated", "pyjwt", "requests>=2.14.0"],
         extras_require={"integrations": ["cryptography"]},
-        tests_require=["cryptography", "httpretty>=0.9.6"],
+        tests_require=["cryptography", "httpretty>=1.0.3"],
     )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 cryptography
-httpretty>=0.9.6
+httpretty>=1.0.3
 pytest>=5.3
 pytest-cov>=2.8


### PR DESCRIPTION
This reverts commit d159425f36dc7f68766cc980e262e9287e5f111c.

The dependency pinning was primarily motivated by the breakage of `httpretty` by the last minor release of `requests`. As mentioned in https://github.com/gabrielfalcao/HTTPretty/issues/409#issuecomment-733313173, the latest patch release of `httpretty` should restore compatibility with the new semantics of `requests 2.25.0`