### PR TITLE
Ignore pyupgrade commit for git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,6 @@
 
 # Format with new black
 07e29fe014b7e214e72b51129fbef55468a7309d
+
+# Add pyupgrade to pre-commit
+e113e37de1ec687c68337d777f3629251b35ab28


### PR DESCRIPTION
Since the pyupgrade commit makes a large amount of changes, ignore the
commit by default with git blame.