### PR TITLE
Test repr() for PublicKey

### DIFF
--- a/tests/PublicKey.py
+++ b/tests/PublicKey.py
@@ -40,3 +40,7 @@ class PublicKey(Framework.TestCase):
             self.public_key.key, "u5e1Z25+z8pmgVVt5Pd8k0z/sKpVL1MXYtRAecE4vm8="
         )
         self.assertEqual(self.public_key.key_id, "568250167242549743")
+        self.assertEqual(
+            repr(self.public_key),
+            'PublicKey(key_id="568250167242549743", key="u5e1Z25+z8pmgVVt5Pd8k0z/sKpVL1MXYtRAecE4vm8=")',
+        )


### PR DESCRIPTION
The new PublicKey tests did not test the repr() method, increase
coverage by doing so.