### PR TITLE
Add GitRelease.upload_asset_from_memory stub

### DIFF
--- a/github/GitRelease.pyi
+++ b/github/GitRelease.pyi
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict, Union
+from typing import Any, Dict, IO, Union
 
 from github.GithubObject import CompletableGithubObject, _NotSetType
 from github.GitReleaseAsset import GitReleaseAsset
@@ -51,6 +51,14 @@ class GitRelease(CompletableGithubObject):
         label: str = ...,
         content_type: Union[_NotSetType, str] = ...,
         name: Union[_NotSetType, str] = ...,
+    ) -> GitReleaseAsset: ...
+    def upload_asset_from_memory(
+        self,
+        file_like: IO[Any],
+        file_size: int,
+        name: str,
+        content_type: Union[_NotSetType, str] = ...,
+        label: str = ...,
     ) -> GitReleaseAsset: ...
     @property
     def upload_url(self) -> str: ...


### PR DESCRIPTION
PyGithub v1.54.1 does not have an interface/stub for the `GitRelease.upload_asset_from_memory` method. One consequence of this is that mypy will not recognize that this method exists.

This PR adds that missing stub. There is no "code change" per se.

The types I chose for the arguments and the return type match what is documented on the [method docstring](https://github.com/PyGithub/PyGithub/blob/master/github/GitRelease.py#L275), and from a cursory read through, appear to match what the code itself requires.

The only interesting one was the `file_like` argument. Our docstring is perhaps a little restrictive in asking for an object that ["must implement `read()`"](https://github.com/PyGithub/PyGithub/blob/v1.54.1/github/GitRelease.py#L278) because this object [is later used](https://github.com/PyGithub/PyGithub/blob/v1.54.1/github/Requester.py#L108) by the requests library, which has a much broader requirement of a ["Dictionary, list of tuples, bytes, or file-like object to send"](https://github.com/psf/requests/blob/v2.25.1/requests/sessions.py#L481).

Without wanting to expand the scope of this PR too much, I chose to stick to file-like objects as the docstring asks for. This type could be summed up as `IO[Any]`. My reference for that comes from noting how this argument is passed by PyGithub to requests, which passes it to urllib3, which passes it to `http.client`, which finally has a [typeshed stub](https://github.com/python/typeshed/blob/master/stdlib/http/client.pyi#L166) describing the argument as [`Union[bytes, IO[Any], Iterable[bytes], str]`](https://github.com/python/typeshed/blob/master/stdlib/http/client.pyi#L26). The `IO[Any]` one seems to fit best.

I'm not really sure how to test stubs... But here's one method that might be sufficient:

1. Save this code to `foo.py`:
    ```python
    from pathlib import Path
    from github import Github
    
    gh = Github(login_or_token="api_token")
    repo = gh.get_repo("user/repo")
    release = repo.get_release("some release")
    
    asset_path = Path("./foo.txt")
    
    with asset_path.open("rb") as asset_file:
        release.upload_asset_from_memory(
            file_like=asset_file,
            file_size=asset_path.stat().st_size,
            name="foo"
        )
    ```
2. Run `mypy foo.py` and note the error `error: "GitRelease" has no attribute "upload_asset_from_memory"`
3. Apply this patch, run mypy again, and see how the error is gone.