### PR TITLE
No longer show username and password examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,7 @@ from github import Github
 
 # First create a Github instance:
 
-# using username and password
-g = Github("user", "password")
-
-# or using an access token
+# using an access token
 g = Github("access_token")
 
 # Github Enterprise with custom hostname

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -15,10 +15,7 @@ First create a Github instance::
 
     from github import Github
     
-    # using username and password
-    g = Github("user", "password")
-    
-    # or using an access token
+    # using an access token
     g = Github("access_token")
 
     # Github Enterprise with custom hostname


### PR DESCRIPTION
With GitHub moving away from allowing authentication to the API using an
username and password, update our documentation to remove it and rely on
tokens. Perhaps we should link to how to create an API token, but that
can be addressed later.

Fixes #1851