### PR TITLE
Updating links to Github documentation

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1221,7 +1221,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def create_key(self, title, key, read_only=False):
         """
-        :calls: `POST /repos/:owner/:repo/keys <http://developer.github.com/v3/repos/keys>`_
+        :calls: `POST /repos/:owner/:repo/keys <http://developer.github.com/v3/repos/#deploy-keys>`_
         :param title: string
         :param key: string
         :param read_only: bool
@@ -2565,7 +2565,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_key(self, id):
         """
-        :calls: `GET /repos/:owner/:repo/keys/:id <http://developer.github.com/v3/repos/keys>`_
+        :calls: `GET /repos/:owner/:repo/keys/:id <http://developer.github.com/v3/repos/#deploy-keys>`_
         :param id: integer
         :rtype: :class:`github.RepositoryKey.RepositoryKey`
         """
@@ -2579,7 +2579,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_keys(self):
         """
-        :calls: `GET /repos/:owner/:repo/keys <http://developer.github.com/v3/repos/keys>`_
+        :calls: `GET /repos/:owner/:repo/keys <http://developer.github.com/v3/repos/#deploy-keys>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.RepositoryKey.RepositoryKey`
         """
         return github.PaginatedList.PaginatedList(

--- a/github/RepositoryKey.py
+++ b/github/RepositoryKey.py
@@ -38,7 +38,7 @@ import github.GithubObject
 
 class RepositoryKey(github.GithubObject.CompletableGithubObject):
     """
-    This class represents RepositoryKeys. The reference can be found here http://developer.github.com/v3/repos/keys/
+    This class represents RepositoryKeys. The reference can be found here http://developer.github.com/v3/repos/#deploy-keys
     """
 
     def __repr__(self):
@@ -102,7 +102,7 @@ class RepositoryKey(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/keys/:id <http://developer.github.com/v3/repos/keys>`_
+        :calls: `DELETE /repos/:owner/:repo/keys/:id <http://developer.github.com/v3/repos/#deploy-keys>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("DELETE", self.url)


### PR DESCRIPTION
There are a couple of links to http://developer.github.com/v3/repos/keys/ and I believe these should be going to http://developer.github.com/v3/repos/#deploy-keys. I've updated the docstrings in this file appropriately.