### PR TITLE
Add default arguments to Workflow method type annotations

### DIFF
--- a/github/Workflow.pyi
+++ b/github/Workflow.pyi
@@ -16,14 +16,14 @@ class Workflow(CompletableGithubObject):
     def create_dispatch(
         self,
         ref: Union[str, Branch, Commit, Tag],
-        inputs: Union[Dict[str, Union[str, int, float]], _NotSetType],
+        inputs: Union[Dict[str, Union[str, int, float]], _NotSetType] = ...,
     ) -> bool: ...
     def get_runs(
         self,
-        actor: Union[str, NamedUser, _NotSetType],
-        branch: Union[str, Branch, _NotSetType],
-        event: Union[str, _NotSetType],
-        status: Union[str, _NotSetType],
+        actor: Union[str, NamedUser, _NotSetType] = ...,
+        branch: Union[str, Branch, _NotSetType] = ...,
+        event: Union[str, _NotSetType] = ...,
+        status: Union[str, _NotSetType] = ...,
     ) -> PaginatedList[WorkflowRun]: ...
     @property
     def id(self) -> int: ...


### PR DESCRIPTION
The type annotations for `Workflow.create_dispatch()` and `Workflow.get_runs()` do not include the fact that some of the arguments have default values.  As a result, user code that calls, say, `workflow.get_runs()` without specifying any arguments will not validate with mypy.  This PR fixes that.