### PR TITLE
Fix pyjwt version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.14.0
-pyjwt
+pyjwt<2.0
 sphinx<3
 sphinx-rtd-theme<0.6
 Deprecated

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
             "Topic :: Software Development",
         ],
         python_requires=">=3.6",
-        install_requires=["deprecated", "pyjwt", "requests>=2.14.0"],
+        install_requires=["deprecated", "pyjwt<2.0", "requests>=2.14.0"],
         extras_require={"integrations": ["cryptography"]},
         tests_require=["cryptography", "httpretty>=1.0.3"],
     )


### PR DESCRIPTION
Pyjwt version is not fixed, which can cause syntax error for user since the release of breaking changes from pyjwt (https://pypi.org/project/PyJWT/#history)

Related Issue : https://github.com/PyGithub/PyGithub/issues/1796