### PR TITLE
Update PyJWT Version to 2.0+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pynacl>=1.4.0
 requests>=2.14.0
-pyjwt<2.0
+pyjwt>=2.0
 sphinx<3
 sphinx-rtd-theme<0.6
 Deprecated

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
         python_requires=">=3.6",
         install_requires=[
             "deprecated",
-            "pyjwt<2.0",
+            "pyjwt>=2.0",
             "pynacl>=1.4.0",
             "requests>=2.14.0",
         ],

--- a/tests/GitRelease.py
+++ b/tests/GitRelease.py
@@ -206,7 +206,9 @@ class GitRelease(Framework.TestCase):
     def testUploadAssetWithName(self):
         self.setUpNewRelease()
         release = self.new_release
-        r = release.upload_asset(self.artifact_path, name="foobar.zip")
+        r = release.upload_asset(
+            self.artifact_path, name="foobar.zip", content_type="application/zip"
+        )
         self.assertEqual(r.name, "foobar.zip")
         self.tearDownNewRelease()
 


### PR DESCRIPTION
Most other libraries that use PyJWT and have dropped Python 3.5 support now require version 2.0+, which creates an impossible to resolve dependency issue.

- Updated setup and requirements
- Fixed an issue with a test