### PR TITLE
Manually fixing paths for codecov.io to cover all project files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,8 @@
 comment:
   after_n_builds: 4
+
+codecov:
+  disable_default_path_fixes: true # manual fix properly covers all files
+
+fixes:
+  - "::github/" # manual fix properly covers all files

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ comment:
   after_n_builds: 4
 
 codecov:
-  disable_default_path_fixes: true # manual fix properly covers all files
+  disable_default_path_fixes: true # Automatic detection does not discover all files
 
 fixes:
   - "::github/"

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,4 +5,4 @@ codecov:
   disable_default_path_fixes: true # manual fix properly covers all files
 
 fixes:
-  - "::github/" # manual fix properly covers all files
+  - "::github/"


### PR DESCRIPTION
This fix will change the codecov.io configuration to replace automatic path handling with manual fixes. This is needed to properly reflect all project files in the codecov.io report, since with automatic path fixes it is covering only roughly 50% of the code (compare number of files in the project and those reflected on codecov.io).