### PR TITLE
Make datetime objects timezone-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 on:
   push:
+    branches: master
   pull_request:
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 on:
   push:
-    branches: master
   pull_request:
 jobs:
   test:

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,5 +4,5 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party=deprecated,httpretty,jwt,nacl,pytest,requests,setuptools,urllib3
+known_third_party=dateutil,deprecated,httpretty,jwt,nacl,pytest,requests,setuptools,urllib3
 known_first_party=github

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -166,7 +166,9 @@ class GithubObject:
     @staticmethod
     def _makeTimestampAttribute(value):
         return GithubObject.__makeTransformedAttribute(
-            value, int, datetime.datetime.utcfromtimestamp
+            value,
+            int,
+            lambda t: datetime.datetime.fromtimestamp(t, tz=datetime.timezone.utc),
         )
 
     @staticmethod
@@ -177,15 +179,20 @@ class GithubObject:
             ):  # pragma no branch (This branch was used only when creating a download)
                 # The Downloads API has been removed. I'm keeping this branch because I have no mean
                 # to check if it's really useless now.
-                return datetime.datetime.strptime(
-                    s, "%Y-%m-%dT%H:%M:%S.000Z"
+                return datetime.datetime.strptime(s, "%Y-%m-%dT%H:%M:%S.000Z").replace(
+                    tzinfo=datetime.timezone.utc
                 )  # pragma no cover (This branch was used only when creating a download)
             elif len(s) >= 25:
-                return datetime.datetime.strptime(s[:19], "%Y-%m-%dT%H:%M:%S") + (
-                    1 if s[19] == "-" else -1
-                ) * datetime.timedelta(hours=int(s[20:22]), minutes=int(s[23:25]))
+                return datetime.datetime.strptime(s[:19], "%Y-%m-%dT%H:%M:%S").replace(
+                    tzinfo=datetime.timezone(
+                        (-1 if s[19] == "-" else 1)
+                        * datetime.timedelta(hours=int(s[20:22]), minutes=int(s[23:25]))
+                    )
+                )
             else:
-                return datetime.datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ")
+                return datetime.datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(
+                    tzinfo=datetime.timezone.utc
+                )
 
         return GithubObject.__makeTransformedAttribute(value, str, parseDatetime)
 

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -33,6 +33,8 @@
 import datetime
 from operator import itemgetter
 
+from dateutil import parser
+
 from . import Consts, GithubException
 
 
@@ -173,28 +175,7 @@ class GithubObject:
 
     @staticmethod
     def _makeDatetimeAttribute(value):
-        def parseDatetime(s):
-            if (
-                len(s) == 24
-            ):  # pragma no branch (This branch was used only when creating a download)
-                # The Downloads API has been removed. I'm keeping this branch because I have no mean
-                # to check if it's really useless now.
-                return datetime.datetime.strptime(s, "%Y-%m-%dT%H:%M:%S.000Z").replace(
-                    tzinfo=datetime.timezone.utc
-                )  # pragma no cover (This branch was used only when creating a download)
-            elif len(s) >= 25:
-                return datetime.datetime.strptime(s[:19], "%Y-%m-%dT%H:%M:%S").replace(
-                    tzinfo=datetime.timezone(
-                        (-1 if s[19] == "-" else 1)
-                        * datetime.timedelta(hours=int(s[20:22]), minutes=int(s[23:25]))
-                    )
-                )
-            else:
-                return datetime.datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(
-                    tzinfo=datetime.timezone.utc
-                )
-
-        return GithubObject.__makeTransformedAttribute(value, str, parseDatetime)
+        return GithubObject.__makeTransformedAttribute(value, str, parser.parse)
 
     def _makeClassAttribute(self, klass, value):
         return GithubObject.__makeTransformedAttribute(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pynacl>=1.4.0
+python-dateutil
 requests>=2.14.0
 pyjwt>=2.4.0
 sphinx<3

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ if __name__ == "__main__":
             "pyjwt>=2.4.0",
             "pynacl>=1.4.0",
             "requests>=2.14.0",
+            "python-dateutil",
         ],
         extras_require={"integrations": ["cryptography"]},
         tests_require=["cryptography", "httpretty>=1.0.3"],

--- a/tests/AuthenticatedUser.py
+++ b/tests/AuthenticatedUser.py
@@ -51,7 +51,10 @@ class AuthenticatedUser(Framework.TestCase):
         self.assertEqual(self.user.blog, "http://vincent-jacques.net")
         self.assertEqual(self.user.collaborators, 0)
         self.assertEqual(self.user.company, "Criteo")
-        self.assertEqual(self.user.created_at, datetime.datetime(2010, 7, 9, 6, 10, 6))
+        self.assertEqual(
+            self.user.created_at,
+            datetime.datetime(2010, 7, 9, 6, 10, 6, tzinfo=datetime.timezone.utc),
+        )
         self.assertEqual(self.user.disk_usage, 16692)
         self.assertEqual(self.user.email, "vincent@vincent-jacques.net")
         self.assertEqual(self.user.followers, 13)
@@ -699,7 +702,8 @@ class AuthenticatedUser(Framework.TestCase):
         self.assertEqual(notification.subject.type, "PullRequest")
         self.assertEqual(notification.repository.id, 8432784)
         self.assertEqual(
-            notification.updated_at, datetime.datetime(2013, 3, 15, 5, 43, 11)
+            notification.updated_at,
+            datetime.datetime(2013, 3, 15, 5, 43, 11, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(notification.url, None)
         self.assertEqual(notification.subject.url, None)
@@ -753,7 +757,9 @@ class AuthenticatedUser(Framework.TestCase):
         self.assertEqual(repr(invitation), "Invitation(id=17285388)")
         self.assertEqual(invitation.id, 17285388)
         self.assertEqual(invitation.permissions, "write")
-        created_at = datetime.datetime(2019, 6, 27, 11, 47)
+        created_at = datetime.datetime(
+            2019, 6, 27, 11, 47, tzinfo=datetime.timezone.utc
+        )
         self.assertEqual(invitation.created_at, created_at)
         self.assertEqual(
             invitation.url,

--- a/tests/Authorization.py
+++ b/tests/Authorization.py
@@ -42,7 +42,8 @@ class Authorization(Framework.TestCase):
         )
         self.assertEqual(self.authorization.app.name, "GitHub API")
         self.assertEqual(
-            self.authorization.created_at, datetime.datetime(2012, 5, 22, 18, 3, 17)
+            self.authorization.created_at,
+            datetime.datetime(2012, 5, 22, 18, 3, 17, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.authorization.id, 372259)
         self.assertEqual(self.authorization.note, None)
@@ -52,7 +53,8 @@ class Authorization(Framework.TestCase):
             self.authorization.token, "82459c4500086f8f0cc67d2936c17d1e27ad1c33"
         )
         self.assertEqual(
-            self.authorization.updated_at, datetime.datetime(2012, 5, 22, 18, 3, 17)
+            self.authorization.updated_at,
+            datetime.datetime(2012, 5, 22, 18, 3, 17, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.authorization.url, "https://api.github.com/authorizations/372259"

--- a/tests/BadAttributes.py
+++ b/tests/BadAttributes.py
@@ -35,7 +35,10 @@ from . import Framework
 class BadAttributes(Framework.TestCase):
     def testBadSimpleAttribute(self):
         user = self.g.get_user("klmitch")
-        self.assertEqual(user.created_at, datetime.datetime(2011, 3, 23, 15, 42, 9))
+        self.assertEqual(
+            user.created_at,
+            datetime.datetime(2011, 3, 23, 15, 42, 9, tzinfo=datetime.timezone.utc),
+        )
 
         with self.assertRaises(github.BadAttributeException) as raisedexp:
             user.name

--- a/tests/BadAttributes.py
+++ b/tests/BadAttributes.py
@@ -26,6 +26,8 @@
 
 import datetime
 
+from dateutil.parser import ParserError
+
 import github
 
 from . import Framework
@@ -55,11 +57,11 @@ class BadAttributes(Framework.TestCase):
         self.assertEqual(raisedexp.exception.actual_value, "foobar")
         self.assertEqual(raisedexp.exception.expected_type, str)
         self.assertEqual(
-            raisedexp.exception.transformation_exception.__class__, ValueError
+            raisedexp.exception.transformation_exception.__class__, ParserError
         )
         self.assertEqual(
             raisedexp.exception.transformation_exception.args,
-            ("time data 'foobar' does not match format '%Y-%m-%dT%H:%M:%SZ'",),
+            ("Unknown string format: %s", "foobar"),
         )
 
     def testBadTransformedAttribute(self):

--- a/tests/CheckRun.py
+++ b/tests/CheckRun.py
@@ -40,7 +40,8 @@ class CheckRun(Framework.TestCase):
         self.assertEqual(self.check_run.app.slug, "github-actions")
         self.assertEqual(self.check_run.check_suite_id, 1110219217)
         self.assertEqual(
-            self.check_run.completed_at, datetime.datetime(2020, 8, 28, 4, 21, 21)
+            self.check_run.completed_at,
+            datetime.datetime(2020, 8, 28, 4, 21, 21, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.check_run.conclusion, "success")
         self.assertEqual(
@@ -63,7 +64,8 @@ class CheckRun(Framework.TestCase):
         self.assertEqual(self.check_run.output.annotations_count, 0)
         self.assertEqual(len(self.check_run.pull_requests), 0)
         self.assertEqual(
-            self.check_run.started_at, datetime.datetime(2020, 8, 28, 4, 20, 27)
+            self.check_run.started_at,
+            datetime.datetime(2020, 8, 28, 4, 20, 27, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.check_run.status, "completed")
         self.assertEqual(
@@ -144,7 +146,10 @@ class CheckRun(Framework.TestCase):
         self.assertEqual(check_run.head_sha, "0283d46537193f1fed7d46859f15c5304b9836f9")
         self.assertEqual(check_run.status, "in_progress")
         self.assertEqual(check_run.external_id, "50")
-        self.assertEqual(check_run.started_at, datetime.datetime(2020, 9, 4, 1, 14, 52))
+        self.assertEqual(
+            check_run.started_at,
+            datetime.datetime(2020, 9, 4, 1, 14, 52, tzinfo=datetime.timezone.utc),
+        )
         self.assertEqual(check_run.output.title, "PyGithub Check Run Test")
         self.assertEqual(check_run.output.summary, "Test summary")
         self.assertIsNone(check_run.output.text)
@@ -205,11 +210,13 @@ class CheckRun(Framework.TestCase):
         self.assertEqual(check_run.head_sha, "0283d46537193f1fed7d46859f15c5304b9836f9")
         self.assertEqual(check_run.status, "completed")
         self.assertEqual(
-            check_run.started_at, datetime.datetime(2020, 10, 20, 10, 30, 29)
+            check_run.started_at,
+            datetime.datetime(2020, 10, 20, 10, 30, 29, tzinfo=datetime.timezone.utc),
         ),
         self.assertEqual(check_run.conclusion, "success")
         self.assertEqual(
-            check_run.completed_at, datetime.datetime(2020, 10, 20, 11, 30, 50)
+            check_run.completed_at,
+            datetime.datetime(2020, 10, 20, 11, 30, 50, tzinfo=datetime.timezone.utc),
         ),
         self.assertEqual(check_run.output.annotations_count, 2)
 
@@ -309,10 +316,12 @@ class CheckRun(Framework.TestCase):
         self.assertEqual(check_run.details_url, "https://www.example-url.com")
         self.assertEqual(check_run.external_id, "49")
         self.assertEqual(
-            check_run.started_at, datetime.datetime(2020, 10, 20, 1, 10, 20)
+            check_run.started_at,
+            datetime.datetime(2020, 10, 20, 1, 10, 20, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
-            check_run.completed_at, datetime.datetime(2020, 10, 20, 2, 20, 30)
+            check_run.completed_at,
+            datetime.datetime(2020, 10, 20, 2, 20, 30, tzinfo=datetime.timezone.utc),
         )
 
     def testCheckRunAnnotationAttributes(self):

--- a/tests/CheckSuite.py
+++ b/tests/CheckSuite.py
@@ -21,7 +21,7 @@
 #                                                                              #
 ################################################################################
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from . import Framework
 
@@ -48,7 +48,9 @@ class CheckSuite(Framework.TestCase):
             "https://api.github.com/repos/wrecker/PySample/check-suites/1004503837/check-runs",
         )
         self.assertEqual(cs.conclusion, "success")
-        self.assertEqual(cs.created_at, datetime(2020, 8, 4, 5, 6, 54))
+        self.assertEqual(
+            cs.created_at, datetime(2020, 8, 4, 5, 6, 54, tzinfo=timezone.utc)
+        )
         self.assertEqual(cs.head_branch, "wrecker-patch-1")
         self.assertEqual(cs.head_commit.sha, "fd09d934bcce792176d6b79d6d0387e938b62b7a")
         self.assertEqual(cs.head_sha, "fd09d934bcce792176d6b79d6d0387e938b62b7a")
@@ -61,7 +63,9 @@ class CheckSuite(Framework.TestCase):
             cs.repository.url, "https://api.github.com/repos/wrecker/PySample"
         )
         self.assertEqual(cs.status, "completed")
-        self.assertEqual(cs.updated_at, datetime(2020, 8, 4, 5, 7, 40))
+        self.assertEqual(
+            cs.updated_at, datetime(2020, 8, 4, 5, 7, 40, tzinfo=timezone.utc)
+        )
         self.assertEqual(
             cs.url,
             "https://api.github.com/repos/wrecker/PySample/check-suites/1004503837",

--- a/tests/CommitCombinedStatus.py
+++ b/tests/CommitCombinedStatus.py
@@ -55,11 +55,11 @@ class CommitCombinedStatus(Framework.TestCase):
         )
         self.assertEqual(
             self.combined_status.statuses[4].created_at,
-            datetime.datetime(2015, 12, 14, 13, 24, 18),
+            datetime.datetime(2015, 12, 14, 13, 24, 18, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.combined_status.statuses[3].updated_at,
-            datetime.datetime(2015, 12, 14, 13, 23, 35),
+            datetime.datetime(2015, 12, 14, 13, 23, 35, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.combined_status.sha, "74e70119a23fa3ffb3db19d4590eccfebd72b659"

--- a/tests/CommitComment.py
+++ b/tests/CommitComment.py
@@ -44,7 +44,8 @@ class CommitComment(Framework.TestCase):
             self.comment.commit_id, "6945921c529be14c3a8f566dd1e483674516d46d"
         )
         self.assertEqual(
-            self.comment.created_at, datetime.datetime(2012, 5, 22, 18, 40, 18)
+            self.comment.created_at,
+            datetime.datetime(2012, 5, 22, 18, 40, 18, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.comment.html_url,
@@ -55,7 +56,8 @@ class CommitComment(Framework.TestCase):
         self.assertEqual(self.comment.path, None)
         self.assertEqual(self.comment.position, None)
         self.assertEqual(
-            self.comment.updated_at, datetime.datetime(2012, 5, 22, 18, 40, 18)
+            self.comment.updated_at,
+            datetime.datetime(2012, 5, 22, 18, 40, 18, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.comment.url,

--- a/tests/CommitStatus.py
+++ b/tests/CommitStatus.py
@@ -45,10 +45,12 @@ class CommitStatus(Framework.TestCase):
 
     def testAttributes(self):
         self.assertEqual(
-            self.statuses[0].created_at, datetime.datetime(2012, 9, 8, 11, 30, 56)
+            self.statuses[0].created_at,
+            datetime.datetime(2012, 9, 8, 11, 30, 56, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
-            self.statuses[0].updated_at, datetime.datetime(2012, 9, 8, 11, 30, 56)
+            self.statuses[0].updated_at,
+            datetime.datetime(2012, 9, 8, 11, 30, 56, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.statuses[0].creator.login, "jacquev6")
         self.assertEqual(

--- a/tests/Deployment.py
+++ b/tests/Deployment.py
@@ -48,7 +48,9 @@ class Deployment(Framework.TestCase):
         self.assertEqual(self.deployment.environment, "test")
         self.assertEqual(self.deployment.description, "Test deployment")
         self.assertEqual(self.deployment.creator.login, "jacquev6")
-        created_at = datetime.datetime(2020, 8, 26, 11, 44, 53)
+        created_at = datetime.datetime(
+            2020, 8, 26, 11, 44, 53, tzinfo=datetime.timezone.utc
+        )
         self.assertEqual(self.deployment.created_at, created_at)
         self.assertEqual(self.deployment.updated_at, created_at)
         self.assertEqual(self.deployment.transient_environment, True)

--- a/tests/DeploymentStatus.py
+++ b/tests/DeploymentStatus.py
@@ -36,7 +36,9 @@ class DeploymentStatus(Framework.TestCase):
 
     def testAttributes(self):
         self.assertEqual(self.status.id, 388454671)
-        created_at = datetime.datetime(2020, 8, 26, 14, 32, 51)
+        created_at = datetime.datetime(
+            2020, 8, 26, 14, 32, 51, tzinfo=datetime.timezone.utc
+        )
         self.assertEqual(self.status.created_at, created_at)
         self.assertEqual(self.status.creator.login, "jacquev6")
         self.assertEqual(

--- a/tests/Download.py
+++ b/tests/Download.py
@@ -42,7 +42,8 @@ class Download(Framework.TestCase):
         self.assertEqual(self.download.bucket, None)
         self.assertEqual(self.download.content_type, "text/plain")
         self.assertEqual(
-            self.download.created_at, datetime.datetime(2012, 5, 22, 18, 58, 32)
+            self.download.created_at,
+            datetime.datetime(2012, 5, 22, 18, 58, 32, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.download.description, None)
         self.assertEqual(self.download.download_count, 0)

--- a/tests/Event.py
+++ b/tests/Event.py
@@ -39,7 +39,8 @@ class Event(Framework.TestCase):
     def testAttributes(self):
         self.assertEqual(self.event.actor.login, "jacquev6")
         self.assertEqual(
-            self.event.created_at, datetime.datetime(2012, 5, 26, 10, 1, 39)
+            self.event.created_at,
+            datetime.datetime(2012, 5, 26, 10, 1, 39, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event.id, "1556114751")
         self.assertEqual(self.event.org, None)

--- a/tests/Gist.py
+++ b/tests/Gist.py
@@ -37,7 +37,10 @@ class Gist(Framework.TestCase):
     def testAttributes(self):
         gist = self.g.get_gist("6296732")
         self.assertEqual(gist.comments, 0)
-        self.assertEqual(gist.created_at, datetime.datetime(2013, 8, 21, 16, 28, 24))
+        self.assertEqual(
+            gist.created_at,
+            datetime.datetime(2013, 8, 21, 16, 28, 24, tzinfo=datetime.timezone.utc),
+        )
         self.assertEqual(gist.description, "Github API")
         self.assertEqual(list(gist.files.keys()), ["GithubAPI.lua"])
         self.assertEqual(gist.files["GithubAPI.lua"].size, 21229)
@@ -56,7 +59,8 @@ class Gist(Framework.TestCase):
         self.assertEqual(gist.history[0].change_status.deletions, 0)
         self.assertEqual(gist.history[0].change_status.total, 793)
         self.assertEqual(
-            gist.history[0].committed_at, datetime.datetime(2013, 8, 21, 16, 12, 27)
+            gist.history[0].committed_at,
+            datetime.datetime(2013, 8, 21, 16, 12, 27, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             gist.history[0].url,
@@ -70,7 +74,10 @@ class Gist(Framework.TestCase):
         self.assertEqual(gist.html_url, "https://gist.github.com/6296732")
         self.assertEqual(gist.id, "6296732")
         self.assertTrue(gist.public)
-        self.assertEqual(gist.updated_at, datetime.datetime(2013, 8, 21, 16, 28, 24))
+        self.assertEqual(
+            gist.updated_at,
+            datetime.datetime(2013, 8, 21, 16, 28, 24, tzinfo=datetime.timezone.utc),
+        )
         self.assertEqual(gist.url, "https://api.github.com/gists/6296732")
         self.assertEqual(gist.user, None)
         self.assertEqual(gist.owner.login, "jacquev6")
@@ -87,7 +94,10 @@ class Gist(Framework.TestCase):
         gist = self.g.get_gist("2729810")
         gist.edit()
         self.assertEqual(gist.description, "Gist created by PyGithub")
-        self.assertEqual(gist.updated_at, datetime.datetime(2012, 5, 19, 7, 0, 58))
+        self.assertEqual(
+            gist.updated_at,
+            datetime.datetime(2012, 5, 19, 7, 0, 58, tzinfo=datetime.timezone.utc),
+        )
 
     def testEditWithAllParameters(self):
         gist = self.g.get_gist("2729810")
@@ -96,7 +106,10 @@ class Gist(Framework.TestCase):
             {"barbaz.txt": github.InputFileContent("File also created by PyGithub")},
         )
         self.assertEqual(gist.description, "Description edited by PyGithub")
-        self.assertEqual(gist.updated_at, datetime.datetime(2012, 5, 19, 7, 6, 10))
+        self.assertEqual(
+            gist.updated_at,
+            datetime.datetime(2012, 5, 19, 7, 6, 10, tzinfo=datetime.timezone.utc),
+        )
         self.assertEqual(set(gist.files.keys()), {"foobar.txt", "barbaz.txt"})
 
     def testDeleteFile(self):

--- a/tests/GistComment.py
+++ b/tests/GistComment.py
@@ -39,11 +39,13 @@ class GistComment(Framework.TestCase):
     def testAttributes(self):
         self.assertEqual(self.comment.body, "Comment created by PyGithub")
         self.assertEqual(
-            self.comment.created_at, datetime.datetime(2012, 5, 19, 7, 7, 57)
+            self.comment.created_at,
+            datetime.datetime(2012, 5, 19, 7, 7, 57, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.comment.id, 323629)
         self.assertEqual(
-            self.comment.updated_at, datetime.datetime(2012, 5, 19, 7, 7, 57)
+            self.comment.updated_at,
+            datetime.datetime(2012, 5, 19, 7, 7, 57, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.comment.url, "https://api.github.com/gists/2729810/comments/323629"
@@ -58,7 +60,8 @@ class GistComment(Framework.TestCase):
         self.comment.edit("Comment edited by PyGithub")
         self.assertEqual(self.comment.body, "Comment edited by PyGithub")
         self.assertEqual(
-            self.comment.updated_at, datetime.datetime(2012, 5, 19, 7, 12, 32)
+            self.comment.updated_at,
+            datetime.datetime(2012, 5, 19, 7, 12, 32, tzinfo=datetime.timezone.utc),
         )
 
     def testDelete(self):

--- a/tests/GitCommit.py
+++ b/tests/GitCommit.py
@@ -45,12 +45,16 @@ class GitCommit(Framework.TestCase):
         self.assertEqual(self.commit.author.name, "Vincent Jacques")
         self.assertEqual(self.commit.author.email, "vincent@vincent-jacques.net")
         self.assertEqual(
-            self.commit.author.date, datetime.datetime(2012, 4, 17, 17, 55, 16)
+            self.commit.author.date,
+            datetime.datetime(
+                2012, 4, 17, 17, 55, 16, tzinfo=datetime.timezone(datetime.timedelta(0))
+            ),
         )
         self.assertEqual(self.commit.committer.name, "Vincent Jacques")
         self.assertEqual(self.commit.committer.email, "vincent@vincent-jacques.net")
         self.assertEqual(
-            self.commit.committer.date, datetime.datetime(2012, 4, 17, 17, 55, 16)
+            self.commit.committer.date,
+            datetime.datetime(2012, 4, 17, 17, 55, 16, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.commit.message, "Merge branch 'develop'\n")
         self.assertEqual(len(self.commit.parents), 2)

--- a/tests/GitRelease.py
+++ b/tests/GitRelease.py
@@ -64,8 +64,8 @@ user = "rickrickston123"
 release_id = 28524234
 author_id = 64711998
 tag = "v1.0"
-create_date = datetime.datetime(2020, 7, 12, 7, 34, 42)
-publish_date = datetime.datetime(2020, 7, 14, 0, 58, 20)
+create_date = datetime.datetime(2020, 7, 12, 7, 34, 42, tzinfo=datetime.timezone.utc)
+publish_date = datetime.datetime(2020, 7, 14, 0, 58, 20, tzinfo=datetime.timezone.utc)
 
 
 class GitRelease(Framework.TestCase):

--- a/tests/GitTag.py
+++ b/tests/GitTag.py
@@ -54,7 +54,10 @@ class GitTag(Framework.TestCase):
         self.assertEqual(self.tag.sha, "f5f37322407b02a80de4526ad88d5f188977bc3c")
         self.assertEqual(self.tag.tag, "v0.6")
         self.assertEqual(
-            self.tag.tagger.date, datetime.datetime(2012, 5, 10, 18, 14, 15)
+            self.tag.tagger.date,
+            datetime.datetime(
+                2012, 5, 10, 18, 14, 15, tzinfo=datetime.timezone(datetime.timedelta(0))
+            ),
         )
         self.assertEqual(self.tag.tagger.email, "vincent@vincent-jacques.net")
         self.assertEqual(self.tag.tagger.name, "Vincent Jacques")

--- a/tests/GithubApp.py
+++ b/tests/GithubApp.py
@@ -20,7 +20,7 @@
 #                                                                              #
 ################################################################################
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from . import Framework
 
@@ -32,7 +32,9 @@ class GithubApp(Framework.TestCase):
 
     def testGetPublicApp(self):
         app = self.g.get_app(slug=self.app_slug)
-        self.assertEqual(app.created_at, datetime(2018, 7, 30, 9, 30, 17))
+        self.assertEqual(
+            app.created_at, datetime(2018, 7, 30, 9, 30, 17, tzinfo=timezone.utc)
+        )
         self.assertEqual(
             app.description, "Automate your workflow from idea to production"
         )
@@ -95,7 +97,9 @@ class GithubApp(Framework.TestCase):
             },
         )
         self.assertEqual(app.slug, "github-actions")
-        self.assertEqual(app.updated_at, datetime(2019, 12, 10, 19, 4, 12))
+        self.assertEqual(
+            app.updated_at, datetime(2019, 12, 10, 19, 4, 12, tzinfo=timezone.utc)
+        )
         self.assertEqual(app.url, "/apps/github-actions")
 
     def testGetAuthenticatedApp(self):
@@ -105,7 +109,9 @@ class GithubApp(Framework.TestCase):
         # The url should change when the object is completed - after pulling it down
         # from the github API
         self.assertEqual(app.url, "/app")
-        self.assertEqual(app.created_at, datetime(2020, 8, 1, 17, 23, 46))
+        self.assertEqual(
+            app.created_at, datetime(2020, 8, 1, 17, 23, 46, tzinfo=timezone.utc)
+        )
         self.assertEqual(app.description, "Sample App to test PyGithub")
         self.assertListEqual(
             app.events,
@@ -132,5 +138,7 @@ class GithubApp(Framework.TestCase):
             },
         )
         self.assertEqual(app.slug, "pygithubtest")
-        self.assertEqual(app.updated_at, datetime(2020, 8, 1, 17, 44, 31))
+        self.assertEqual(
+            app.updated_at, datetime(2020, 8, 1, 17, 44, 31, tzinfo=timezone.utc)
+        )
         self.assertEqual(app.url, "/apps/pygithubtest")

--- a/tests/GithubIntegration.py
+++ b/tests/GithubIntegration.py
@@ -155,10 +155,12 @@ class GithubIntegration(unittest.TestCase):
         )
         self.assertEqual(auth_obj.token, "v1.ce63424bc55028318325caac4f4c3a5378ca0038")
         self.assertEqual(
-            auth_obj.expires_at, datetime.datetime(2019, 2, 13, 11, 10, 38)
+            auth_obj.expires_at,
+            datetime.datetime(2019, 2, 13, 11, 10, 38, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
-            repr(auth_obj), "InstallationAuthorization(expires_at=2019-02-13 11:10:38)"
+            repr(auth_obj),
+            "InstallationAuthorization(expires_at=2019-02-13 11:10:38+00:00)",
         )
 
     def test_get_installation(self):

--- a/tests/GithubObject.py
+++ b/tests/GithubObject.py
@@ -1,0 +1,94 @@
+############################ Copyrights and license ############################
+#                                                                              #
+# Copyright 2023 Enrico Minack <github@enrico.minack.dev>                      #
+#                                                                              #
+# This file is part of PyGithub.                                               #
+# http://pygithub.readthedocs.io/                                              #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+################################################################################
+
+from datetime import datetime, timedelta, timezone
+import unittest
+
+from . import Framework
+
+gho = Framework.github.GithubObject
+
+
+class GithubObject(unittest.TestCase):
+    def testMakeDatetimeAttribute(self):
+        for value, expected in [
+            (None, None),
+
+            ("2021-01-23T12:34:56Z", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
+            ("2021-01-23T12:34:56.000Z", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
+            ("2021-01-23T12:34:56.000Z", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
+
+            ("2021-01-23T12:34:56+00:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
+            ("2021-01-23T12:34:56+01:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone(timedelta(hours=1)))),
+            ("2021-01-23T12:34:56-06:30", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone(timedelta(hours=-6, minutes=-30)))),
+
+            ("2021-01-23T12:34:56.000+00:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
+            ("2021-01-23T12:34:56.000+01:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
+            ("2021-01-23T12:34:56.000-06:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc))
+        ]:
+            actual = gho.GithubObject._makeDatetimeAttribute(value)
+            self.assertEqual(gho._ValuedAttribute, type(actual), value)
+            self.assertEqual(expected, actual.value, value)
+
+    def testMakeDatetimeAttributeBadValues(self):
+        for value in [
+            "2021-01-23T12:34:56",
+            "2021-01-23T12:34:56.123",
+            "2021-01-23T12:34:56.123Z",
+            "2021-01-23 12:34:56Z",
+            "not a timestamp",
+            1234
+        ]:
+            actual = gho.GithubObject._makeDatetimeAttribute(value)
+
+            self.assertEqual(gho._BadAttribute, type(actual))
+            with self.assertRaises(Framework.github.BadAttributeException) as e:
+                value = actual.value
+            self.assertEqual(value, e.exception.actual_value)
+            self.assertEqual(str, e.exception.expected_type)
+            if isinstance(value, str):
+                self.assertIsNotNone(e.exception.transformation_exception)
+            else:
+                self.assertIsNone(e.exception.transformation_exception)
+
+    def testMakeTimestampAttribute(self):
+        actual = gho.GithubObject._makeTimestampAttribute(None)
+        self.assertEqual(gho._ValuedAttribute, type(actual))
+        self.assertIsNone(actual.value)
+
+        actual = gho.GithubObject._makeTimestampAttribute(1611405296)
+        self.assertEqual(gho._ValuedAttribute, type(actual))
+        self.assertEqual(datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc), actual.value)
+
+    def testMakeTimetsampAttributeBadValues(self):
+        for value in [
+            "1611405296",
+            1234.567
+        ]:
+            actual = gho.GithubObject._makeTimestampAttribute(value)
+
+            self.assertEqual(gho._BadAttribute, type(actual))
+            with self.assertRaises(Framework.github.BadAttributeException) as e:
+                value = actual.value
+            self.assertEqual(value, e.exception.actual_value)
+            self.assertEqual(int, e.exception.expected_type)
+            self.assertIsNone(e.exception.transformation_exception)

--- a/tests/GithubObject.py
+++ b/tests/GithubObject.py
@@ -20,8 +20,10 @@
 #                                                                              #
 ################################################################################
 
-from datetime import datetime, timedelta, timezone
 import unittest
+from datetime import datetime, timedelta, timezone
+
+from dateutil.tz.tz import tzoffset
 
 from . import Framework
 
@@ -32,32 +34,57 @@ class GithubObject(unittest.TestCase):
     def testMakeDatetimeAttribute(self):
         for value, expected in [
             (None, None),
-
-            ("2021-01-23T12:34:56Z", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
-            ("2021-01-23T12:34:56.000Z", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
-            ("2021-01-23T12:34:56.000Z", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
-
-            ("2021-01-23T12:34:56+00:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
-            ("2021-01-23T12:34:56+01:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone(timedelta(hours=1)))),
-            ("2021-01-23T12:34:56-06:30", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone(timedelta(hours=-6, minutes=-30)))),
-
-            ("2021-01-23T12:34:56.000+00:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
-            ("2021-01-23T12:34:56.000+01:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc)),
-            ("2021-01-23T12:34:56.000-06:00", datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc))
+            (
+                "2021-01-23T12:34:56Z",
+                datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc),
+            ),
+            (
+                "2021-01-23T12:34:56.000Z",
+                datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc),
+            ),
+            (
+                "2021-01-23T12:34:56.000Z",
+                datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc),
+            ),
+            (
+                "2021-01-23T12:34:56+00:00",
+                datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc),
+            ),
+            (
+                "2021-01-23T12:34:56+01:00",
+                datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone(timedelta(hours=1))),
+            ),
+            (
+                "2021-01-23T12:34:56-06:30",
+                datetime(
+                    2021,
+                    1,
+                    23,
+                    12,
+                    34,
+                    56,
+                    tzinfo=timezone(timedelta(hours=-6, minutes=-30)),
+                ),
+            ),
+            (
+                "2021-01-23T12:34:56.000+00:00",
+                datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc),
+            ),
+            (
+                "2021-01-23T12:34:56.000+01:00",
+                datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone(timedelta(hours=1))),
+            ),
+            (
+                "2021-01-23T12:34:56.000-06:00",
+                datetime(2021, 1, 23, 12, 34, 56, tzinfo=tzoffset(None, -21600)),
+            ),
         ]:
             actual = gho.GithubObject._makeDatetimeAttribute(value)
             self.assertEqual(gho._ValuedAttribute, type(actual), value)
             self.assertEqual(expected, actual.value, value)
 
     def testMakeDatetimeAttributeBadValues(self):
-        for value in [
-            "2021-01-23T12:34:56",
-            "2021-01-23T12:34:56.123",
-            "2021-01-23T12:34:56.123Z",
-            "2021-01-23 12:34:56Z",
-            "not a timestamp",
-            1234
-        ]:
+        for value in ["not a timestamp", 1234]:
             actual = gho.GithubObject._makeDatetimeAttribute(value)
 
             self.assertEqual(gho._BadAttribute, type(actual))
@@ -77,13 +104,12 @@ class GithubObject(unittest.TestCase):
 
         actual = gho.GithubObject._makeTimestampAttribute(1611405296)
         self.assertEqual(gho._ValuedAttribute, type(actual))
-        self.assertEqual(datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc), actual.value)
+        self.assertEqual(
+            datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc), actual.value
+        )
 
     def testMakeTimetsampAttributeBadValues(self):
-        for value in [
-            "1611405296",
-            1234.567
-        ]:
+        for value in ["1611405296", 1234.567]:
             actual = gho.GithubObject._makeTimestampAttribute(value)
 
             self.assertEqual(gho._BadAttribute, type(actual))

--- a/tests/Hook.py
+++ b/tests/Hook.py
@@ -40,7 +40,10 @@ class Hook(Framework.TestCase):
     def testAttributes(self):
         self.assertTrue(self.hook.active)  # WTF
         self.assertEqual(self.hook.config, {"url": "http://foobar.com"})
-        self.assertEqual(self.hook.created_at, datetime.datetime(2012, 5, 19, 6, 1, 45))
+        self.assertEqual(
+            self.hook.created_at,
+            datetime.datetime(2012, 5, 19, 6, 1, 45, tzinfo=datetime.timezone.utc),
+        )
         self.assertEqual(self.hook.events, ["push"])
         self.assertEqual(self.hook.id, 257993)
         self.assertEqual(self.hook.last_response.status, "ok")
@@ -48,7 +51,8 @@ class Hook(Framework.TestCase):
         self.assertEqual(self.hook.last_response.code, 200)
         self.assertEqual(self.hook.name, "web")
         self.assertEqual(
-            self.hook.updated_at, datetime.datetime(2012, 5, 29, 18, 49, 47)
+            self.hook.updated_at,
+            datetime.datetime(2012, 5, 29, 18, 49, 47, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.hook.url, "https://api.github.com/repos/jacquev6/PyGithub/hooks/257993"
@@ -71,7 +75,10 @@ class Hook(Framework.TestCase):
     def testEditWithMinimalParameters(self):
         self.hook.edit("web", {"url": "http://foobar.com/hook"})
         self.assertEqual(self.hook.config, {"url": "http://foobar.com/hook"})
-        self.assertEqual(self.hook.updated_at, datetime.datetime(2012, 5, 19, 5, 8, 16))
+        self.assertEqual(
+            self.hook.updated_at,
+            datetime.datetime(2012, 5, 19, 5, 8, 16, tzinfo=datetime.timezone.utc),
+        )
 
     def testDelete(self):
         self.hook.delete()

--- a/tests/Issue.py
+++ b/tests/Issue.py
@@ -50,12 +50,14 @@ class Issue(Framework.TestCase):
         )
         self.assertEqual(self.issue.body, "Body edited by PyGithub")
         self.assertEqual(
-            self.issue.closed_at, datetime.datetime(2012, 5, 26, 14, 59, 33)
+            self.issue.closed_at,
+            datetime.datetime(2012, 5, 26, 14, 59, 33, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.issue.closed_by.login, "jacquev6")
         self.assertEqual(self.issue.comments, 0)
         self.assertEqual(
-            self.issue.created_at, datetime.datetime(2012, 5, 19, 10, 38, 23)
+            self.issue.created_at,
+            datetime.datetime(2012, 5, 19, 10, 38, 23, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.issue.html_url, "https://github.com/jacquev6/PyGithub/issues/28"
@@ -74,7 +76,8 @@ class Issue(Framework.TestCase):
         self.assertEqual(self.issue.state, "closed")
         self.assertEqual(self.issue.title, "Issue created by PyGithub")
         self.assertEqual(
-            self.issue.updated_at, datetime.datetime(2012, 5, 26, 14, 59, 33)
+            self.issue.updated_at,
+            datetime.datetime(2012, 5, 26, 14, 59, 33, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.issue.url, "https://api.github.com/repos/jacquev6/PyGithub/issues/28"
@@ -138,7 +141,9 @@ class Issue(Framework.TestCase):
 
     def testGetCommentsSince(self):
         self.assertListKeyEqual(
-            self.issue.get_comments(datetime.datetime(2012, 5, 26, 13, 59, 33)),
+            self.issue.get_comments(
+                datetime.datetime(2012, 5, 26, 13, 59, 33, tzinfo=datetime.timezone.utc)
+            ),
             lambda c: c.user.login,
             ["jacquev6", "roskakori"],
         )

--- a/tests/Issue54.py
+++ b/tests/Issue54.py
@@ -41,4 +41,9 @@ class Issue54(Framework.TestCase):
             commit.message,
             "Test commit created around Fri, 13 Jul 2012 18:43:21 GMT, that is vendredi 13 juillet 2012 20:43:21 GMT+2\n",
         )
-        self.assertEqual(commit.author.date, datetime.datetime(2012, 7, 13, 18, 47, 10))
+        self.assertEqual(
+            commit.author.date,
+            datetime.datetime(
+                2012, 7, 13, 18, 47, 10, tzinfo=datetime.timezone(datetime.timedelta(0))
+            ),
+        )

--- a/tests/IssueComment.py
+++ b/tests/IssueComment.py
@@ -43,11 +43,13 @@ class IssueComment(Framework.TestCase):
     def testAttributes(self):
         self.assertEqual(self.comment.body, "Comment created by PyGithub")
         self.assertEqual(
-            self.comment.created_at, datetime.datetime(2012, 5, 20, 11, 46, 42)
+            self.comment.created_at,
+            datetime.datetime(2012, 5, 20, 11, 46, 42, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.comment.id, 5808311)
         self.assertEqual(
-            self.comment.updated_at, datetime.datetime(2012, 5, 20, 11, 46, 42)
+            self.comment.updated_at,
+            datetime.datetime(2012, 5, 20, 11, 46, 42, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.comment.url,
@@ -67,7 +69,8 @@ class IssueComment(Framework.TestCase):
         self.comment.edit("Comment edited by PyGithub")
         self.assertEqual(self.comment.body, "Comment edited by PyGithub")
         self.assertEqual(
-            self.comment.updated_at, datetime.datetime(2012, 5, 20, 11, 53, 59)
+            self.comment.updated_at,
+            datetime.datetime(2012, 5, 20, 11, 53, 59, tzinfo=datetime.timezone.utc),
         )
 
     def testDelete(self):

--- a/tests/IssueEvent.py
+++ b/tests/IssueEvent.py
@@ -76,7 +76,8 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_subscribed.actor.login, "jacquev6")
         self.assertEqual(self.event_subscribed.commit_id, None)
         self.assertEqual(
-            self.event_subscribed.created_at, datetime.datetime(2012, 5, 27, 5, 40, 15)
+            self.event_subscribed.created_at,
+            datetime.datetime(2012, 5, 27, 5, 40, 15, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_subscribed.event, "subscribed")
         self.assertEqual(self.event_subscribed.id, 16347479)
@@ -104,7 +105,8 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_assigned.actor.login, "jacquev6")
         self.assertEqual(self.event_assigned.commit_id, None)
         self.assertEqual(
-            self.event_assigned.created_at, datetime.datetime(2012, 5, 27, 5, 40, 15)
+            self.event_assigned.created_at,
+            datetime.datetime(2012, 5, 27, 5, 40, 15, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_assigned.event, "assigned")
         self.assertEqual(self.event_assigned.id, 16347480)
@@ -134,7 +136,8 @@ class IssueEvent(Framework.TestCase):
             self.event_referenced.commit_id, "ed866fc43833802ab553e5ff8581c81bb00dd433"
         )
         self.assertEqual(
-            self.event_referenced.created_at, datetime.datetime(2012, 5, 27, 7, 29, 25)
+            self.event_referenced.created_at,
+            datetime.datetime(2012, 5, 27, 7, 29, 25, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_referenced.event, "referenced")
         self.assertEqual(self.event_referenced.id, 16348656)
@@ -165,7 +168,8 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_closed.actor.login, "jacquev6")
         self.assertEqual(self.event_closed.commit_id, None)
         self.assertEqual(
-            self.event_closed.created_at, datetime.datetime(2012, 5, 27, 11, 4, 25)
+            self.event_closed.created_at,
+            datetime.datetime(2012, 5, 27, 11, 4, 25, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_closed.event, "closed")
         self.assertEqual(self.event_closed.id, 16351220)
@@ -191,7 +195,8 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_labeled.actor.login, "jacquev6")
         self.assertEqual(self.event_labeled.commit_id, None)
         self.assertEqual(
-            self.event_labeled.created_at, datetime.datetime(2014, 3, 2, 18, 55, 10)
+            self.event_labeled.created_at,
+            datetime.datetime(2014, 3, 2, 18, 55, 10, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_labeled.event, "labeled")
         self.assertEqual(self.event_labeled.id, 98136337)
@@ -217,7 +222,8 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_mentioned.actor.login, "jzelinskie")
         self.assertEqual(self.event_mentioned.commit_id, None)
         self.assertEqual(
-            self.event_mentioned.created_at, datetime.datetime(2017, 3, 21, 17, 30, 14)
+            self.event_mentioned.created_at,
+            datetime.datetime(2017, 3, 21, 17, 30, 14, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_mentioned.event, "mentioned")
         self.assertEqual(self.event_mentioned.id, 1009034767)
@@ -247,7 +253,8 @@ class IssueEvent(Framework.TestCase):
             self.event_merged.commit_id, "2525515b094d7425f7018eb5b66171e21c5fbc10"
         )
         self.assertEqual(
-            self.event_merged.created_at, datetime.datetime(2017, 3, 25, 16, 52, 49)
+            self.event_merged.created_at,
+            datetime.datetime(2017, 3, 25, 16, 52, 49, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_merged.event, "merged")
         self.assertEqual(self.event_merged.id, 1015402964)
@@ -279,7 +286,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_review_requested.commit_id, None)
         self.assertEqual(
             self.event_review_requested.created_at,
-            datetime.datetime(2017, 3, 22, 19, 6, 44),
+            datetime.datetime(2017, 3, 22, 19, 6, 44, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_review_requested.event, "review_requested")
         self.assertEqual(self.event_review_requested.id, 1011101309)
@@ -312,7 +319,8 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_reopened.actor.login, "sfdye")
         self.assertEqual(self.event_reopened.commit_id, None)
         self.assertEqual(
-            self.event_reopened.created_at, datetime.datetime(2018, 8, 10, 13, 10, 9)
+            self.event_reopened.created_at,
+            datetime.datetime(2018, 8, 10, 13, 10, 9, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_reopened.event, "reopened")
         self.assertEqual(self.event_reopened.id, 1782463023)
@@ -340,7 +348,8 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_unassigned.actor.login, "sfdye")
         self.assertEqual(self.event_unassigned.commit_id, None)
         self.assertEqual(
-            self.event_unassigned.created_at, datetime.datetime(2018, 8, 10, 13, 10, 21)
+            self.event_unassigned.created_at,
+            datetime.datetime(2018, 8, 10, 13, 10, 21, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_unassigned.event, "unassigned")
         self.assertEqual(self.event_unassigned.id, 1782463379)
@@ -368,7 +377,8 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_unlabeled.actor.login, "sfdye")
         self.assertEqual(self.event_unlabeled.commit_id, None)
         self.assertEqual(
-            self.event_unlabeled.created_at, datetime.datetime(2018, 8, 10, 13, 10, 38)
+            self.event_unlabeled.created_at,
+            datetime.datetime(2018, 8, 10, 13, 10, 38, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_unlabeled.event, "unlabeled")
         self.assertEqual(self.event_unlabeled.id, 1782463917)
@@ -396,7 +406,8 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_renamed.actor.login, "sfdye")
         self.assertEqual(self.event_renamed.commit_id, None)
         self.assertEqual(
-            self.event_renamed.created_at, datetime.datetime(2018, 8, 10, 13, 15, 18)
+            self.event_renamed.created_at,
+            datetime.datetime(2018, 8, 10, 13, 15, 18, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_renamed.event, "renamed")
         self.assertEqual(self.event_renamed.id, 1782472556)
@@ -431,7 +442,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_base_ref_changed.commit_id, None)
         self.assertEqual(
             self.event_base_ref_changed.created_at,
-            datetime.datetime(2018, 8, 10, 16, 38, 22),
+            datetime.datetime(2018, 8, 10, 16, 38, 22, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_base_ref_changed.event, "base_ref_changed")
         self.assertEqual(self.event_base_ref_changed.id, 1782915693)
@@ -461,7 +472,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_head_ref_deleted.commit_id, None)
         self.assertEqual(
             self.event_head_ref_deleted.created_at,
-            datetime.datetime(2018, 8, 10, 16, 39, 20),
+            datetime.datetime(2018, 8, 10, 16, 39, 20, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_head_ref_deleted.event, "head_ref_deleted")
         self.assertEqual(self.event_head_ref_deleted.id, 1782917185)
@@ -491,7 +502,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_head_ref_restored.commit_id, None)
         self.assertEqual(
             self.event_head_ref_restored.created_at,
-            datetime.datetime(2018, 8, 10, 16, 39, 23),
+            datetime.datetime(2018, 8, 10, 16, 39, 23, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_head_ref_restored.event, "head_ref_restored")
         self.assertEqual(self.event_head_ref_restored.id, 1782917299)
@@ -522,7 +533,8 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_milestoned.actor.login, "sfdye")
         self.assertEqual(self.event_milestoned.commit_id, None)
         self.assertEqual(
-            self.event_milestoned.created_at, datetime.datetime(2018, 8, 11, 0, 46, 19)
+            self.event_milestoned.created_at,
+            datetime.datetime(2018, 8, 11, 0, 46, 19, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_milestoned.event, "milestoned")
         self.assertEqual(self.event_milestoned.id, 1783596418)
@@ -551,7 +563,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_demilestoned.commit_id, None)
         self.assertEqual(
             self.event_demilestoned.created_at,
-            datetime.datetime(2018, 8, 11, 0, 46, 22),
+            datetime.datetime(2018, 8, 11, 0, 46, 22, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_demilestoned.event, "demilestoned")
         self.assertEqual(self.event_demilestoned.id, 1783596452)
@@ -580,7 +592,8 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_locked.actor.login, "PyGithub")
         self.assertEqual(self.event_locked.commit_id, None)
         self.assertEqual(
-            self.event_locked.created_at, datetime.datetime(2018, 8, 11, 0, 46, 56)
+            self.event_locked.created_at,
+            datetime.datetime(2018, 8, 11, 0, 46, 56, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_locked.event, "locked")
         self.assertEqual(self.event_locked.id, 1783596743)
@@ -608,7 +621,8 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_unlocked.actor.login, "PyGithub")
         self.assertEqual(self.event_unlocked.commit_id, None)
         self.assertEqual(
-            self.event_unlocked.created_at, datetime.datetime(2018, 8, 11, 0, 47, 7)
+            self.event_unlocked.created_at,
+            datetime.datetime(2018, 8, 11, 0, 47, 7, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_unlocked.event, "unlocked")
         self.assertEqual(self.event_unlocked.id, 1783596818)
@@ -637,7 +651,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_review_dismissed.commit_id, None)
         self.assertEqual(
             self.event_review_dismissed.created_at,
-            datetime.datetime(2018, 8, 11, 1, 7, 10),
+            datetime.datetime(2018, 8, 11, 1, 7, 10, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_review_dismissed.event, "review_dismissed")
         self.assertEqual(self.event_review_dismissed.id, 1783605084)
@@ -674,7 +688,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_review_request_removed.commit_id, None)
         self.assertEqual(
             self.event_review_request_removed.created_at,
-            datetime.datetime(2018, 8, 11, 12, 32, 59),
+            datetime.datetime(2018, 8, 11, 12, 32, 59, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.event_review_request_removed.event, "review_request_removed"
@@ -712,7 +726,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_marked_as_duplicate.commit_id, None)
         self.assertEqual(
             self.event_marked_as_duplicate.created_at,
-            datetime.datetime(2018, 8, 11, 12, 32, 35),
+            datetime.datetime(2018, 8, 11, 12, 32, 35, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_marked_as_duplicate.event, "marked_as_duplicate")
         self.assertEqual(self.event_marked_as_duplicate.id, 1783779725)
@@ -744,7 +758,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_unmarked_as_duplicate.commit_id, None)
         self.assertEqual(
             self.event_unmarked_as_duplicate.created_at,
-            datetime.datetime(2018, 8, 15, 2, 57, 46),
+            datetime.datetime(2018, 8, 15, 2, 57, 46, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.event_unmarked_as_duplicate.event, "unmarked_as_duplicate"
@@ -778,7 +792,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_added_to_project.commit_id, None)
         self.assertEqual(
             self.event_added_to_project.created_at,
-            datetime.datetime(2018, 8, 16, 8, 13, 24),
+            datetime.datetime(2018, 8, 16, 8, 13, 24, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_added_to_project.event, "added_to_project")
         self.assertEqual(self.event_added_to_project.id, 1791766828)
@@ -808,7 +822,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_moved_columns_in_project.commit_id, None)
         self.assertEqual(
             self.event_moved_columns_in_project.created_at,
-            datetime.datetime(2018, 8, 16, 8, 13, 55),
+            datetime.datetime(2018, 8, 16, 8, 13, 55, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.event_moved_columns_in_project.event, "moved_columns_in_project"
@@ -842,7 +856,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_removed_from_project.commit_id, None)
         self.assertEqual(
             self.event_removed_from_project.created_at,
-            datetime.datetime(2018, 8, 16, 8, 14, 8),
+            datetime.datetime(2018, 8, 16, 8, 14, 8, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.event_removed_from_project.event, "removed_from_project")
         self.assertEqual(self.event_removed_from_project.id, 1791768212)
@@ -874,7 +888,7 @@ class IssueEvent(Framework.TestCase):
         self.assertEqual(self.event_converted_note_to_issue.commit_id, None)
         self.assertEqual(
             self.event_converted_note_to_issue.created_at,
-            datetime.datetime(2018, 8, 16, 8, 14, 34),
+            datetime.datetime(2018, 8, 16, 8, 14, 34, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.event_converted_note_to_issue.event, "converted_note_to_issue"

--- a/tests/Migration.py
+++ b/tests/Migration.py
@@ -71,10 +71,14 @@ class Migration(Framework.TestCase):
             self.migration.url, "https://api.github.com/user/migrations/25320"
         )
         self.assertEqual(
-            self.migration.created_at, datetime.datetime(2018, 9, 14, 1, 35, 35)
+            self.migration.created_at,
+            datetime.datetime(
+                2018, 9, 14, 1, 35, 35, tzinfo=datetime.timezone(datetime.timedelta(0))
+            ),
         )
         self.assertEqual(
-            self.migration.updated_at, datetime.datetime(2018, 9, 14, 1, 35, 46)
+            self.migration.updated_at,
+            datetime.datetime(2018, 9, 14, 1, 35, 46, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             repr(self.migration),

--- a/tests/Migration.py
+++ b/tests/Migration.py
@@ -47,6 +47,8 @@
 
 import datetime
 
+from dateutil.tz.tz import tzoffset
+
 import github
 
 from . import Framework
@@ -72,13 +74,11 @@ class Migration(Framework.TestCase):
         )
         self.assertEqual(
             self.migration.created_at,
-            datetime.datetime(
-                2018, 9, 14, 1, 35, 35, tzinfo=datetime.timezone(datetime.timedelta(0))
-            ),
+            datetime.datetime(2018, 9, 14, 1, 35, 35, tzinfo=tzoffset(None, 19800)),
         )
         self.assertEqual(
             self.migration.updated_at,
-            datetime.datetime(2018, 9, 14, 1, 35, 46, tzinfo=datetime.timezone.utc),
+            datetime.datetime(2018, 9, 14, 1, 35, 46, tzinfo=tzoffset(None, 19800)),
         )
         self.assertEqual(
             repr(self.migration),

--- a/tests/Milestone.py
+++ b/tests/Milestone.py
@@ -39,10 +39,14 @@ class Milestone(Framework.TestCase):
     def testAttributes(self):
         self.assertEqual(self.milestone.closed_issues, 2)
         self.assertEqual(
-            self.milestone.created_at, datetime.datetime(2012, 3, 8, 12, 22, 10)
+            self.milestone.created_at,
+            datetime.datetime(2012, 3, 8, 12, 22, 10, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.milestone.description, "")
-        self.assertEqual(self.milestone.due_on, datetime.datetime(2012, 3, 13, 7, 0, 0))
+        self.assertEqual(
+            self.milestone.due_on,
+            datetime.datetime(2012, 3, 13, 7, 0, 0, tzinfo=datetime.timezone.utc),
+        )
         self.assertEqual(self.milestone.id, 93546)
         self.assertEqual(self.milestone.number, 1)
         self.assertEqual(self.milestone.open_issues, 0)
@@ -71,7 +75,10 @@ class Milestone(Framework.TestCase):
         self.assertEqual(self.milestone.title, "Title edited twice by PyGithub")
         self.assertEqual(self.milestone.state, "closed")
         self.assertEqual(self.milestone.description, "Description edited by PyGithub")
-        self.assertEqual(self.milestone.due_on, datetime.datetime(2012, 6, 16, 7, 0, 0))
+        self.assertEqual(
+            self.milestone.due_on,
+            datetime.datetime(2012, 6, 16, 7, 0, 0, tzinfo=datetime.timezone.utc),
+        )
 
     def testGetLabels(self):
         self.assertListKeyEqual(

--- a/tests/NamedUser.py
+++ b/tests/NamedUser.py
@@ -50,7 +50,8 @@ class NamedUser(Framework.TestCase):
         self.assertEqual(self.user.collaborators, None)
         self.assertEqual(self.user.company, "3rd Cloud")
         self.assertEqual(
-            self.user.created_at, datetime.datetime(2009, 5, 12, 21, 19, 38)
+            self.user.created_at,
+            datetime.datetime(2009, 5, 12, 21, 19, 38, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.user.disk_usage, None)
         self.assertEqual(self.user.email, "vincent@3rdcloud.com")
@@ -85,7 +86,10 @@ class NamedUser(Framework.TestCase):
         self.assertEqual(self.user.blog, "http://vincent-jacques.net")
         self.assertEqual(self.user.collaborators, 0)
         self.assertEqual(self.user.company, "Criteo")
-        self.assertEqual(self.user.created_at, datetime.datetime(2010, 7, 9, 6, 10, 6))
+        self.assertEqual(
+            self.user.created_at,
+            datetime.datetime(2010, 7, 9, 6, 10, 6, tzinfo=datetime.timezone.utc),
+        )
         self.assertEqual(self.user.disk_usage, 17080)
         self.assertEqual(self.user.email, "vincent@vincent-jacques.net")
         self.assertEqual(self.user.followers, 13)
@@ -106,7 +110,8 @@ class NamedUser(Framework.TestCase):
         self.assertEqual(self.user.public_gists, 2)
         self.assertEqual(self.user.public_repos, 11)
         self.assertEqual(
-            self.user.suspended_at, datetime.datetime(2013, 8, 10, 7, 11, 7)
+            self.user.suspended_at,
+            datetime.datetime(2013, 8, 10, 7, 11, 7, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.user.total_private_repos, 5)
         self.assertIsNone(self.user.twitter_username)

--- a/tests/Organization.py
+++ b/tests/Organization.py
@@ -53,7 +53,10 @@ class Organization(Framework.TestCase):
         self.assertEqual(self.org.blog, "http://www.example.com")
         self.assertEqual(self.org.collaborators, 9)
         self.assertEqual(self.org.company, None)
-        self.assertEqual(self.org.created_at, datetime.datetime(2014, 1, 9, 16, 56, 17))
+        self.assertEqual(
+            self.org.created_at,
+            datetime.datetime(2014, 1, 9, 16, 56, 17, tzinfo=datetime.timezone.utc),
+        )
         self.assertEqual(self.org.default_repository_permission, "none")
         self.assertEqual(self.org.description, "BeaverSoftware writes software.")
         self.assertEqual(self.org.disk_usage, 2)

--- a/tests/ProjectColumn.py
+++ b/tests/ProjectColumn.py
@@ -49,11 +49,11 @@ class ProjectColumn(Framework.TestCase):
         )
         self.assertEqual(
             self.get_project_column.created_at,
-            datetime.datetime(2020, 4, 13, 20, 29, 53),
+            datetime.datetime(2020, 4, 13, 20, 29, 53, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.get_project_column.updated_at,
-            datetime.datetime(2020, 4, 14, 18, 9, 38),
+            datetime.datetime(2020, 4, 14, 18, 9, 38, tzinfo=datetime.timezone.utc),
         )
 
     def testGetAllCards(self):

--- a/tests/PullRequest.py
+++ b/tests/PullRequest.py
@@ -52,11 +52,11 @@ class PullRequest(Framework.TestCase):
     def testAttributesIssue256(self):
         self.assertEqual(
             self.pullIssue256Closed.closed_at,
-            datetime.datetime(2018, 5, 22, 14, 50, 43),
+            datetime.datetime(2018, 5, 22, 14, 50, 43, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.pullIssue256Merged.closed_at,
-            datetime.datetime(2018, 5, 22, 14, 53, 13),
+            datetime.datetime(2018, 5, 22, 14, 53, 13, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.pullIssue256Conflict.closed_at, None)
         self.assertEqual(self.pullIssue256Uncached.closed_at, None)
@@ -96,11 +96,15 @@ class PullRequest(Framework.TestCase):
         self.assertEqual(self.pull.base.repo.full_name, "jacquev6/PyGithub")
         self.assertEqual(self.pull.body, "Body edited by PyGithub")
         self.assertEqual(self.pull.changed_files, 45)
-        self.assertEqual(self.pull.closed_at, datetime.datetime(2012, 5, 27, 10, 29, 7))
+        self.assertEqual(
+            self.pull.closed_at,
+            datetime.datetime(2012, 5, 27, 10, 29, 7, tzinfo=datetime.timezone.utc),
+        )
         self.assertEqual(self.pull.comments, 1)
         self.assertEqual(self.pull.commits, 3)
         self.assertEqual(
-            self.pull.created_at, datetime.datetime(2012, 5, 27, 9, 25, 36)
+            self.pull.created_at,
+            datetime.datetime(2012, 5, 27, 9, 25, 36, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.pull.deletions, 384)
         self.assertEqual(
@@ -119,7 +123,10 @@ class PullRequest(Framework.TestCase):
         self.assertFalse(self.pull.mergeable)
         self.assertFalse(self.pull.rebaseable)
         self.assertTrue(self.pull.merged)
-        self.assertEqual(self.pull.merged_at, datetime.datetime(2012, 5, 27, 10, 29, 7))
+        self.assertEqual(
+            self.pull.merged_at,
+            datetime.datetime(2012, 5, 27, 10, 29, 7, tzinfo=datetime.timezone.utc),
+        )
         self.assertEqual(self.pull.merged_by.login, "jacquev6")
         self.assertEqual(self.pull.number, 31)
         self.assertEqual(
@@ -129,7 +136,8 @@ class PullRequest(Framework.TestCase):
         self.assertEqual(self.pull.state, "closed")
         self.assertEqual(self.pull.title, "Title edited by PyGithub")
         self.assertEqual(
-            self.pull.updated_at, datetime.datetime(2012, 11, 3, 8, 19, 40)
+            self.pull.updated_at,
+            datetime.datetime(2012, 11, 3, 8, 19, 40, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.pull.url, "https://api.github.com/repos/jacquev6/PyGithub/pulls/31"

--- a/tests/PullRequestComment.py
+++ b/tests/PullRequestComment.py
@@ -46,7 +46,8 @@ class PullRequestComment(Framework.TestCase):
             self.comment.commit_id, "8a4f306d4b223682dd19410d4a9150636ebe4206"
         )
         self.assertEqual(
-            self.comment.created_at, datetime.datetime(2012, 5, 27, 9, 40, 12)
+            self.comment.created_at,
+            datetime.datetime(2012, 5, 27, 9, 40, 12, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.comment.id, 886298)
         self.assertEqual(
@@ -56,7 +57,8 @@ class PullRequestComment(Framework.TestCase):
         self.assertEqual(self.comment.path, "src/github/Issue.py")
         self.assertEqual(self.comment.position, 5)
         self.assertEqual(
-            self.comment.updated_at, datetime.datetime(2012, 5, 27, 9, 40, 12)
+            self.comment.updated_at,
+            datetime.datetime(2012, 5, 27, 9, 40, 12, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.comment.url,

--- a/tests/PullRequestReview.py
+++ b/tests/PullRequestReview.py
@@ -73,7 +73,8 @@ class PullRequestReview(Framework.TestCase):
             "https://api.github.com/repos/PyGithub/PyGithub/pulls/538",
         )
         self.assertEqual(
-            self.pullreview.submitted_at, datetime.datetime(2017, 3, 22, 19, 6, 59)
+            self.pullreview.submitted_at,
+            datetime.datetime(2017, 3, 22, 19, 6, 59, tzinfo=datetime.timezone.utc),
         )
         self.assertIn(self.created_pullreview.id, [r.id for r in self.pullreviews])
         self.assertEqual(

--- a/tests/RateLimiting.py
+++ b/tests/RateLimiting.py
@@ -45,12 +45,15 @@ class RateLimiting(Framework.TestCase):
         rateLimit = self.g.get_rate_limit()
         self.assertEqual(
             repr(rateLimit),
-            "RateLimit(core=Rate(reset=2018-09-05 04:55:56, remaining=4929, limit=5000))",
+            "RateLimit(core=Rate(reset=2018-09-05 04:55:56+00:00, remaining=4929, limit=5000))",
         )
         self.assertEqual(
             repr(rateLimit.core),
-            "Rate(reset=2018-09-05 04:55:56, remaining=4929, limit=5000)",
+            "Rate(reset=2018-09-05 04:55:56+00:00, remaining=4929, limit=5000)",
         )
         self.assertEqual(rateLimit.core.limit, 5000)
         self.assertEqual(rateLimit.core.remaining, 4929)
-        self.assertEqual(rateLimit.core.reset, datetime.datetime(2018, 9, 5, 4, 55, 56))
+        self.assertEqual(
+            rateLimit.core.reset,
+            datetime.datetime(2018, 9, 5, 4, 55, 56, tzinfo=datetime.timezone.utc),
+        )

--- a/tests/Reaction.py
+++ b/tests/Reaction.py
@@ -39,7 +39,8 @@ class Reaction(Framework.TestCase):
     def testAttributes(self):
         self.assertEqual(self.reactions[0].content, "+1")
         self.assertEqual(
-            self.reactions[0].created_at, datetime.datetime(2017, 12, 5, 1, 59, 33)
+            self.reactions[0].created_at,
+            datetime.datetime(2017, 12, 5, 1, 59, 33, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(self.reactions[0].id, 16916340)
         self.assertEqual(self.reactions[0].user.login, "nicolastrres")

--- a/tests/ReleaseAsset.py
+++ b/tests/ReleaseAsset.py
@@ -47,10 +47,12 @@ class ReleaseAsset(Framework.TestCase):
         self.assertEqual(self.asset.size, 3783)
         self.assertEqual(self.asset.download_count, 2)
         self.assertEqual(
-            self.asset.created_at, datetime.datetime(2017, 2, 1, 22, 40, 58)
+            self.asset.created_at,
+            datetime.datetime(2017, 2, 1, 22, 40, 58, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
-            self.asset.updated_at, datetime.datetime(2017, 2, 1, 22, 44, 58)
+            self.asset.updated_at,
+            datetime.datetime(2017, 2, 1, 22, 44, 58, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.asset.browser_download_url,

--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -65,7 +65,8 @@ class Repository(Framework.TestCase):
             self.repo.clone_url, "https://github.com/jacquev6/PyGithub.git"
         )
         self.assertEqual(
-            self.repo.created_at, datetime.datetime(2012, 2, 25, 12, 53, 47)
+            self.repo.created_at,
+            datetime.datetime(2012, 2, 25, 12, 53, 47, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.repo.description, "Python library implementing the full Github API v3"
@@ -101,13 +102,17 @@ class Repository(Framework.TestCase):
         self.assertTrue(self.repo.permissions.pull)
         self.assertTrue(self.repo.permissions.push)
         self.assertFalse(self.repo.private)
-        self.assertEqual(self.repo.pushed_at, datetime.datetime(2012, 5, 27, 6, 0, 28))
+        self.assertEqual(
+            self.repo.pushed_at,
+            datetime.datetime(2012, 5, 27, 6, 0, 28, tzinfo=datetime.timezone.utc),
+        )
         self.assertEqual(self.repo.size, 308)
         self.assertEqual(self.repo.source, None)
         self.assertEqual(self.repo.ssh_url, "git@github.com:jacquev6/PyGithub.git")
         self.assertEqual(self.repo.svn_url, "https://github.com/jacquev6/PyGithub")
         self.assertEqual(
-            self.repo.updated_at, datetime.datetime(2012, 5, 27, 6, 55, 28)
+            self.repo.updated_at,
+            datetime.datetime(2012, 5, 27, 6, 55, 28, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             self.repo.url, "https://api.github.com/repos/jacquev6/PyGithub"
@@ -477,11 +482,11 @@ class Repository(Framework.TestCase):
         )
         self.assertEqual(
             codescan_alert.created_at,
-            datetime.datetime(2021, 6, 29, 12, 28, 30),
+            datetime.datetime(2021, 6, 29, 12, 28, 30, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(
             codescan_alert.dismissed_at,
-            datetime.datetime(2021, 6, 30, 5, 5, 5),
+            datetime.datetime(2021, 6, 30, 5, 5, 5, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(codescan_alert.dismissed_reason, "Won't tell")
         dismissed_by = codescan_alert.dismissed_by
@@ -991,7 +996,11 @@ class Repository(Framework.TestCase):
             ],
         )
         self.assertListKeyEqual(
-            self.repo.get_issues(since=datetime.datetime(2012, 5, 28, 23, 0, 0)),
+            self.repo.get_issues(
+                since=datetime.datetime(
+                    2012, 5, 28, 23, 0, 0, tzinfo=datetime.timezone.utc
+                )
+            ),
             lambda i: i.id,
             [4793216, 4793162, 4793106, 3624556, 3619973, 3527266],
         )
@@ -1238,12 +1247,42 @@ class Repository(Framework.TestCase):
             stargazers,
             lambda stargazer: (stargazer.starred_at, stargazer.user.login),
             [
-                (datetime.datetime(2014, 8, 13, 19, 22, 5), "sAlexander"),
-                (datetime.datetime(2014, 10, 15, 5, 2, 30), "ThomasG77"),
-                (datetime.datetime(2015, 4, 14, 15, 22, 40), "therusek"),
-                (datetime.datetime(2015, 4, 29, 0, 9, 40), "athomann"),
-                (datetime.datetime(2015, 4, 29, 14, 26, 46), "jcapron"),
-                (datetime.datetime(2015, 5, 9, 19, 14, 45), "JoePython1"),
+                (
+                    datetime.datetime(
+                        2014, 8, 13, 19, 22, 5, tzinfo=datetime.timezone.utc
+                    ),
+                    "sAlexander",
+                ),
+                (
+                    datetime.datetime(
+                        2014, 10, 15, 5, 2, 30, tzinfo=datetime.timezone.utc
+                    ),
+                    "ThomasG77",
+                ),
+                (
+                    datetime.datetime(
+                        2015, 4, 14, 15, 22, 40, tzinfo=datetime.timezone.utc
+                    ),
+                    "therusek",
+                ),
+                (
+                    datetime.datetime(
+                        2015, 4, 29, 0, 9, 40, tzinfo=datetime.timezone.utc
+                    ),
+                    "athomann",
+                ),
+                (
+                    datetime.datetime(
+                        2015, 4, 29, 14, 26, 46, tzinfo=datetime.timezone.utc
+                    ),
+                    "jcapron",
+                ),
+                (
+                    datetime.datetime(
+                        2015, 5, 9, 19, 14, 45, tzinfo=datetime.timezone.utc
+                    ),
+                    "JoePython1",
+                ),
             ],
         )
         self.assertEqual(repr(stargazers[0]), 'Stargazer(user="sAlexander")')
@@ -1315,13 +1354,17 @@ class Repository(Framework.TestCase):
         # Attributes retrieved from legacy API without lazy completion call
         self.assertEqual(issues[0].number, 49)
         self.assertEqual(
-            issues[0].created_at, datetime.datetime(2012, 6, 21, 12, 27, 38)
+            issues[0].created_at,
+            datetime.datetime(
+                2012, 6, 21, 12, 27, 38, tzinfo=datetime.timezone(datetime.timedelta(0))
+            ),
         )
         self.assertEqual(issues[0].comments, 4)
         self.assertEqual(issues[0].body[:20], "New API ported from ")
         self.assertEqual(issues[0].title, "Support new Search API")
         self.assertEqual(
-            issues[0].updated_at, datetime.datetime(2012, 6, 28, 21, 13, 25)
+            issues[0].updated_at,
+            datetime.datetime(2012, 6, 28, 21, 13, 25, tzinfo=datetime.timezone.utc),
         )
         self.assertEqual(issues[0].user.login, "kukuts")
         self.assertEqual(issues[0].user.url, "/users/kukuts")
@@ -1685,18 +1728,27 @@ class Repository(Framework.TestCase):
             if s.author.login == "jacquev6":
                 seenJacquev6 = True
                 self.assertEqual(adTotal, 282147)
-                self.assertEqual(s.weeks[0].w, datetime.datetime(2012, 2, 12))
+                self.assertEqual(
+                    s.weeks[0].w,
+                    datetime.datetime(2012, 2, 12, tzinfo=datetime.timezone.utc),
+                )
         self.assertTrue(seenJacquev6)
 
     def testStatisticsCommitActivity(self):
         stats = self.repo.get_stats_commit_activity()
-        self.assertEqual(stats[0].week, datetime.datetime(2012, 11, 18, 0, 0))
+        self.assertEqual(
+            stats[0].week,
+            datetime.datetime(2012, 11, 18, 0, 0, tzinfo=datetime.timezone.utc),
+        )
         self.assertEqual(stats[0].total, 29)
         self.assertEqual(stats[0].days, [0, 7, 3, 9, 7, 3, 0])
 
     def testStatisticsCodeFrequency(self):
         stats = self.repo.get_stats_code_frequency()
-        self.assertEqual(stats[0].week, datetime.datetime(2012, 2, 12, 0, 0))
+        self.assertEqual(
+            stats[0].week,
+            datetime.datetime(2012, 2, 12, 0, 0, tzinfo=datetime.timezone.utc),
+        )
         self.assertEqual(stats[0].additions, 3853)
         self.assertEqual(stats[0].deletions, -2098)
 

--- a/tests/RepositoryKey.py
+++ b/tests/RepositoryKey.py
@@ -51,7 +51,10 @@ class RepositoryKey(Framework.TestCase):
         self.assertEqual(
             self.key.url, "https://api.github.com/repos/lra/mackup/keys/21870881"
         )
-        self.assertEqual(self.key.created_at, datetime.datetime(2017, 2, 22, 8, 16, 23))
+        self.assertEqual(
+            self.key.created_at,
+            datetime.datetime(2017, 2, 22, 8, 16, 23, tzinfo=datetime.timezone.utc),
+        )
         self.assertTrue(self.key.verified)
         self.assertTrue(self.key.read_only)
         self.assertEqual(

--- a/tests/Team.py
+++ b/tests/Team.py
@@ -34,7 +34,7 @@
 
 
 import warnings
-from datetime import datetime
+from datetime import datetime, timezone
 
 from . import Framework
 
@@ -75,7 +75,9 @@ class Team(Framework.TestCase):
         self.assertEqual(
             d.comments_url, "https://api.github.com/teams/189850/discussions/1/comments"
         )
-        self.assertEqual(d.created_at, datetime(2019, 10, 8, 21, 3, 36))
+        self.assertEqual(
+            d.created_at, datetime(2019, 10, 8, 21, 3, 36, tzinfo=timezone.utc)
+        )
         self.assertEqual(
             d.html_url,
             "https://github.com/orgs/BeaverSoftware/teams/Team/discussions/1",
@@ -87,7 +89,9 @@ class Team(Framework.TestCase):
         self.assertEqual(d.private, False)
         self.assertEqual(d.team_url, "https://api.github.com/teams/189850")
         self.assertEqual(d.title, "TITLE")
-        self.assertEqual(d.updated_at, datetime(2019, 10, 8, 21, 3, 36))
+        self.assertEqual(
+            d.updated_at, datetime(2019, 10, 8, 21, 3, 36, tzinfo=timezone.utc)
+        )
         self.assertEqual(d.url, "https://api.github.com/teams/189850/discussions/1")
         self.assertEqual(repr(d), 'TeamDiscussion(title="TITLE", number=1)')
 

--- a/tests/Topic.py
+++ b/tests/Topic.py
@@ -21,7 +21,7 @@
 ################################################################################
 
 
-from datetime import datetime
+from datetime import datetime, timezone
 from operator import attrgetter
 
 from . import Framework
@@ -47,8 +47,12 @@ class Topic(Framework.TestCase):
         )
         self.assertEqual(topic.created_by, "Guido van Rossum")
         self.assertEqual(topic.released, "February 20, 1991")
-        self.assertEqual(topic.created_at, datetime(2016, 12, 7, 0, 7, 2))
-        self.assertEqual(topic.updated_at, datetime(2019, 10, 9, 20, 33, 49))
+        self.assertEqual(
+            topic.created_at, datetime(2016, 12, 7, 0, 7, 2, tzinfo=timezone.utc)
+        )
+        self.assertEqual(
+            topic.updated_at, datetime(2019, 10, 9, 20, 33, 49, tzinfo=timezone.utc)
+        )
         self.assertEqual(topic.featured, True)
         self.assertEqual(topic.curated, True)
         self.assertEqual(topic.score, 7576.306)

--- a/tests/Traffic.py
+++ b/tests/Traffic.py
@@ -68,10 +68,14 @@ class Traffic(Framework.TestCase):
         self.assertEqual(len(viewsResponse["views"]), 5)
         view_obj = viewsResponse["views"][0]
         self.assertEqual(view_obj.uniques, 4)
-        self.assertEqual(view_obj.timestamp, datetime.datetime(2018, 11, 27, 0, 0))
+        self.assertEqual(
+            view_obj.timestamp,
+            datetime.datetime(2018, 11, 27, 0, 0, tzinfo=datetime.timezone.utc),
+        )
         self.assertEqual(view_obj.count, 56)
         self.assertEqual(
-            repr(view_obj), "View(uniques=4, timestamp=2018-11-27 00:00:00, count=56)"
+            repr(view_obj),
+            "View(uniques=4, timestamp=2018-11-27 00:00:00+00:00, count=56)",
         )
 
     def testGetClones(self):
@@ -81,8 +85,12 @@ class Traffic(Framework.TestCase):
         self.assertEqual(len(clonesResponse["clones"]), 1)
         clone_obj = clonesResponse["clones"][0]
         self.assertEqual(clone_obj.uniques, 4)
-        self.assertEqual(clone_obj.timestamp, datetime.datetime(2018, 11, 27, 0, 0))
+        self.assertEqual(
+            clone_obj.timestamp,
+            datetime.datetime(2018, 11, 27, 0, 0, tzinfo=datetime.timezone.utc),
+        )
         self.assertEqual(clone_obj.count, 4)
         self.assertEqual(
-            repr(clone_obj), "Clones(uniques=4, timestamp=2018-11-27 00:00:00, count=4)"
+            repr(clone_obj),
+            "Clones(uniques=4, timestamp=2018-11-27 00:00:00+00:00, count=4)",
         )

--- a/tests/Workflow.py
+++ b/tests/Workflow.py
@@ -39,7 +39,9 @@ class Workflow(Framework.TestCase):
         self.assertEqual(self.workflow.name, "check")
         self.assertEqual(self.workflow.path, ".github/workflows/check.yml")
         self.assertEqual(self.workflow.state, "active")
-        timestamp = datetime.datetime(2020, 4, 15, 0, 48, 32)
+        timestamp = datetime.datetime(
+            2020, 4, 15, 0, 48, 32, tzinfo=datetime.timezone.utc
+        )
         self.assertEqual(self.workflow.created_at, timestamp)
         self.assertEqual(self.workflow.updated_at, timestamp)
         self.assertEqual(

--- a/tests/WorkflowRun.py
+++ b/tests/WorkflowRun.py
@@ -55,9 +55,13 @@ class WorkflowRun(Framework.TestCase):
             "https://github.com/PyGithub/PyGithub/actions/runs/148274629",
         )
         self.assertEqual(self.workflow_run.pull_requests, [])
-        created_at = datetime.datetime(2020, 6, 26, 4, 51, 26)
+        created_at = datetime.datetime(
+            2020, 6, 26, 4, 51, 26, tzinfo=datetime.timezone.utc
+        )
         self.assertEqual(self.workflow_run.created_at, created_at)
-        updated_at = datetime.datetime(2020, 6, 26, 4, 52, 59)
+        updated_at = datetime.datetime(
+            2020, 6, 26, 4, 52, 59, tzinfo=datetime.timezone.utc
+        )
         self.assertEqual(self.workflow_run.updated_at, updated_at)
         self.assertEqual(
             self.workflow_run.jobs_url,

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ deps =
     types-requests
     pre-commit
     mypy
+    types-python-dateutil
 commands =
     pre-commit run --all-files --show-diff-on-failure
     ; Run mypy outside pre-commit because pre-commit runs mypy in a venv


### PR DESCRIPTION
Timestamps returned by the GitHub API include timezone information, yet PyGithub throws this information away.  This can lead to wrong results in client code, as naïve timestamps are generally assumed to use the system time zone, yet the majority of timestamps returned by the API are in UTC.  This PR fixes the library to retain timezone information when parsing timestamps and always produce timezone-aware `datetime` objects.