### PR TITLE
Update most URLs to docs.github.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@
 [![codecov](https://codecov.io/gh/PyGithub/PyGithub/branch/master/graph/badge.svg)](https://codecov.io/gh/PyGithub/PyGithub)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-PyGitHub is a Python library to access the [GitHub API v3] and [Github Enterprise API v3].
+PyGitHub is a Python library to access the [GitHub REST API].
 This library enables you to manage [GitHub] resources such as repositories, user profiles, and organizations in your Python applications.
 
-[GitHub API v3]: https://developer.github.com/v3
-[Github Enterprise API v3]: https://developer.github.com/enterprise/v3/
+[GitHub REST API]: https://docs.github.com/en/rest
 [GitHub]: https://github.com
 
 ## Install

--- a/github/ApplicationOAuth.py
+++ b/github/ApplicationOAuth.py
@@ -29,7 +29,7 @@ from github.AccessToken import AccessToken
 class ApplicationOAuth(github.GithubObject.NonCompletableGithubObject):
     """
     This class is used for identifying and authorizing users for Github Apps.
-    https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/#1-users-are-redirected-to-request-their-github-identity
+    The reference can be found at https://docs.github.com/en/developers/apps/identifying-and-authorizing-users-for-github-apps
     """
 
     def __repr__(self):
@@ -77,7 +77,7 @@ class ApplicationOAuth(github.GithubObject.NonCompletableGithubObject):
 
     def get_access_token(self, code, state=None):
         """
-        :calls: `POST /login/oauth/access_token <https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/>`_
+        :calls: `POST /login/oauth/access_token <https://docs.github.com/en/developers/apps/identifying-and-authorizing-users-for-github-apps>`_
         :param code: string
         :param state: string
         """

--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -63,7 +63,7 @@ from . import Consts
 
 class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
     """
-    This class represents AuthenticatedUsers as returned by https://developer.github.com/v3/users/#get-the-authenticated-user
+    This class represents AuthenticatedUsers as returned by https://docs.github.com/en/rest/reference/users#get-the-authenticated-user
 
     An AuthenticatedUser object can be created by calling ``get_user()`` on a Github object.
     """
@@ -369,7 +369,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def add_to_emails(self, *emails):
         """
-        :calls: `POST /user/emails <http://developer.github.com/v3/users/emails>`_
+        :calls: `POST /user/emails <http://docs.github.com/en/rest/reference/users#emails>`_
         :param email: string
         :rtype: None
         """
@@ -381,7 +381,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def add_to_following(self, following):
         """
-        :calls: `PUT /user/following/:user <http://developer.github.com/v3/users/followers>`_
+        :calls: `PUT /user/following/{user} <http://docs.github.com/en/rest/reference/users#followers>`_
         :param following: :class:`github.NamedUser.NamedUser`
         :rtype: None
         """
@@ -392,7 +392,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def add_to_starred(self, starred):
         """
-        :calls: `PUT /user/starred/:owner/:repo <http://developer.github.com/v3/activity/starring>`_
+        :calls: `PUT /user/starred/{owner}/{repo} <http://docs.github.com/en/rest/reference/activity#starring>`_
         :param starred: :class:`github.Repository.Repository`
         :rtype: None
         """
@@ -403,7 +403,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def add_to_subscriptions(self, subscription):
         """
-        :calls: `PUT /user/subscriptions/:owner/:repo <http://developer.github.com/v3/activity/watching>`_
+        :calls: `PUT /user/subscriptions/{owner}/{repo} <http://docs.github.com/en/rest/reference/activity#watching>`_
         :param subscription: :class:`github.Repository.Repository`
         :rtype: None
         """
@@ -414,7 +414,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def add_to_watched(self, watched):
         """
-        :calls: `PUT /repos/:owner/:repo/subscription <http://developer.github.com/v3/activity/watching>`_
+        :calls: `PUT /repos/{owner}/{repo}/subscription <http://docs.github.com/en/rest/reference/activity#watching>`_
         :param watched: :class:`github.Repository.Repository`
         :rtype: None
         """
@@ -435,7 +435,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         onetime_password=None,
     ):
         """
-        :calls: `POST /authorizations <http://developer.github.com/v3/oauth>`_
+        :calls: `POST /authorizations <https://docs.github.com/en/developers/apps/authorizing-oauth-apps>`_
         :param scopes: list of string
         :param note: string
         :param note_url: string
@@ -489,7 +489,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def create_fork(self, repo):
         """
-        :calls: `POST /repos/:owner/:repo/forks <http://developer.github.com/v3/repos/forks>`_
+        :calls: `POST /repos/{owner}/{repo}/forks <http://docs.github.com/en/rest/reference/repos#forks>`_
         :param repo: :class:`github.Repository.Repository`
         :rtype: :class:`github.Repository.Repository`
         """
@@ -503,7 +503,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def create_gist(self, public, files, description=github.GithubObject.NotSet):
         """
-        :calls: `POST /gists <http://developer.github.com/v3/gists>`_
+        :calls: `POST /gists <http://docs.github.com/en/rest/reference/gists>`_
         :param public: bool
         :param files: dict of string to :class:`github.InputFileContent.InputFileContent`
         :param description: string
@@ -529,7 +529,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def create_key(self, title, key):
         """
-        :calls: `POST /user/keys <http://developer.github.com/v3/users/keys>`_
+        :calls: `POST /user/keys <http://docs.github.com/en/rest/reference/users#git-ssh-keys>`_
         :param title: string
         :param key: string
         :rtype: :class:`github.UserKey.UserKey`
@@ -547,7 +547,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def create_project(self, name, body=github.GithubObject.NotSet):
         """
-        :calls: `POST /user/projects <https://developer.github.com/v3/projects/#create-a-user-project>`_
+        :calls: `POST /user/projects <https://docs.github.com/en/rest/reference/projects#create-a-user-project>`_
         :param name: string
         :param body: string
         :rtype: :class:`github.Project.Project`
@@ -585,7 +585,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         delete_branch_on_merge=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /user/repos <http://developer.github.com/v3/repos>`_
+        :calls: `POST /user/repos <http://docs.github.com/en/rest/reference/repos>`_
         :param name: string
         :param description: string
         :param homepage: string
@@ -695,7 +695,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         bio=github.GithubObject.NotSet,
     ):
         """
-        :calls: `PATCH /user <http://developer.github.com/v3/users>`_
+        :calls: `PATCH /user <http://docs.github.com/en/rest/reference/users>`_
         :param name: string
         :param email: string
         :param blog: string
@@ -740,7 +740,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_authorization(self, id):
         """
-        :calls: `GET /authorizations/:id <http://developer.github.com/v3/oauth>`_
+        :calls: `GET /authorizations/{id} <https://docs.github.com/en/developers/apps/authorizing-oauth-apps>`_
         :param id: integer
         :rtype: :class:`github.Authorization.Authorization`
         """
@@ -754,7 +754,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_authorizations(self):
         """
-        :calls: `GET /authorizations <http://developer.github.com/v3/oauth>`_
+        :calls: `GET /authorizations <https://docs.github.com/en/developers/apps/authorizing-oauth-apps>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Authorization.Authorization`
         """
         return github.PaginatedList.PaginatedList(
@@ -763,7 +763,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_emails(self):
         """
-        :calls: `GET /user/emails <http://developer.github.com/v3/users/emails>`_
+        :calls: `GET /user/emails <http://docs.github.com/en/rest/reference/users#emails>`_
         :rtype: list of namedtuples with members email, primary, verified and visibility
         """
         headers, data = self._requester.requestJsonAndCheck("GET", "/user/emails")
@@ -772,7 +772,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_events(self):
         """
-        :calls: `GET /events <http://developer.github.com/v3/activity/events>`_
+        :calls: `GET /events <http://docs.github.com/en/rest/reference/activity#events>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
         """
         return github.PaginatedList.PaginatedList(
@@ -781,7 +781,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_followers(self):
         """
-        :calls: `GET /user/followers <http://developer.github.com/v3/users/followers>`_
+        :calls: `GET /user/followers <http://docs.github.com/en/rest/reference/users#followers>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
         return github.PaginatedList.PaginatedList(
@@ -790,7 +790,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_following(self):
         """
-        :calls: `GET /user/following <http://developer.github.com/v3/users/followers>`_
+        :calls: `GET /user/following <http://docs.github.com/en/rest/reference/users#followers>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
         return github.PaginatedList.PaginatedList(
@@ -799,7 +799,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_gists(self, since=github.GithubObject.NotSet):
         """
-        :calls: `GET /gists <http://developer.github.com/v3/gists>`_
+        :calls: `GET /gists <http://docs.github.com/en/rest/reference/gists>`_
         :param since: datetime.datetime format YYYY-MM-DDTHH:MM:SSZ
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Gist.Gist`
         """
@@ -823,7 +823,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         since=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /issues <http://developer.github.com/v3/issues>`_
+        :calls: `GET /issues <http://docs.github.com/en/rest/reference/issues>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Issue.Issue`
         :param filter: string
         :param state: string
@@ -872,7 +872,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         since=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /user/issues <http://developer.github.com/v3/issues>`_
+        :calls: `GET /user/issues <http://docs.github.com/en/rest/reference/issues>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Issue.Issue`
         :param filter: string
         :param state: string
@@ -913,7 +913,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_key(self, id):
         """
-        :calls: `GET /user/keys/:id <http://developer.github.com/v3/users/keys>`_
+        :calls: `GET /user/keys/{id} <http://docs.github.com/en/rest/reference/users#git-ssh-keys>`_
         :param id: integer
         :rtype: :class:`github.UserKey.UserKey`
         """
@@ -923,7 +923,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_keys(self):
         """
-        :calls: `GET /user/keys <http://developer.github.com/v3/users/keys>`_
+        :calls: `GET /user/keys <http://docs.github.com/en/rest/reference/users#git-ssh-keys>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.UserKey.UserKey`
         """
         return github.PaginatedList.PaginatedList(
@@ -932,7 +932,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_notification(self, id):
         """
-        :calls: `GET /notifications/threads/:id <http://developer.github.com/v3/activity/notifications>`_
+        :calls: `GET /notifications/threads/{id} <http://docs.github.com/en/rest/reference/activity#notifications>`_
         :rtype: :class:`github.Notification.Notification`
         """
 
@@ -952,7 +952,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         before=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /notifications <http://developer.github.com/v3/activity/notifications>`_
+        :calls: `GET /notifications <http://docs.github.com/en/rest/reference/activity#notifications>`_
         :param all: bool
         :param participating: bool
         :param since: datetime.datetime
@@ -987,7 +987,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_organization_events(self, org):
         """
-        :calls: `GET /users/:user/events/orgs/:org <http://developer.github.com/v3/activity/events>`_
+        :calls: `GET /users/{user}/events/orgs/{org} <http://docs.github.com/en/rest/reference/activity#events>`_
         :param org: :class:`github.Organization.Organization`
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
         """
@@ -1001,7 +1001,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_orgs(self):
         """
-        :calls: `GET /user/orgs <http://developer.github.com/v3/orgs>`_
+        :calls: `GET /user/orgs <http://docs.github.com/en/rest/reference/orgs>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Organization.Organization`
         """
         return github.PaginatedList.PaginatedList(
@@ -1010,7 +1010,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_repo(self, name):
         """
-        :calls: `GET /repos/:owner/:repo <http://developer.github.com/v3/repos>`_
+        :calls: `GET /repos/{owner}/{repo} <http://docs.github.com/en/rest/reference/repos>`_
         :param name: string
         :rtype: :class:`github.Repository.Repository`
         """
@@ -1031,7 +1031,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         direction=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /user/repos <http://developer.github.com/v3/repos>`
+        :calls: `GET /user/repos <http://docs.github.com/en/rest/reference/repos>`
         :param visibility: string
         :param affiliation: string
         :param type: string
@@ -1067,7 +1067,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_starred(self):
         """
-        :calls: `GET /user/starred <http://developer.github.com/v3/activity/starring>`_
+        :calls: `GET /user/starred <http://docs.github.com/en/rest/reference/activity#starring>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
         """
         return github.PaginatedList.PaginatedList(
@@ -1076,7 +1076,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_starred_gists(self):
         """
-        :calls: `GET /gists/starred <http://developer.github.com/v3/gists>`_
+        :calls: `GET /gists/starred <http://docs.github.com/en/rest/reference/gists>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Gist.Gist`
         """
         return github.PaginatedList.PaginatedList(
@@ -1085,7 +1085,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_subscriptions(self):
         """
-        :calls: `GET /user/subscriptions <http://developer.github.com/v3/activity/watching>`_
+        :calls: `GET /user/subscriptions <http://docs.github.com/en/rest/reference/activity#watching>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
         """
         return github.PaginatedList.PaginatedList(
@@ -1094,7 +1094,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_teams(self):
         """
-        :calls: `GET /user/teams <http://developer.github.com/v3/orgs/teams>`_
+        :calls: `GET /user/teams <http://docs.github.com/en/rest/reference/teams>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Team.Team`
         """
         return github.PaginatedList.PaginatedList(
@@ -1103,7 +1103,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_watched(self):
         """
-        :calls: `GET /user/subscriptions <http://developer.github.com/v3/activity/watching>`_
+        :calls: `GET /user/subscriptions <http://docs.github.com/en/rest/reference/activity#watching>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
         """
         return github.PaginatedList.PaginatedList(
@@ -1112,7 +1112,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_installations(self):
         """
-        :calls: `GET /user/installations <http://developer.github.com/v3/apps>`_
+        :calls: `GET /user/installations <http://docs.github.com/en/rest/reference/apps>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Installation.Installation`
         """
         return github.PaginatedList.PaginatedList(
@@ -1126,7 +1126,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def has_in_following(self, following):
         """
-        :calls: `GET /user/following/:user <http://developer.github.com/v3/users/followers>`_
+        :calls: `GET /user/following/{user} <http://docs.github.com/en/rest/reference/users#followers>`_
         :param following: :class:`github.NamedUser.NamedUser`
         :rtype: bool
         """
@@ -1138,7 +1138,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def has_in_starred(self, starred):
         """
-        :calls: `GET /user/starred/:owner/:repo <http://developer.github.com/v3/activity/starring>`_
+        :calls: `GET /user/starred/{owner}/{repo} <http://docs.github.com/en/rest/reference/activity#starring>`_
         :param starred: :class:`github.Repository.Repository`
         :rtype: bool
         """
@@ -1150,7 +1150,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def has_in_subscriptions(self, subscription):
         """
-        :calls: `GET /user/subscriptions/:owner/:repo <http://developer.github.com/v3/activity/watching>`_
+        :calls: `GET /user/subscriptions/{owner}/{repo} <http://docs.github.com/en/rest/reference/activity#watching>`_
         :param subscription: :class:`github.Repository.Repository`
         :rtype: bool
         """
@@ -1162,7 +1162,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def has_in_watched(self, watched):
         """
-        :calls: `GET /repos/:owner/:repo/subscription <http://developer.github.com/v3/activity/watching>`_
+        :calls: `GET /repos/{owner}/{repo}/subscription <http://docs.github.com/en/rest/reference/activity#watching>`_
         :param watched: :class:`github.Repository.Repository`
         :rtype: bool
         """
@@ -1174,7 +1174,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def mark_notifications_as_read(self, last_read_at=datetime.datetime.utcnow()):
         """
-        :calls: `PUT /notifications <https://developer.github.com/v3/activity/notifications>`_
+        :calls: `PUT /notifications <https://docs.github.com/en/rest/reference/activity#notifications>`_
         :param last_read_at: datetime
         """
         assert isinstance(last_read_at, datetime.datetime)
@@ -1186,7 +1186,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def remove_from_emails(self, *emails):
         """
-        :calls: `DELETE /user/emails <http://developer.github.com/v3/users/emails>`_
+        :calls: `DELETE /user/emails <http://docs.github.com/en/rest/reference/users#emails>`_
         :param email: string
         :rtype: None
         """
@@ -1198,7 +1198,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def remove_from_following(self, following):
         """
-        :calls: `DELETE /user/following/:user <http://developer.github.com/v3/users/followers>`_
+        :calls: `DELETE /user/following/{user} <http://docs.github.com/en/rest/reference/users#followers>`_
         :param following: :class:`github.NamedUser.NamedUser`
         :rtype: None
         """
@@ -1209,7 +1209,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def remove_from_starred(self, starred):
         """
-        :calls: `DELETE /user/starred/:owner/:repo <http://developer.github.com/v3/activity/starring>`_
+        :calls: `DELETE /user/starred/{owner}/{repo} <http://docs.github.com/en/rest/reference/activity#starring>`_
         :param starred: :class:`github.Repository.Repository`
         :rtype: None
         """
@@ -1220,7 +1220,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def remove_from_subscriptions(self, subscription):
         """
-        :calls: `DELETE /user/subscriptions/:owner/:repo <http://developer.github.com/v3/activity/watching>`_
+        :calls: `DELETE /user/subscriptions/{owner}/{repo} <http://docs.github.com/en/rest/reference/activity#watching>`_
         :param subscription: :class:`github.Repository.Repository`
         :rtype: None
         """
@@ -1231,7 +1231,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def remove_from_watched(self, watched):
         """
-        :calls: `DELETE /repos/:owner/:repo/subscription <http://developer.github.com/v3/activity/watching>`_
+        :calls: `DELETE /repos/{owner}/{repo}/subscription <http://docs.github.com/en/rest/reference/activity#watching>`_
         :param watched: :class:`github.Repository.Repository`
         :rtype: None
         """
@@ -1242,7 +1242,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def accept_invitation(self, invitation):
         """
-        :calls: `PATCH /user/repository_invitations/:invitation_id <https://developer.github.com/v3/repos/invitations/>`
+        :calls: `PATCH /user/repository_invitations/{invitation_id} <https://docs.github.com/en/rest/reference/repos/invitations#>`
         :param invitation: :class:`github.Invitation.Invitation` or int
         :rtype: None
         """
@@ -1259,7 +1259,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_invitations(self):
         """
-        :calls: `GET /user/repository_invitations <https://developer.github.com/v3/repos/invitations/>`_
+        :calls: `GET /user/repository_invitations <https://docs.github.com/en/rest/reference/repos#invitations>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Invitation.Invitation`
         """
         return github.PaginatedList.PaginatedList(
@@ -1276,7 +1276,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         exclude_attachments=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /user/migrations <https://developer.github.com/v3/migrations/users>`_
+        :calls: `POST /user/migrations <https://docs.github.com/en/rest/reference/migrations>`_
         :param repos: list or tuple of str
         :param lock_repositories: bool
         :param exclude_attachments: bool
@@ -1307,7 +1307,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_migrations(self):
         """
-        :calls: `GET /user/migrations <https://developer.github.com/v3/migrations/users>`_
+        :calls: `GET /user/migrations <https://docs.github.com/en/rest/reference/migrations>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Migration.Migration`
         """
         return github.PaginatedList.PaginatedList(
@@ -1320,7 +1320,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def get_organization_membership(self, org):
         """
-        :calls: `GET /user/memberships/orgs/:org <https://developer.github.com/v3/orgs/members/#get-your-organization-membership>`_
+        :calls: `GET /user/memberships/orgs/{org} <https://docs.github.com/en/rest/reference/orgs#get-an-organization-membership-for-the-authenticated-user>`_
         :rtype: :class:`github.Membership.Membership`
         """
         assert isinstance(org, str)

--- a/github/Authorization.py
+++ b/github/Authorization.py
@@ -34,7 +34,7 @@ import github.GithubObject
 
 class Authorization(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Authorizations. The reference can be found here https://developer.github.com/v3/oauth_authorizations/
+    This class represents Authorizations. The reference can be found here https://docs.github.com/en/enterprise-server@3.0/rest/reference/oauth-authorizations
     """
 
     def __repr__(self):
@@ -114,7 +114,7 @@ class Authorization(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /authorizations/:id <http://developer.github.com/v3/oauth>`_
+        :calls: `DELETE /authorizations/{id} <https://docs.github.com/en/developers/apps/authorizing-oauth-apps>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("DELETE", self.url)
@@ -128,7 +128,7 @@ class Authorization(github.GithubObject.CompletableGithubObject):
         note_url=github.GithubObject.NotSet,
     ):
         """
-        :calls: `PATCH /authorizations/:id <http://developer.github.com/v3/oauth>`_
+        :calls: `PATCH /authorizations/{id} <https://docs.github.com/en/developers/apps/authorizing-oauth-apps>`_
         :param scopes: list of string
         :param add_scopes: list of string
         :param remove_scopes: list of string

--- a/github/Branch.py
+++ b/github/Branch.py
@@ -42,7 +42,7 @@ from . import Consts
 
 class Branch(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents Branches. The reference can be found here https://developer.github.com/v3/repos/branches
+    This class represents Branches. The reference can be found here https://docs.github.com/en/rest/reference/repos#branches
     """
 
     def __repr__(self):
@@ -98,7 +98,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def get_protection(self):
         """
-        :calls: `GET /repos/:owner/:repo/branches/:branch/protection <https://developer.github.com/v3/repos/branches>`_
+        :calls: `GET /repos/{owner}/{repo}/branches/{branch}/protection <https://docs.github.com/en/rest/reference/repos#branches>`_
         """
         headers, data = self._requester.requestJsonAndCheck(
             "GET",
@@ -123,7 +123,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         team_push_restrictions=github.GithubObject.NotSet,
     ):
         """
-        :calls: `PUT /repos/:owner/:repo/branches/:branch/protection <https://developer.github.com/v3/repos/branches>`_
+        :calls: `PUT /repos/{owner}/{repo}/branches/{branch}/protection <https://docs.github.com/en/rest/reference/repos#branches>`_
         :strict: bool
         :contexts: list of strings
         :enforce_admins: bool
@@ -245,7 +245,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def remove_protection(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/branches/:branch/protection <https://developer.github.com/v3/repos/branches>`_
+        :calls: `DELETE /repos/{owner}/{repo}/branches/{branch}/protection <https://docs.github.com/en/rest/reference/repos#branches>`_
         """
         headers, data = self._requester.requestJsonAndCheck(
             "DELETE",
@@ -254,7 +254,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def get_required_status_checks(self):
         """
-        :calls: `GET /repos/:owner/:repo/branches/:branch/protection/required_status_checks <https://developer.github.com/v3/repos/branches>`_
+        :calls: `GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks <https://docs.github.com/en/rest/reference/repos#branches>`_
         :rtype: :class:`github.RequiredStatusChecks.RequiredStatusChecks`
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -268,7 +268,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         self, strict=github.GithubObject.NotSet, contexts=github.GithubObject.NotSet
     ):
         """
-        :calls: `PATCH /repos/:owner/:repo/branches/:branch/protection/required_status_checks <https://developer.github.com/v3/repos/branches>`_
+        :calls: `PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks <https://docs.github.com/en/rest/reference/repos#branches>`_
         :strict: bool
         :contexts: list of strings
         """
@@ -290,7 +290,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def remove_required_status_checks(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/branches/:branch/protection/required_status_checks <https://developer.github.com/v3/repos/branches>`_
+        :calls: `DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks <https://docs.github.com/en/rest/reference/repos#branches>`_
         """
         headers, data = self._requester.requestJsonAndCheck(
             "DELETE",
@@ -299,7 +299,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def get_required_pull_request_reviews(self):
         """
-        :calls: `GET /repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews <https://developer.github.com/v3/repos/branches>`_
+        :calls: `GET /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews <https://docs.github.com/en/rest/reference/repos#branches>`_
         :rtype: :class:`github.RequiredPullRequestReviews.RequiredPullRequestReviews`
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -320,7 +320,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         required_approving_review_count=github.GithubObject.NotSet,
     ):
         """
-        :calls: `PATCH /repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews <https://developer.github.com/v3/repos/branches>`_
+        :calls: `PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews <https://docs.github.com/en/rest/reference/repos#branches>`_
         :dismissal_users: list of strings
         :dismissal_teams: list of strings
         :dismiss_stale_reviews: bool
@@ -368,7 +368,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def remove_required_pull_request_reviews(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/branches/:branch/protection/required_pull_request_reviews <https://developer.github.com/v3/repos/branches>`_
+        :calls: `DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews <https://docs.github.com/en/rest/reference/repos#branches>`_
         """
         headers, data = self._requester.requestJsonAndCheck(
             "DELETE",
@@ -377,7 +377,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def get_admin_enforcement(self):
         """
-        :calls: `GET /repos/:owner/:repo/branches/:branch/protection/enforce_admins <https://developer.github.com/v3/repos/branches>`_
+        :calls: `GET /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins <https://docs.github.com/en/rest/reference/repos#branches>`_
         :rtype: bool
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -387,7 +387,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def set_admin_enforcement(self):
         """
-        :calls: `POST /repos/:owner/:repo/branches/:branch/protection/enforce_admins <https://developer.github.com/v3/repos/branches>`_
+        :calls: `POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins <https://docs.github.com/en/rest/reference/repos#branches>`_
         """
         headers, data = self._requester.requestJsonAndCheck(
             "POST", f"{self.protection_url}/enforce_admins"
@@ -395,7 +395,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def remove_admin_enforcement(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/branches/:branch/protection/enforce_admins <https://developer.github.com/v3/repos/branches>`_
+        :calls: `DELETE /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins <https://docs.github.com/en/rest/reference/repos#branches>`_
         """
         headers, data = self._requester.requestJsonAndCheck(
             "DELETE", f"{self.protection_url}/enforce_admins"
@@ -403,7 +403,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def get_user_push_restrictions(self):
         """
-        :calls: `GET /repos/:owner/:repo/branches/:branch/protection/restrictions/users <https://developer.github.com/v3/repos/branches>`_
+        :calls: `GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users <https://docs.github.com/en/rest/reference/repos#branches>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
         return github.PaginatedList.PaginatedList(
@@ -415,7 +415,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def get_team_push_restrictions(self):
         """
-        :calls: `GET /repos/:owner/:repo/branches/:branch/protection/restrictions/teams <https://developer.github.com/v3/repos/branches>`_
+        :calls: `GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams <https://docs.github.com/en/rest/reference/repos#branches>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Team.Team`
         """
         return github.PaginatedList.PaginatedList(
@@ -427,7 +427,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def add_user_push_restrictions(self, *users):
         """
-        :calls: `POST /repos/:owner/:repo/branches/:branch/protection/restrictions/users <https://developer.github.com/v3/repos/branches>`_
+        :calls: `POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users <https://docs.github.com/en/rest/reference/repos#branches>`_
         :users: list of strings (user names)
         """
         assert all(isinstance(element, str) for element in users), users
@@ -438,7 +438,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def replace_user_push_restrictions(self, *users):
         """
-        :calls: `PUT /repos/:owner/:repo/branches/:branch/protection/restrictions/users <https://developer.github.com/v3/repos/branches>`_
+        :calls: `PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users <https://docs.github.com/en/rest/reference/repos#branches>`_
         :users: list of strings (user names)
         """
         assert all(isinstance(element, str) for element in users), users
@@ -449,7 +449,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def remove_user_push_restrictions(self, *users):
         """
-        :calls: `DELETE /repos/:owner/:repo/branches/:branch/protection/restrictions/users <https://developer.github.com/v3/repos/branches>`_
+        :calls: `DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/users <https://docs.github.com/en/rest/reference/repos#branches>`_
         :users: list of strings (user names)
         """
         assert all(isinstance(element, str) for element in users), users
@@ -460,7 +460,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def add_team_push_restrictions(self, *teams):
         """
-        :calls: `POST /repos/:owner/:repo/branches/:branch/protection/restrictions/teams <https://developer.github.com/v3/repos/branches>`_
+        :calls: `POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams <https://docs.github.com/en/rest/reference/repos#branches>`_
         :teams: list of strings (team slugs)
         """
         assert all(isinstance(element, str) for element in teams), teams
@@ -471,7 +471,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def replace_team_push_restrictions(self, *teams):
         """
-        :calls: `PUT /repos/:owner/:repo/branches/:branch/protection/restrictions/teams <https://developer.github.com/v3/repos/branches>`_
+        :calls: `PUT /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams <https://docs.github.com/en/rest/reference/repos#branches>`_
         :teams: list of strings (team slugs)
         """
         assert all(isinstance(element, str) for element in teams), teams
@@ -482,7 +482,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def remove_team_push_restrictions(self, *teams):
         """
-        :calls: `DELETE /repos/:owner/:repo/branches/:branch/protection/restrictions/teams <https://developer.github.com/v3/repos/branches>`_
+        :calls: `DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/teams <https://docs.github.com/en/rest/reference/repos#branches>`_
         :teams: list of strings (team slugs)
         """
         assert all(isinstance(element, str) for element in teams), teams
@@ -493,7 +493,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def remove_push_restrictions(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/branches/:branch/protection/restrictions <https://developer.github.com/v3/repos/branches>`_
+        :calls: `DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions <https://docs.github.com/en/rest/reference/repos#branches>`_
         """
         headers, data = self._requester.requestJsonAndCheck(
             "DELETE", f"{self.protection_url}/restrictions"
@@ -501,7 +501,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def get_required_signatures(self):
         """
-        :calls: `GET /repos/:owner/:repo/branches/:branch/protection/required_signatures <https://developer.github.com/v3/repos/branches>`
+        :calls: `GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures <https://docs.github.com/en/rest/reference/repos#branches>`
         """
         headers, data = self._requester.requestJsonAndCheck(
             "GET",
@@ -512,7 +512,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def add_required_signatures(self):
         """
-        :calls: `POST /repos/:owner/:repo/branches/:branch/protection/required_signatures <https://developer.github.com/v3/repos/branches>`
+        :calls: `POST /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures <https://docs.github.com/en/rest/reference/repos#branches>`
         """
         headers, data = self._requester.requestJsonAndCheck(
             "POST",
@@ -522,7 +522,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def remove_required_signatures(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/branches/:branch/protection/required_signatures <https://developer.github.com/v3/repos/branches>`
+        :calls: `DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures <https://docs.github.com/en/rest/reference/repos#branches>`
         """
         headers, data = self._requester.requestJsonAndCheck(
             "DELETE",

--- a/github/BranchProtection.py
+++ b/github/BranchProtection.py
@@ -29,7 +29,7 @@ import github.Team
 
 class BranchProtection(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Branch Protection. The reference can be found here https://developer.github.com/v3/repos/branches/#get-branch-protection
+    This class represents Branch Protection. The reference can be found here https://docs.github.com/en/rest/reference/repos#get-branch-protection
     """
 
     def __repr__(self):

--- a/github/CheckRun.py
+++ b/github/CheckRun.py
@@ -171,7 +171,7 @@ class CheckRun(github.GithubObject.CompletableGithubObject):
 
     def get_annotations(self):
         """
-        :calls: `GET /repos/:owner/:repo/check-runs/:check_run_id/annotations <https://docs.github.com/en/rest/reference/checks#list-check-run-annotations>`_
+        :calls: `GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations <https://docs.github.com/en/rest/reference/checks#list-check-run-annotations>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.CheckRunAnnotation.CheckRunAnnotation`
         """
         return github.PaginatedList.PaginatedList(
@@ -196,7 +196,7 @@ class CheckRun(github.GithubObject.CompletableGithubObject):
         actions=github.GithubObject.NotSet,
     ):
         """
-        :calls: `PATCH /repos/:owner/:repo/check-runs/:check_run_id <https://docs.github.com/en/rest/reference/checks#update-a-check-run>`_
+        :calls: `PATCH /repos/{owner}/{repo}/check-runs/{check_run_id} <https://docs.github.com/en/rest/reference/checks#update-a-check-run>`_
         :param name: string
         :param head_sha: string
         :param details_url: string

--- a/github/CheckSuite.py
+++ b/github/CheckSuite.py
@@ -161,7 +161,7 @@ class CheckSuite(github.GithubObject.CompletableGithubObject):
 
     def rerequest(self):
         """
-        :calls: `POST /repos/:owner/:repo/check-suites/:check_suite_id/rerequest <https://docs.github.com/en/rest/reference/checks#rerequest-a-check-suite>`_
+        :calls: `POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest <https://docs.github.com/en/rest/reference/checks#rerequest-a-check-suite>`_
         :rtype: bool
         """
         request_headers = {"Accept": "application/vnd.github.v3+json"}
@@ -177,7 +177,7 @@ class CheckSuite(github.GithubObject.CompletableGithubObject):
         filter=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /repos/:owner/:repo/check-suites/:check_suite_id/check-runs <https://docs.github.com/en/rest/reference/checks#list-check-runs-in-a-check-suite>`_
+        :calls: `GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs <https://docs.github.com/en/rest/reference/checks#list-check-runs-in-a-check-suite>`_
         :param check_name: string
         :param status: string
         :param filter: string

--- a/github/Clones.py
+++ b/github/Clones.py
@@ -30,7 +30,7 @@ import github.GithubObject
 class Clones(github.GithubObject.NonCompletableGithubObject):
     """
     This class represents a popular Path for a GitHub repository.
-    The reference can be found here https://developer.github.com/v3/repos/traffic/
+    The reference can be found here https://docs.github.com/en/rest/reference/repos#get-repository-clones
     """
 
     def __repr__(self):

--- a/github/Commit.py
+++ b/github/Commit.py
@@ -45,7 +45,7 @@ import github.PaginatedList
 
 class Commit(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Commits. The reference can be found here http://developer.github.com/v3/git/commits/
+    This class represents Commits. The reference can be found here http://docs.github.com/en/rest/reference/git#commits
     """
 
     def __repr__(self):
@@ -139,7 +139,7 @@ class Commit(github.GithubObject.CompletableGithubObject):
         position=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /repos/:owner/:repo/commits/:sha/comments <http://developer.github.com/v3/repos/comments>`_
+        :calls: `POST /repos/{owner}/{repo}/commits/{sha}/comments <http://docs.github.com/en/rest/reference/repos#comments>`_
         :param body: string
         :param line: integer
         :param path: string
@@ -176,7 +176,7 @@ class Commit(github.GithubObject.CompletableGithubObject):
         context=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /repos/:owner/:repo/statuses/:sha <http://developer.github.com/v3/repos/statuses>`_
+        :calls: `POST /repos/{owner}/{repo}/statuses/{sha} <http://docs.github.com/en/rest/reference/repos#statuses>`_
         :param state: string
         :param target_url: string
         :param description: string
@@ -213,7 +213,7 @@ class Commit(github.GithubObject.CompletableGithubObject):
 
     def get_comments(self):
         """
-        :calls: `GET /repos/:owner/:repo/commits/:sha/comments <http://developer.github.com/v3/repos/comments>`_
+        :calls: `GET /repos/{owner}/{repo}/commits/{sha}/comments <http://docs.github.com/en/rest/reference/repos#comments>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.CommitComment.CommitComment`
         """
         return github.PaginatedList.PaginatedList(
@@ -225,7 +225,7 @@ class Commit(github.GithubObject.CompletableGithubObject):
 
     def get_statuses(self):
         """
-        :calls: `GET /repos/:owner/:repo/statuses/:ref <http://developer.github.com/v3/repos/statuses>`_
+        :calls: `GET /repos/{owner}/{repo}/statuses/{ref} <http://docs.github.com/en/rest/reference/repos#statuses>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.CommitStatus.CommitStatus`
         """
         return github.PaginatedList.PaginatedList(
@@ -237,7 +237,7 @@ class Commit(github.GithubObject.CompletableGithubObject):
 
     def get_combined_status(self):
         """
-        :calls: `GET /repos/:owner/:repo/commits/:ref/status/ <http://developer.github.com/v3/repos/statuses>`_
+        :calls: `GET /repos/{owner}/{repo}/commits/{ref}/status/ <http://docs.github.com/en/rest/reference/repos#statuses>`_
         :rtype: :class:`github.CommitCombinedStatus.CommitCombinedStatus`
         """
         headers, data = self._requester.requestJsonAndCheck("GET", f"{self.url}/status")
@@ -247,7 +247,7 @@ class Commit(github.GithubObject.CompletableGithubObject):
 
     def get_pulls(self):
         """
-        :calls: `GET /repos/:owner/:repo/commits/:sha/pulls <https://developer.github.com/v3/repos/commits/#list-pull-requests-associated-with-commit>`_
+        :calls: `GET /repos/{owner}/{repo}/commits/{sha}/pulls <https://docs.github.com/en/rest/reference/repos#list-pull-requests-associated-with-a-commit>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.PullRequest.PullRequest`
         """
         return github.PaginatedList.PaginatedList(
@@ -265,7 +265,7 @@ class Commit(github.GithubObject.CompletableGithubObject):
         filter=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /repos/:owner/:repo/commits/:sha/check-runs <https://docs.github.com/en/rest/reference/checks#list-check-runs-for-a-git-reference>`_
+        :calls: `GET /repos/{owner}/{repo}/commits/{sha}/check-runs <https://docs.github.com/en/rest/reference/checks#list-check-runs-for-a-git-reference>`_
         :param check_name: string
         :param status: string
         :param filter: string
@@ -296,7 +296,7 @@ class Commit(github.GithubObject.CompletableGithubObject):
         self, app_id=github.GithubObject.NotSet, check_name=github.GithubObject.NotSet
     ):
         """
-        :class: `GET /repos/:owner/:repo/commits/:ref/check-suites <https://docs.github.com/en/rest/reference/checks#list-check-suites-for-a-git-reference>`_
+        :class: `GET /repos/{owner}/{repo}/commits/{ref}/check-suites <https://docs.github.com/en/rest/reference/checks#list-check-suites-for-a-git-reference>`_
         :param app_id: int
         :param check_name: string
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.CheckSuite.CheckSuite`

--- a/github/CommitCombinedStatus.py
+++ b/github/CommitCombinedStatus.py
@@ -31,7 +31,7 @@ import github.Repository
 
 class CommitCombinedStatus(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents CommitCombinedStatuses. The reference can be found here https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
+    This class represents CommitCombinedStatuses. The reference can be found here https://docs.github.com/en/rest/reference/repos#statuses
     """
 
     def __repr__(self):

--- a/github/CommitComment.py
+++ b/github/CommitComment.py
@@ -39,7 +39,7 @@ from . import Consts
 
 class CommitComment(github.GithubObject.CompletableGithubObject):
     """
-    This class represents CommitComments. The reference can be found here https://developer.github.com/v3/repos/comments/
+    This class represents CommitComments. The reference can be found here https://docs.github.com/en/rest/reference/repos#comments
     """
 
     def __repr__(self):
@@ -135,14 +135,14 @@ class CommitComment(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/comments/:id <http://developer.github.com/v3/repos/comments>`_
+        :calls: `DELETE /repos/{owner}/{repo}/comments/{id} <http://docs.github.com/en/rest/reference/repos#comments>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("DELETE", self.url)
 
     def edit(self, body):
         """
-        :calls: `PATCH /repos/:owner/:repo/comments/:id <http://developer.github.com/v3/repos/comments>`_
+        :calls: `PATCH /repos/{owner}/{repo}/comments/{id} <http://docs.github.com/en/rest/reference/repos#comments>`_
         :param body: string
         :rtype: None
         """
@@ -157,8 +157,8 @@ class CommitComment(github.GithubObject.CompletableGithubObject):
 
     def get_reactions(self):
         """
-        :calls: `GET /repos/:owner/:repo/comments/:id/reactions
-                <https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment>`_
+        :calls: `GET /repos/{owner}/{repo}/comments/{id}/reactions
+                <https://docs.github.com/en/rest/reference/reactions#list-reactions-for-a-commit-comment>`_
         :return: :class: :class:`github.PaginatedList.PaginatedList` of :class:`github.Reaction.Reaction`
         """
         return github.PaginatedList.PaginatedList(
@@ -171,8 +171,8 @@ class CommitComment(github.GithubObject.CompletableGithubObject):
 
     def create_reaction(self, reaction_type):
         """
-        :calls: `POST /repos/:owner/:repo/comments/:id/reactions
-                <https://developer.github.com/v3/reactions/#create-reaction-for-a-commit-comment>`_
+        :calls: `POST /repos/{owner}/{repo}/comments/{id}/reactions
+                <https://docs.github.com/en/rest/reference/reactions#create-reaction-for-a-commit-comment>`_
         :param reaction_type: string
         :rtype: :class:`github.Reaction.Reaction`
         """
@@ -190,8 +190,8 @@ class CommitComment(github.GithubObject.CompletableGithubObject):
 
     def delete_reaction(self, reaction_id):
         """
-        :calls: `DELETE /repos/:owner/:repo/comments/:comment_id/reactions/:reaction_id
-                <https://developer.github.com/v3/reactions/#delete-a-commit-comment-reaction>`_
+        :calls: `DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}
+                <https://docs.github.com/en/rest/reference/reactions#delete-a-commit-comment-reaction>`_
         :param reaction_id: integer
         :rtype: bool
         """

--- a/github/CommitStatus.py
+++ b/github/CommitStatus.py
@@ -36,7 +36,7 @@ import github.NamedUser
 
 class CommitStatus(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents CommitStatuses.The reference can be found here https://developer.github.com/v3/repos/statuses/
+    This class represents CommitStatuses.The reference can be found here https://docs.github.com/en/rest/reference/repos#statuses
     """
 
     def __repr__(self):

--- a/github/Consts.py
+++ b/github/Consts.py
@@ -99,7 +99,7 @@ mediaTypeRequireMultipleApprovingReviews = (
 # https://developer.github.com/changes/2018-05-24-user-migration-api/
 mediaTypeMigrationPreview = "application/vnd.github.wyandotte-preview+json"
 
-# https://developer.github.com/v3/search/#highlighting-code-search-results-1
+# https://docs.github.com/en/rest/reference/search#highlighting-code-search-results-1
 highLightSearchPreview = "application/vnd.github.v3.text-match+json"
 
 # https://developer.github.com/changes/2018-02-22-protected-branches-required-signatures/
@@ -117,7 +117,7 @@ updateBranchPreview = "application/vnd.github.lydian-preview+json"
 # https://developer.github.com/changes/2016-05-23-timeline-preview-api/
 issueTimelineEventsPreview = "application/vnd.github.mockingbird-preview"
 
-# https://developer.github.com/v3/teams/#check-if-a-team-manages-a-repository
+# https://docs.github.com/en/rest/reference/teams#check-if-a-team-manages-a-repository
 teamRepositoryPermissions = "application/vnd.github.v3.repository+json"
 
 # https://developer.github.com/changes/2016-04-06-deployment-and-deployment-status-enhancements/

--- a/github/ContentFile.py
+++ b/github/ContentFile.py
@@ -37,7 +37,7 @@ import github.Repository
 
 class ContentFile(github.GithubObject.CompletableGithubObject):
     """
-    This class represents ContentFiles. The reference can be found here https://developer.github.com/v3/repos/contents/#get-contents
+    This class represents ContentFiles. The reference can be found here https://docs.github.com/en/rest/reference/repos#contents
     """
 
     def __repr__(self):

--- a/github/Deployment.py
+++ b/github/Deployment.py
@@ -29,7 +29,7 @@ import github.GithubObject
 
 class Deployment(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Deployments. The reference can be found here https://developer.github.com/v3/repos/deployments
+    This class represents Deployments. The reference can be found here https://docs.github.com/en/rest/reference/repos#deployments
     """
 
     def __repr__(self):
@@ -157,7 +157,7 @@ class Deployment(github.GithubObject.CompletableGithubObject):
 
     def get_statuses(self):
         """
-        :calls: `GET /repos/:owner/deployments/:deployment_id/statuses <https://developer.github.com/v3/repos/deployments/#list-deployment-statuses>`_
+        :calls: `GET /repos/{owner}/deployments/{deployment_id}/statuses <https://docs.github.com/en/rest/reference/repos#list-deployments>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.DeploymentStatus.DeploymentStatus`
         """
         return github.PaginatedList.PaginatedList(
@@ -170,7 +170,7 @@ class Deployment(github.GithubObject.CompletableGithubObject):
 
     def get_status(self, id_):
         """
-        :calls: `GET /repos/:owner/deployments/:deployment_id/statuses/:status_id  <https://developer.github.com/v3/repos/deployments/#get-a-deployment-status>`_
+        :calls: `GET /repos/{owner}/deployments/{deployment_id}/statuses/{status_id}  <https://docs.github.com/en/rest/reference/repos#get-a-deployment>`_
         :param id_: int
         :rtype: :class:`github.DeploymentStatus.DeploymentStatus`
         """
@@ -194,7 +194,7 @@ class Deployment(github.GithubObject.CompletableGithubObject):
         auto_inactive=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /repos/:owner/:repo/deployments/:deployment_id/statuses <https://developer.github.com/v3/repos/deployments/#create-a-deployment-status>`_
+        :calls: `POST /repos/{owner}/{repo}/deployments/{deployment_id}/statuses <https://docs.github.com/en/rest/reference/repos#create-a-deployment-status>`_
         :param: state: string
         :param: target_url: string
         :param: description: string

--- a/github/DeploymentStatus.py
+++ b/github/DeploymentStatus.py
@@ -26,7 +26,7 @@ import github.GithubObject
 
 class DeploymentStatus(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Deployment Statuses. The reference can be found here https://developer.github.com/v3/repos/deployments/
+    This class represents Deployment Statuses. The reference can be found here https://docs.github.com/en/rest/reference/repos#deployments
     """
 
     def __repr__(self):

--- a/github/Download.py
+++ b/github/Download.py
@@ -33,7 +33,7 @@ import github.GithubObject
 
 class Download(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Downloads. The reference can be found here https://developer.github.com/v3/repos/downloads/
+    This class represents Downloads. The reference can be found here https://docs.github.com/en/rest/reference/repos
     """
 
     def __repr__(self):
@@ -201,7 +201,7 @@ class Download(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/downloads/:id <http://developer.github.com/v3/repos/downloads>`_
+        :calls: `DELETE /repos/{owner}/{repo}/downloads/{id} <https://docs.github.com/en/rest/reference/repos>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("DELETE", self.url)

--- a/github/Event.py
+++ b/github/Event.py
@@ -36,7 +36,7 @@ import github.Repository
 
 class Event(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents Events. The reference can be found here http://developer.github.com/v3/activity/events/
+    This class represents Events. The reference can be found here https://docs.github.com/en/rest/reference/activity#events
     """
 
     def __repr__(self):

--- a/github/Gist.py
+++ b/github/Gist.py
@@ -41,7 +41,7 @@ import github.PaginatedList
 
 class Gist(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Gists. The reference can be found here https://developer.github.com/v3/gists/
+    This class represents Gists. The reference can be found here https://docs.github.com/en/rest/reference/gists
     """
 
     def __repr__(self):
@@ -201,7 +201,7 @@ class Gist(github.GithubObject.CompletableGithubObject):
 
     def create_comment(self, body):
         """
-        :calls: `POST /gists/:gist_id/comments <http://developer.github.com/v3/gists/comments>`_
+        :calls: `POST /gists/{gist_id}/comments <http://docs.github.com/en/rest/reference/gists#comments>`_
         :param body: string
         :rtype: :class:`github.GistComment.GistComment`
         """
@@ -218,7 +218,7 @@ class Gist(github.GithubObject.CompletableGithubObject):
 
     def create_fork(self):
         """
-        :calls: `POST /gists/:id/forks <http://developer.github.com/v3/gists>`_
+        :calls: `POST /gists/{id}/forks <http://docs.github.com/en/rest/reference/gists>`_
         :rtype: :class:`github.Gist.Gist`
         """
         headers, data = self._requester.requestJsonAndCheck("POST", f"{self.url}/forks")
@@ -226,7 +226,7 @@ class Gist(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /gists/:id <http://developer.github.com/v3/gists>`_
+        :calls: `DELETE /gists/{id} <http://docs.github.com/en/rest/reference/gists>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("DELETE", self.url)
@@ -235,7 +235,7 @@ class Gist(github.GithubObject.CompletableGithubObject):
         self, description=github.GithubObject.NotSet, files=github.GithubObject.NotSet
     ):
         """
-        :calls: `PATCH /gists/:id <http://developer.github.com/v3/gists>`_
+        :calls: `PATCH /gists/{id} <http://docs.github.com/en/rest/reference/gists>`_
         :param description: string
         :param files: dict of string to :class:`github.InputFileContent.InputFileContent`
         :rtype: None
@@ -262,7 +262,7 @@ class Gist(github.GithubObject.CompletableGithubObject):
 
     def get_comment(self, id):
         """
-        :calls: `GET /gists/:gist_id/comments/:id <http://developer.github.com/v3/gists/comments>`_
+        :calls: `GET /gists/{gist_id}/comments/{id} <http://docs.github.com/en/rest/reference/gists#comments>`_
         :param id: integer
         :rtype: :class:`github.GistComment.GistComment`
         """
@@ -276,7 +276,7 @@ class Gist(github.GithubObject.CompletableGithubObject):
 
     def get_comments(self):
         """
-        :calls: `GET /gists/:gist_id/comments <http://developer.github.com/v3/gists/comments>`_
+        :calls: `GET /gists/{gist_id}/comments <http://docs.github.com/en/rest/reference/gists#comments>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.GistComment.GistComment`
         """
         return github.PaginatedList.PaginatedList(
@@ -288,7 +288,7 @@ class Gist(github.GithubObject.CompletableGithubObject):
 
     def is_starred(self):
         """
-        :calls: `GET /gists/:id/star <http://developer.github.com/v3/gists>`_
+        :calls: `GET /gists/{id}/star <http://docs.github.com/en/rest/reference/gists>`_
         :rtype: bool
         """
         status, headers, data = self._requester.requestJson("GET", f"{self.url}/star")
@@ -296,7 +296,7 @@ class Gist(github.GithubObject.CompletableGithubObject):
 
     def reset_starred(self):
         """
-        :calls: `DELETE /gists/:id/star <http://developer.github.com/v3/gists>`_
+        :calls: `DELETE /gists/{id}/star <http://docs.github.com/en/rest/reference/gists>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -305,7 +305,7 @@ class Gist(github.GithubObject.CompletableGithubObject):
 
     def set_starred(self):
         """
-        :calls: `PUT /gists/:id/star <http://developer.github.com/v3/gists>`_
+        :calls: `PUT /gists/{id}/star <http://docs.github.com/en/rest/reference/gists>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("PUT", f"{self.url}/star")

--- a/github/GistComment.py
+++ b/github/GistComment.py
@@ -34,7 +34,7 @@ import github.NamedUser
 
 class GistComment(github.GithubObject.CompletableGithubObject):
     """
-    This class represents GistComments. The reference can be found here https://developer.github.com/v3/gists/comments/
+    This class represents GistComments. The reference can be found here https://docs.github.com/en/rest/reference/gists#comments
     """
 
     def __repr__(self):
@@ -90,14 +90,14 @@ class GistComment(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /gists/:gist_id/comments/:id <http://developer.github.com/v3/gists/comments>`_
+        :calls: `DELETE /gists/{gist_id}/comments/{id} <http://docs.github.com/en/rest/reference/gists#comments>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("DELETE", self.url)
 
     def edit(self, body):
         """
-        :calls: `PATCH /gists/:gist_id/comments/:id <http://developer.github.com/v3/gists/comments>`_
+        :calls: `PATCH /gists/{gist_id}/comments/{id} <http://docs.github.com/en/rest/reference/gists#comments>`_
         :param body: string
         :rtype: None
         """

--- a/github/GitBlob.py
+++ b/github/GitBlob.py
@@ -33,7 +33,7 @@ import github.GithubObject
 
 class GitBlob(github.GithubObject.CompletableGithubObject):
     """
-    This class represents GitBlobs. The reference can be found here https://developer.github.com/v3/git/blobs/
+    This class represents GitBlobs. The reference can be found here https://docs.github.com/en/rest/reference/git#blobs
     """
 
     def __repr__(self):

--- a/github/GitCommit.py
+++ b/github/GitCommit.py
@@ -35,7 +35,7 @@ import github.GitTree
 
 class GitCommit(github.GithubObject.CompletableGithubObject):
     """
-    This class represents GitCommits. The reference can be found here https://developer.github.com/v3/git/commits/
+    This class represents GitCommits. The reference can be found here https://docs.github.com/en/rest/reference/git#commits
     """
 
     def __repr__(self):

--- a/github/GitRef.py
+++ b/github/GitRef.py
@@ -34,7 +34,7 @@ import github.GitObject
 
 class GitRef(github.GithubObject.CompletableGithubObject):
     """
-    This class represents GitRefs. The reference can be found here https://developer.github.com/v3/git/refs/
+    This class represents GitRefs. The reference can be found here https://docs.github.com/en/rest/reference/git#refs
     """
 
     def __repr__(self):
@@ -66,14 +66,14 @@ class GitRef(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/git/refs/:ref <http://developer.github.com/v3/git/refs>`_
+        :calls: `DELETE /repos/{owner}/{repo}/git/refs/{ref} <http://docs.github.com/en/rest/reference/git#refs>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("DELETE", self.url)
 
     def edit(self, sha, force=github.GithubObject.NotSet):
         """
-        :calls: `PATCH /repos/:owner/:repo/git/refs/:ref <http://developer.github.com/v3/git/refs>`_
+        :calls: `PATCH /repos/{owner}/{repo}/git/refs/{ref} <http://docs.github.com/en/rest/reference/git#refs>`_
         :param sha: string
         :param force: bool
         :rtype: None

--- a/github/GitRelease.py
+++ b/github/GitRelease.py
@@ -44,7 +44,7 @@ from . import Consts
 
 class GitRelease(github.GithubObject.CompletableGithubObject):
     """
-    This class represents GitReleases. The reference can be found here https://developer.github.com/v3/repos/releases
+    This class represents GitReleases. The reference can be found here https://docs.github.com/en/rest/reference/repos#releases
     """
 
     def __repr__(self):
@@ -172,7 +172,7 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
 
     def delete_release(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/releases/:release_id <https://developer.github.com/v3/repos/releases/#delete-a-release>`_
+        :calls: `DELETE /repos/{owner}/{repo}/releases/{release_id} <https://docs.github.com/en/rest/reference/repos/releases#delete-a-release>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("DELETE", self.url)
@@ -187,7 +187,7 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
         target_commitish=github.GithubObject.NotSet,
     ):
         """
-        :calls: `PATCH /repos/:owner/:repo/releases/:release_id <https://developer.github.com/v3/repos/releases/#edit-a-release>`_
+        :calls: `PATCH /repos/{owner}/{repo}/releases/{release_id} <https://docs.github.com/en/rest/reference/repos/releases#edit-a-release>`_
         :param name: string
         :param message: string
         :param draft: bool
@@ -234,7 +234,7 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
         name=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST https://<upload_url>/repos/:owner/:repo/releases/:release_id/assets <https://developer.github.com/v3/repos/releases/#upload-a-release-asset>`_
+        :calls: `POST https://<upload_url>/repos/{owner}/{repo}/releases/{release_id}/assets <https://docs.github.com/en/rest/reference/repos/releases#upload-a-release-asset>`_
         :param path: string
         :param label: string
         :param content_type: string
@@ -274,7 +274,7 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
     ):
         """Uploads an asset. Unlike ``upload_asset()`` this method allows you to pass in a file-like object to upload.
         Note that this method is more strict and requires you to specify the ``name``, since there's no file name to infer these from.
-        :calls: `POST https://<upload_url>/repos/:owner/:repo/releases/:release_id/assets <https://developer.github.com/v3/repos/releases/#upload-a-release-asset>`_
+        :calls: `POST https://<upload_url>/repos/{owner}/{repo}/releases/{release_id}/assets <https://docs.github.com/en/rest/reference/repos/releases#upload-a-release-asset>`_
         :param file_like: binary file-like object, such as those returned by ``open("file_name", "rb")``. At the very minimum, this object must implement ``read()``.
         :param file_size: int, size in bytes of ``file_like``
         :param content_type: string
@@ -307,7 +307,7 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
 
     def get_assets(self):
         """
-        :calls: `GET /repos/:owner/:repo/releases/:release_id/assets <https://developer.github.com/v3/repos/releases/#list-assets-for-a-release>`_
+        :calls: `GET /repos/{owner}/{repo}/releases/{release_id}/assets <https://docs.github.com/en/rest/reference/repos/releases#list-assets-for-a-release>`_
         :rtype: :class:`github.PaginatedList.PaginatedList`
         """
         return github.PaginatedList.PaginatedList(

--- a/github/GitReleaseAsset.py
+++ b/github/GitReleaseAsset.py
@@ -28,7 +28,7 @@ import github.GithubObject
 
 class GitReleaseAsset(github.GithubObject.CompletableGithubObject):
     """
-    This class represents GitReleaseAssets. The reference can be found here https://developer.github.com/v3/repos/releases/#get-a-single-release-asset
+    This class represents GitReleaseAssets. The reference can be found here https://docs.github.com/en/rest/reference/repos#releases
     """
 
     def __repr__(self):

--- a/github/GitTag.py
+++ b/github/GitTag.py
@@ -35,7 +35,7 @@ import github.GitObject
 
 class GitTag(github.GithubObject.CompletableGithubObject):
     """
-    This class represents GitTags. The reference can be found here https://developer.github.com/v3/git/tags/
+    This class represents GitTags. The reference can be found here https://docs.github.com/en/rest/reference/git#tags
     """
 
     def __repr__(self):

--- a/github/GitTree.py
+++ b/github/GitTree.py
@@ -34,7 +34,7 @@ import github.GitTreeElement
 
 class GitTree(github.GithubObject.CompletableGithubObject):
     """
-    This class represents GitTrees. The reference can be found here https://developer.github.com/v3/git/trees/
+    This class represents GitTrees. The reference can be found here https://docs.github.com/en/rest/reference/git#trees
     """
 
     def __repr__(self):

--- a/github/GitignoreTemplate.py
+++ b/github/GitignoreTemplate.py
@@ -32,7 +32,7 @@ import github.GithubObject
 
 class GitignoreTemplate(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents GitignoreTemplates. The reference can be found here https://developer.github.com/v3/gitignore/
+    This class represents GitignoreTemplates. The reference can be found here https://docs.github.com/en/rest/reference/gitignore
     """
 
     def __repr__(self):

--- a/github/Hook.py
+++ b/github/Hook.py
@@ -35,7 +35,7 @@ import github.HookResponse
 
 class Hook(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Hooks. The reference can be found here http://developer.github.com/v3/repos/hooks
+    This class represents Hooks. The reference can be found here http://docs.github.com/en/rest/reference/repos#webhooks
     """
 
     def __repr__(self):
@@ -131,7 +131,7 @@ class Hook(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/hooks/:id <http://developer.github.com/v3/repos/hooks>`_
+        :calls: `DELETE /repos/{owner}/{repo}/hooks/{id} <http://docs.github.com/en/rest/reference/repos#webhooks>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("DELETE", self.url)
@@ -146,7 +146,7 @@ class Hook(github.GithubObject.CompletableGithubObject):
         active=github.GithubObject.NotSet,
     ):
         """
-        :calls: `PATCH /repos/:owner/:repo/hooks/:id <http://developer.github.com/v3/repos/hooks>`_
+        :calls: `PATCH /repos/{owner}/{repo}/hooks/{id} <http://docs.github.com/en/rest/reference/repos#webhooks>`_
         :param name: string
         :param config: dict
         :param events: list of string
@@ -186,14 +186,14 @@ class Hook(github.GithubObject.CompletableGithubObject):
 
     def test(self):
         """
-        :calls: `POST /repos/:owner/:repo/hooks/:id/tests <http://developer.github.com/v3/repos/hooks>`_
+        :calls: `POST /repos/{owner}/{repo}/hooks/{id}/tests <http://docs.github.com/en/rest/reference/repos#webhooks>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("POST", f"{self.url}/tests")
 
     def ping(self):
         """
-        :calls: `POST /repos/:owner/:repo/hooks/:id/pings <http://developer.github.com/v3/repos/hooks>`_
+        :calls: `POST /repos/{owner}/{repo}/hooks/{id}/pings <http://docs.github.com/en/rest/reference/repos#webhooks>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("POST", f"{self.url}/pings")

--- a/github/Installation.py
+++ b/github/Installation.py
@@ -43,7 +43,7 @@ INTEGRATION_PREVIEW_HEADERS = {"Accept": Consts.mediaTypeIntegrationPreview}
 
 class Installation(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents Installations. The reference can be found here https://developer.github.com/v3/apps/installations/
+    This class represents Installations. The reference can be found here https://docs.github.com/en/rest/reference/apps#installations
     """
 
     def __repr__(self):
@@ -79,7 +79,7 @@ class Installation(github.GithubObject.NonCompletableGithubObject):
 
     def get_repos(self):
         """
-        :calls: `GET /installation/repositories <https://developer.github.com/v3/integrations/installations/#list-repositories>`_
+        :calls: `GET /installation/repositories <https://docs.github.com/en/rest/reference/integrations/installations#list-repositories>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
         """
         url_parameters = dict()

--- a/github/Invitation.py
+++ b/github/Invitation.py
@@ -27,7 +27,7 @@ import github.GithubObject
 
 class Invitation(github.GithubObject.CompletableGithubObject):
     """
-    This class represents repository invitations. The reference can be found here https://developer.github.com/v3/repos/invitations/
+    This class represents repository invitations. The reference can be found here https://docs.github.com/en/rest/reference/repos#invitations
     """
 
     def __repr__(self):

--- a/github/Issue.py
+++ b/github/Issue.py
@@ -62,7 +62,7 @@ from . import Consts
 
 class Issue(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Issues. The reference can be found here https://developer.github.com/v3/issues/
+    This class represents Issues. The reference can be found here https://docs.github.com/en/rest/reference/issues
     """
 
     def __repr__(self):
@@ -272,7 +272,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
 
     def as_pull_request(self):
         """
-        :calls: `GET /repos/:owner/:repo/pulls/:number <http://developer.github.com/v3/pulls>`_
+        :calls: `GET /repos/{owner}/{repo}/pulls/{number} <http://docs.github.com/en/rest/reference/pulls>`_
         :rtype: :class:`github.PullRequest.PullRequest`
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -284,7 +284,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
 
     def add_to_assignees(self, *assignees):
         """
-        :calls: `POST /repos/:owner/:repo/issues/:number/assignees <https://developer.github.com/v3/issues/assignees>`_
+        :calls: `POST /repos/{owner}/{repo}/issues/{number}/assignees <https://docs.github.com/en/rest/reference/issues#assignees>`_
         :param assignee: :class:`github.NamedUser.NamedUser` or string
         :rtype: None
         """
@@ -307,7 +307,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
 
     def add_to_labels(self, *labels):
         """
-        :calls: `POST /repos/:owner/:repo/issues/:number/labels <http://developer.github.com/v3/issues/labels>`_
+        :calls: `POST /repos/{owner}/{repo}/issues/{number}/labels <http://docs.github.com/en/rest/reference/issues#labels>`_
         :param label: :class:`github.Label.Label` or string
         :rtype: None
         """
@@ -324,7 +324,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
 
     def create_comment(self, body):
         """
-        :calls: `POST /repos/:owner/:repo/issues/:number/comments <http://developer.github.com/v3/issues/comments>`_
+        :calls: `POST /repos/{owner}/{repo}/issues/{number}/comments <http://docs.github.com/en/rest/reference/issues#comments>`_
         :param body: string
         :rtype: :class:`github.IssueComment.IssueComment`
         """
@@ -341,7 +341,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
 
     def delete_labels(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/issues/:number/labels <http://developer.github.com/v3/issues/labels>`_
+        :calls: `DELETE /repos/{owner}/{repo}/issues/{number}/labels <http://docs.github.com/en/rest/reference/issues#labels>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -359,7 +359,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
         assignees=github.GithubObject.NotSet,
     ):
         """
-        :calls: `PATCH /repos/:owner/:repo/issues/:number <http://developer.github.com/v3/issues>`_
+        :calls: `PATCH /repos/{owner}/{repo}/issues/{number} <http://docs.github.com/en/rest/reference/issues>`_
         :param title: string
         :param body: string
         :param assignee: string or :class:`github.NamedUser.NamedUser` or None
@@ -420,7 +420,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
 
     def lock(self, lock_reason):
         """
-        :calls: `PUT /repos/:owner/:repo/issues/:issue_number/lock <https://developer.github.com/v3/issues>`_
+        :calls: `PUT /repos/{owner}/{repo}/issues/{issue_number}/lock <https://docs.github.com/en/rest/reference/issues>`_
         :param lock_reason: string
         :rtype: None
         """
@@ -436,7 +436,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
 
     def unlock(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/issues/:issue_number/lock <https://developer.github.com/v3/issues>`_
+        :calls: `DELETE /repos/{owner}/{repo}/issues/{issue_number}/lock <https://docs.github.com/en/rest/reference/issues>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -445,7 +445,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
 
     def get_comment(self, id):
         """
-        :calls: `GET /repos/:owner/:repo/issues/comments/:id <http://developer.github.com/v3/issues/comments>`_
+        :calls: `GET /repos/{owner}/{repo}/issues/comments/{id} <http://docs.github.com/en/rest/reference/issues#comments>`_
         :param id: integer
         :rtype: :class:`github.IssueComment.IssueComment`
         """
@@ -459,7 +459,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
 
     def get_comments(self, since=github.GithubObject.NotSet):
         """
-        :calls: `GET /repos/:owner/:repo/issues/:number/comments <http://developer.github.com/v3/issues/comments>`_
+        :calls: `GET /repos/{owner}/{repo}/issues/{number}/comments <http://docs.github.com/en/rest/reference/issues#comments>`_
         :param since: datetime.datetime format YYYY-MM-DDTHH:MM:SSZ
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.IssueComment.IssueComment`
         """
@@ -478,7 +478,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
 
     def get_events(self):
         """
-        :calls: `GET /repos/:owner/:repo/issues/:issue_number/events <http://developer.github.com/v3/issues/events>`_
+        :calls: `GET /repos/{owner}/{repo}/issues/{issue_number}/events <http://docs.github.com/en/rest/reference/issues#events>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.IssueEvent.IssueEvent`
         """
         return github.PaginatedList.PaginatedList(
@@ -491,7 +491,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
 
     def get_labels(self):
         """
-        :calls: `GET /repos/:owner/:repo/issues/:number/labels <http://developer.github.com/v3/issues/labels>`_
+        :calls: `GET /repos/{owner}/{repo}/issues/{number}/labels <http://docs.github.com/en/rest/reference/issues#labels>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Label.Label`
         """
         return github.PaginatedList.PaginatedList(
@@ -500,7 +500,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
 
     def remove_from_assignees(self, *assignees):
         """
-        :calls: `DELETE /repos/:owner/:repo/issues/:number/assignees <https://developer.github.com/v3/issues/assignees>`_
+        :calls: `DELETE /repos/{owner}/{repo}/issues/{number}/assignees <https://docs.github.com/en/rest/reference/issues#assignees>`_
         :param assignee: :class:`github.NamedUser.NamedUser` or string
         :rtype: None
         """
@@ -523,7 +523,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
 
     def remove_from_labels(self, label):
         """
-        :calls: `DELETE /repos/:owner/:repo/issues/:number/labels/:name <http://developer.github.com/v3/issues/labels>`_
+        :calls: `DELETE /repos/{owner}/{repo}/issues/{number}/labels/{name} <http://docs.github.com/en/rest/reference/issues#labels>`_
         :param label: :class:`github.Label.Label` or string
         :rtype: None
         """
@@ -538,7 +538,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
 
     def set_labels(self, *labels):
         """
-        :calls: `PUT /repos/:owner/:repo/issues/:number/labels <http://developer.github.com/v3/issues/labels>`_
+        :calls: `PUT /repos/{owner}/{repo}/issues/{number}/labels <http://docs.github.com/en/rest/reference/issues#labels>`_
         :param labels: list of :class:`github.Label.Label` or strings
         :rtype: None
         """
@@ -555,7 +555,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
 
     def get_reactions(self):
         """
-        :calls: `GET /repos/:owner/:repo/issues/:number/reactions <https://developer.github.com/v3/reactions/#list-reactions-for-an-issue>`_
+        :calls: `GET /repos/{owner}/{repo}/issues/{number}/reactions <https://docs.github.com/en/rest/reference/reactions#list-reactions-for-an-issue>`_
         :return: :class: :class:`github.PaginatedList.PaginatedList` of :class:`github.Reaction.Reaction`
         """
         return github.PaginatedList.PaginatedList(
@@ -568,7 +568,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
 
     def create_reaction(self, reaction_type):
         """
-        :calls: `POST /repos/:owner/:repo/issues/:number/reactions <https://developer.github.com/v3/reactions>`_
+        :calls: `POST /repos/{owner}/{repo}/issues/{number}/reactions <https://docs.github.com/en/rest/reference/reactions>`_
         :param reaction_type: string
         :rtype: :class:`github.Reaction.Reaction`
         """
@@ -586,7 +586,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
 
     def delete_reaction(self, reaction_id):
         """
-        :calls: `DELETE /repos/:owner/:repo/issues/:issue_number/reactions/:reaction_id <https://developer.github.com/v3/reactions/#delete-an-issue-reaction>`_
+        :calls: `DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id} <https://docs.github.com/en/rest/reference/reactions#delete-an-issue-reaction>`_
         :param reaction_id: integer
         :rtype: bool
         """
@@ -600,7 +600,7 @@ class Issue(github.GithubObject.CompletableGithubObject):
 
     def get_timeline(self):
         """
-        :calls: `GET /repos/:owner/:repo/issues/:number/timeline <https://developer.github.com/v3/issues/timeline/#list-events-for-an-issue>`_
+        :calls: `GET /repos/{owner}/{repo}/issues/{number}/timeline <https://docs.github.com/en/rest/reference/issues/timeline#list-events-for-an-issue>`_
         :return: :class: :class:`github.PaginatedList.PaginatedList` of :class:`github.TimelineEvent.TimelineEvent`
         """
         return github.PaginatedList.PaginatedList(

--- a/github/IssueComment.py
+++ b/github/IssueComment.py
@@ -40,7 +40,7 @@ from . import Consts
 
 class IssueComment(github.GithubObject.CompletableGithubObject):
     """
-    This class represents IssueComments. The reference can be found here https://developer.github.com/v3/issues/comments/
+    This class represents IssueComments. The reference can be found here https://docs.github.com/en/rest/reference/issues#comments
     """
 
     def __repr__(self):
@@ -112,14 +112,14 @@ class IssueComment(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/issues/comments/:id <http://developer.github.com/v3/issues/comments>`_
+        :calls: `DELETE /repos/{owner}/{repo}/issues/comments/{id} <http://docs.github.com/en/rest/reference/issues#comments>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("DELETE", self.url)
 
     def edit(self, body):
         """
-        :calls: `PATCH /repos/:owner/:repo/issues/comments/:id <http://developer.github.com/v3/issues/comments>`_
+        :calls: `PATCH /repos/{owner}/{repo}/issues/comments/{id} <http://docs.github.com/en/rest/reference/issues#comments>`_
         :param body: string
         :rtype: None
         """
@@ -134,8 +134,8 @@ class IssueComment(github.GithubObject.CompletableGithubObject):
 
     def get_reactions(self):
         """
-        :calls: `GET /repos/:owner/:repo/issues/comments/:id/reactions
-                <https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment>`_
+        :calls: `GET /repos/{owner}/{repo}/issues/comments/{id}/reactions
+                <https://docs.github.com/en/rest/reference/reactions#list-reactions-for-an-issue-comment>`_
         :return: :class: :class:`github.PaginatedList.PaginatedList` of :class:`github.Reaction.Reaction`
         """
         return github.PaginatedList.PaginatedList(
@@ -148,8 +148,8 @@ class IssueComment(github.GithubObject.CompletableGithubObject):
 
     def create_reaction(self, reaction_type):
         """
-        :calls: `POST /repos/:owner/:repo/issues/comments/:id/reactions
-                <https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment>`_
+        :calls: `POST /repos/{owner}/{repo}/issues/comments/{id}/reactions
+                <https://docs.github.com/en/rest/reference/reactions#create-reaction-for-an-issue-comment>`_
         :param reaction_type: string
         :rtype: :class:`github.Reaction.Reaction`
         """
@@ -167,8 +167,8 @@ class IssueComment(github.GithubObject.CompletableGithubObject):
 
     def delete_reaction(self, reaction_id):
         """
-        :calls: `DELETE /repos/:owner/:repo/issues/comments/:comment_id/reactions/:reaction_id
-                <https://developer.github.com/v3/reactions/#delete-an-issue-comment-reaction>`_
+        :calls: `DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}
+                <https://docs.github.com/en/rest/reference/reactions#delete-an-issue-comment-reaction>`_
         :param reaction_id: integer
         :rtype: bool
         """

--- a/github/IssueEvent.py
+++ b/github/IssueEvent.py
@@ -36,7 +36,7 @@ import github.NamedUser
 
 class IssueEvent(github.GithubObject.CompletableGithubObject):
     """
-    This class represents IssueEvents. The reference can be found here https://developer.github.com/v3/issues/events/
+    This class represents IssueEvents. The reference can be found here https://docs.github.com/en/rest/reference/issues#events
     """
 
     def __repr__(self):

--- a/github/Label.py
+++ b/github/Label.py
@@ -38,7 +38,7 @@ from . import Consts
 
 class Label(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Labels. The reference can be found here http://developer.github.com/v3/issues/labels/
+    This class represents Labels. The reference can be found here http://docs.github.com/en/rest/reference/issues#labels
     """
 
     def __repr__(self):
@@ -78,14 +78,14 @@ class Label(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/labels/:name <http://developer.github.com/v3/issues/labels>`_
+        :calls: `DELETE /repos/{owner}/{repo}/labels/{name} <http://docs.github.com/en/rest/reference/issues#labels>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("DELETE", self.url)
 
     def edit(self, name, color, description=github.GithubObject.NotSet):
         """
-        :calls: `PATCH /repos/:owner/:repo/labels/:name <http://developer.github.com/v3/issues/labels>`_
+        :calls: `PATCH /repos/{owner}/{repo}/labels/{name} <http://docs.github.com/en/rest/reference/issues#labels>`_
         :param name: string
         :param color: string
         :param description: string

--- a/github/License.py
+++ b/github/License.py
@@ -25,7 +25,7 @@ import github.GithubObject
 
 class License(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Licenses. The reference can be found here https://developer.github.com/v3/licenses/
+    This class represents Licenses. The reference can be found here https://docs.github.com/en/rest/reference/licenses
     """
 
     def __repr__(self):

--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -197,7 +197,7 @@ class Github:
         """
         Rate limit status for different resources (core/search/graphql).
 
-        :calls: `GET /rate_limit <http://developer.github.com/v3/rate_limit>`_
+        :calls: `GET /rate_limit <http://docs.github.com/en/rest/reference/rate_limit>`_
         :rtype: :class:`github.RateLimit.RateLimit`
         """
         headers, data = self.__requester.requestJsonAndCheck("GET", "/rate_limit")
@@ -212,7 +212,7 @@ class Github:
 
     def get_license(self, key=github.GithubObject.NotSet):
         """
-        :calls: `GET /license/:license <https://developer.github.com/v3/licenses/#get-an-individual-license>`_
+        :calls: `GET /license/{license} <https://docs.github.com/en/rest/reference/licenses#get-an-individual-license>`_
         :param key: string
         :rtype: :class:`github.License.License`
         """
@@ -223,7 +223,7 @@ class Github:
 
     def get_licenses(self):
         """
-        :calls: `GET /licenses <https://developer.github.com/v3/licenses/#list-all-licenses>`_
+        :calls: `GET /licenses <https://docs.github.com/en/rest/reference/licenses#list-all-licenses>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.License.License`
         """
 
@@ -235,7 +235,7 @@ class Github:
 
     def get_events(self):
         """
-        :calls: `GET /events <https://developer.github.com/v3/activity/events/#list-public-events>`_
+        :calls: `GET /events <https://docs.github.com/en/rest/reference/activity/events#list-public-events>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
         """
 
@@ -245,7 +245,7 @@ class Github:
 
     def get_user(self, login=github.GithubObject.NotSet):
         """
-        :calls: `GET /users/:user <http://developer.github.com/v3/users>`_ or `GET /user <http://developer.github.com/v3/users>`_
+        :calls: `GET /users/{user} <http://docs.github.com/en/rest/reference/users>`_ or `GET /user <http://docs.github.com/en/rest/reference/users>`_
         :param login: string
         :rtype: :class:`github.NamedUser.NamedUser` or :class:`github.AuthenticatedUser.AuthenticatedUser`
         """
@@ -264,7 +264,7 @@ class Github:
 
     def get_user_by_id(self, user_id):
         """
-        :calls: `GET /user/:id <http://developer.github.com/v3/users>`_
+        :calls: `GET /user/{id} <http://docs.github.com/en/rest/reference/users>`_
         :param user_id: int
         :rtype: :class:`github.NamedUser.NamedUser`
         """
@@ -276,7 +276,7 @@ class Github:
 
     def get_users(self, since=github.GithubObject.NotSet):
         """
-        :calls: `GET /users <http://developer.github.com/v3/users>`_
+        :calls: `GET /users <http://docs.github.com/en/rest/reference/users>`_
         :param since: integer
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
@@ -290,7 +290,7 @@ class Github:
 
     def get_organization(self, login):
         """
-        :calls: `GET /orgs/:org <http://developer.github.com/v3/orgs>`_
+        :calls: `GET /orgs/{org} <http://docs.github.com/en/rest/reference/orgs>`_
         :param login: string
         :rtype: :class:`github.Organization.Organization`
         """
@@ -302,7 +302,7 @@ class Github:
 
     def get_organizations(self, since=github.GithubObject.NotSet):
         """
-        :calls: `GET /organizations <http://developer.github.com/v3/orgs#list-all-organizations>`_
+        :calls: `GET /organizations <http://docs.github.com/en/rest/reference/orgs#list-all-organizations>`_
         :param since: integer
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Organization.Organization`
         """
@@ -319,7 +319,7 @@ class Github:
 
     def get_repo(self, full_name_or_id, lazy=False):
         """
-        :calls: `GET /repos/:owner/:repo <http://developer.github.com/v3/repos>`_ or `GET /repositories/:id <http://developer.github.com/v3/repos>`_
+        :calls: `GET /repos/{owner}/{repo} <http://docs.github.com/en/rest/reference/repos>`_ or `GET /repositories/{id} <http://docs.github.com/en/rest/reference/repos>`_
         :rtype: :class:`github.Repository.Repository`
         """
         assert isinstance(full_name_or_id, (str, int)), full_name_or_id
@@ -336,7 +336,7 @@ class Github:
         self, since=github.GithubObject.NotSet, visibility=github.GithubObject.NotSet
     ):
         """
-        :calls: `GET /repositories <http://developer.github.com/v3/repos/#list-all-public-repositories>`_
+        :calls: `GET /repositories <http://docs.github.com/en/rest/reference/repos#list-all-public-repositories>`_
         :param since: integer
         :param visibility: string ('all','public')
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
@@ -357,7 +357,7 @@ class Github:
 
     def get_project(self, id):
         """
-        :calls: `GET /projects/:project_id <https://developer.github.com/v3/projects/#get-a-project>`_
+        :calls: `GET /projects/{project_id} <https://docs.github.com/en/rest/reference/projects#get-a-project>`_
         :rtype: :class:`github.Project.Project`
         :param id: integer
         """
@@ -370,7 +370,7 @@ class Github:
 
     def get_project_column(self, id):
         """
-        :calls: `GET /projects/columns/:column_id <https://developer.github.com/v3/projects/columns/#get-a-project-column>`_
+        :calls: `GET /projects/columns/{column_id} <https://docs.github.com/en/rest/reference/projects/columns#get-a-project-column>`_
         :rtype: :class:`github.ProjectColumn.ProjectColumn`
         :param id: integer
         """
@@ -385,7 +385,7 @@ class Github:
 
     def get_gist(self, id):
         """
-        :calls: `GET /gists/:id <http://developer.github.com/v3/gists>`_
+        :calls: `GET /gists/{id} <http://docs.github.com/en/rest/reference/gists>`_
         :param id: string
         :rtype: :class:`github.Gist.Gist`
         """
@@ -395,7 +395,7 @@ class Github:
 
     def get_gists(self, since=github.GithubObject.NotSet):
         """
-        :calls: `GET /gists/public <http://developer.github.com/v3/gists>`_
+        :calls: `GET /gists/public <http://docs.github.com/en/rest/reference/gists>`_
         :param since: datetime.datetime format YYYY-MM-DDTHH:MM:SSZ
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Gist.Gist`
         """
@@ -417,7 +417,7 @@ class Github:
         **qualifiers,
     ):
         """
-        :calls: `GET /search/repositories <http://developer.github.com/v3/search>`_
+        :calls: `GET /search/repositories <http://docs.github.com/en/rest/reference/search>`_
         :param query: string
         :param sort: string ('stars', 'forks', 'updated')
         :param order: string ('asc', 'desc')
@@ -462,7 +462,7 @@ class Github:
         **qualifiers,
     ):
         """
-        :calls: `GET /search/users <http://developer.github.com/v3/search>`_
+        :calls: `GET /search/users <http://docs.github.com/en/rest/reference/search>`_
         :param query: string
         :param sort: string ('followers', 'repositories', 'joined')
         :param order: string ('asc', 'desc')
@@ -503,7 +503,7 @@ class Github:
         **qualifiers,
     ):
         """
-        :calls: `GET /search/issues <http://developer.github.com/v3/search>`_
+        :calls: `GET /search/issues <http://docs.github.com/en/rest/reference/search>`_
         :param query: string
         :param sort: string ('comments', 'created', 'updated')
         :param order: string ('asc', 'desc')
@@ -542,7 +542,7 @@ class Github:
         **qualifiers,
     ):
         """
-        :calls: `GET /search/code <http://developer.github.com/v3/search>`_
+        :calls: `GET /search/code <http://docs.github.com/en/rest/reference/search>`_
         :param query: string
         :param sort: string ('indexed')
         :param order: string ('asc', 'desc')
@@ -591,7 +591,7 @@ class Github:
         **qualifiers,
     ):
         """
-        :calls: `GET /search/commits <http://developer.github.com/v3/search>`_
+        :calls: `GET /search/commits <http://docs.github.com/en/rest/reference/search>`_
         :param query: string
         :param sort: string ('author-date', 'committer-date')
         :param order: string ('asc', 'desc')
@@ -631,7 +631,7 @@ class Github:
 
     def search_topics(self, query, **qualifiers):
         """
-        :calls: `GET /search/topics <http://developer.github.com/v3/search>`_
+        :calls: `GET /search/topics <http://docs.github.com/en/rest/reference/search>`_
         :param query: string
         :param qualifiers: keyword dict query qualifiers
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Topic.Topic`
@@ -659,7 +659,7 @@ class Github:
 
     def render_markdown(self, text, context=github.GithubObject.NotSet):
         """
-        :calls: `POST /markdown <http://developer.github.com/v3/markdown>`_
+        :calls: `POST /markdown <http://docs.github.com/en/rest/reference/markdown>`_
         :param text: string
         :param context: :class:`github.Repository.Repository`
         :rtype: string
@@ -679,7 +679,7 @@ class Github:
 
     def get_hook(self, name):
         """
-        :calls: `GET /hooks/:name <http://developer.github.com/v3/repos/hooks/>`_
+        :calls: `GET /hooks/{name} <http://docs.github.com/en/rest/reference/repos#hooks>`_
         :param name: string
         :rtype: :class:`github.HookDescription.HookDescription`
         """
@@ -693,7 +693,7 @@ class Github:
 
     def get_hooks(self):
         """
-        :calls: `GET /hooks <http://developer.github.com/v3/repos/hooks/>`_
+        :calls: `GET /hooks <http://docs.github.com/en/rest/reference/repos#hooks>`_
         :rtype: list of :class:`github.HookDescription.HookDescription`
         """
         headers, data = self.__requester.requestJsonAndCheck("GET", "/hooks")
@@ -706,7 +706,7 @@ class Github:
 
     def get_gitignore_templates(self):
         """
-        :calls: `GET /gitignore/templates <http://developer.github.com/v3/gitignore>`_
+        :calls: `GET /gitignore/templates <http://docs.github.com/en/rest/reference/gitignore>`_
         :rtype: list of string
         """
         headers, data = self.__requester.requestJsonAndCheck(
@@ -716,7 +716,7 @@ class Github:
 
     def get_gitignore_template(self, name):
         """
-        :calls: `GET /gitignore/templates/:name <http://developer.github.com/v3/gitignore>`_
+        :calls: `GET /gitignore/templates/{name} <http://docs.github.com/en/rest/reference/gitignore>`_
         :rtype: :class:`github.GitignoreTemplate.GitignoreTemplate`
         """
         assert isinstance(name, str), name
@@ -729,7 +729,7 @@ class Github:
 
     def get_emojis(self):
         """
-        :calls: `GET /emojis <http://developer.github.com/v3/emojis/>`_
+        :calls: `GET /emojis <http://docs.github.com/en/rest/reference/emojis>`_
         :rtype: dictionary of type => url for emoji`
         """
         headers, attributes = self.__requester.requestJsonAndCheck("GET", "/emojis")
@@ -778,7 +778,7 @@ class Github:
 
     def get_app(self, slug=github.GithubObject.NotSet):
         """
-        :calls: `GET /apps/:slug <https://docs.github.com/en/rest/reference/apps>`_ or `GET /app <https://docs.github.com/en/rest/reference/apps>`_
+        :calls: `GET /apps/{slug} <https://docs.github.com/en/rest/reference/apps>`_ or `GET /app <https://docs.github.com/en/rest/reference/apps>`_
         :param slug: string
         :rtype: :class:`github.GithubApp.GithubApp`
         """
@@ -867,7 +867,7 @@ class GithubIntegration:
 
     def get_installation(self, owner, repo):
         """
-        :calls: `GET /repos/:owner/:repo/installation <https://developer.github.com/v3/apps/#get-a-repository-installation>`_
+        :calls: `GET /repos/{owner}/{repo}/installation <https://docs.github.com/en/rest/reference/apps#get-a-repository-installation>`_
         :param owner: str
         :param repo: str
         :rtype: :class:`github.Installation.Installation`

--- a/github/Membership.py
+++ b/github/Membership.py
@@ -43,7 +43,7 @@ import github.GithubObject
 
 class Membership(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Membership of an organization. The reference can be found here http://developer.github.com/v3/orgs/
+    This class represents Membership of an organization. The reference can be found here http://docs.github.com/en/rest/reference/orgs
     """
 
     def __repr__(self):

--- a/github/Migration.py
+++ b/github/Migration.py
@@ -39,7 +39,7 @@ from . import Consts
 
 class Migration(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Migrations. The reference can be found here http://developer.github.com/v3/migrations/
+    This class represents Migrations. The reference can be found here http://docs.github.com/en/rest/reference/migrations
     """
 
     def __repr__(self):
@@ -128,7 +128,7 @@ class Migration(github.GithubObject.CompletableGithubObject):
 
     def get_status(self):
         """
-        :calls: `GET /user/migrations/:migration_id <https://developer.github.com/v3/migrations/users>`_
+        :calls: `GET /user/migrations/{migration_id} <https://docs.github.com/en/rest/reference/migrations>`_
         :rtype: str
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -139,7 +139,7 @@ class Migration(github.GithubObject.CompletableGithubObject):
 
     def get_archive_url(self):
         """
-        :calls: `GET /user/migrations/:migration_id/archive <https://developer.github.com/v3/migrations/users>`_
+        :calls: `GET /user/migrations/{migration_id}/archive <https://docs.github.com/en/rest/reference/migrations>`_
         :rtype: str
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -151,7 +151,7 @@ class Migration(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /user/migrations/:migration_id/archive <https://developer.github.com/v3/migrations/users>`_
+        :calls: `DELETE /user/migrations/{migration_id}/archive <https://docs.github.com/en/rest/reference/migrations>`_
         """
         headers, data = self._requester.requestJsonAndCheck(
             "DELETE",
@@ -161,7 +161,7 @@ class Migration(github.GithubObject.CompletableGithubObject):
 
     def unlock_repo(self, repo_name):
         """
-        :calls: `DELETE /user/migrations/:migration_id/repos/:repo_name/lock <https://developer.github.com/v3/migrations/users>`_
+        :calls: `DELETE /user/migrations/{migration_id}/repos/{repo_name}/lock <https://docs.github.com/en/rest/reference/migrations>`_
         :param repo_name: str
         :rtype: None
         """

--- a/github/Milestone.py
+++ b/github/Milestone.py
@@ -38,7 +38,7 @@ import github.PaginatedList
 
 class Milestone(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Milestones. The reference can be found here http://developer.github.com/v3/issues/milestones/
+    This class represents Milestones. The reference can be found here http://docs.github.com/en/rest/reference/issues#milestones
     """
 
     def __repr__(self):
@@ -152,7 +152,7 @@ class Milestone(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/milestones/:number <http://developer.github.com/v3/issues/milestones>`_
+        :calls: `DELETE /repos/{owner}/{repo}/milestones/{number} <http://docs.github.com/en/rest/reference/issues#milestones>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("DELETE", self.url)
@@ -165,7 +165,7 @@ class Milestone(github.GithubObject.CompletableGithubObject):
         due_on=github.GithubObject.NotSet,
     ):
         """
-        :calls: `PATCH /repos/:owner/:repo/milestones/:number <http://developer.github.com/v3/issues/milestones>`_
+        :calls: `PATCH /repos/{owner}/{repo}/milestones/{number} <http://docs.github.com/en/rest/reference/issues#milestones>`_
         :param title: string
         :param state: string
         :param description: string
@@ -196,7 +196,7 @@ class Milestone(github.GithubObject.CompletableGithubObject):
 
     def get_labels(self):
         """
-        :calls: `GET /repos/:owner/:repo/milestones/:number/labels <http://developer.github.com/v3/issues/labels>`_
+        :calls: `GET /repos/{owner}/{repo}/milestones/{number}/labels <http://docs.github.com/en/rest/reference/issues#labels>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Label.Label`
         """
         return github.PaginatedList.PaginatedList(

--- a/github/NamedUser.py
+++ b/github/NamedUser.py
@@ -52,7 +52,7 @@ from . import Consts
 
 class NamedUser(github.GithubObject.CompletableGithubObject):
     """
-    This class represents NamedUsers. The reference can be found here https://developer.github.com/v3/users/#get-a-single-user
+    This class represents NamedUsers. The reference can be found here https://docs.github.com/en/rest/reference/users#get-a-single-user
     """
 
     def __repr__(self):
@@ -430,7 +430,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
 
     def get_events(self):
         """
-        :calls: `GET /users/:user/events <http://developer.github.com/v3/activity/events>`_
+        :calls: `GET /users/{user}/events <http://docs.github.com/en/rest/reference/activity#events>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
         """
         return github.PaginatedList.PaginatedList(
@@ -439,7 +439,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
 
     def get_followers(self):
         """
-        :calls: `GET /users/:user/followers <http://developer.github.com/v3/users/followers>`_
+        :calls: `GET /users/{user}/followers <http://docs.github.com/en/rest/reference/users#followers>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
         return github.PaginatedList.PaginatedList(
@@ -448,7 +448,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
 
     def get_following(self):
         """
-        :calls: `GET /users/:user/following <http://developer.github.com/v3/users/followers>`_
+        :calls: `GET /users/{user}/following <http://docs.github.com/en/rest/reference/users#followers>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
         return github.PaginatedList.PaginatedList(
@@ -457,7 +457,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
 
     def get_gists(self, since=github.GithubObject.NotSet):
         """
-        :calls: `GET /users/:user/gists <http://developer.github.com/v3/gists>`_
+        :calls: `GET /users/{user}/gists <http://docs.github.com/en/rest/reference/gists>`_
         :param since: datetime.datetime format YYYY-MM-DDTHH:MM:SSZ
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Gist.Gist`
         """
@@ -473,7 +473,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
 
     def get_keys(self):
         """
-        :calls: `GET /users/:user/keys <http://developer.github.com/v3/users/keys>`_
+        :calls: `GET /users/{user}/keys <http://docs.github.com/en/rest/reference/users#keys>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.UserKey.UserKey`
         """
         return github.PaginatedList.PaginatedList(
@@ -482,7 +482,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
 
     def get_orgs(self):
         """
-        :calls: `GET /users/:user/orgs <http://developer.github.com/v3/orgs>`_
+        :calls: `GET /users/{user}/orgs <http://docs.github.com/en/rest/reference/orgs>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Organization.Organization`
         """
         return github.PaginatedList.PaginatedList(
@@ -491,7 +491,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
 
     def get_projects(self, state="open"):
         """
-        :calls: `GET /users/:user/projects <https://developer.github.com/v3/projects/#list-user-projects>`_
+        :calls: `GET /users/{user}/projects <https://docs.github.com/en/rest/reference/projects#list-user-projects>`_
         :param state: string
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Project.Project`
         """
@@ -507,7 +507,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
 
     def get_public_events(self):
         """
-        :calls: `GET /users/:user/events/public <http://developer.github.com/v3/activity/events>`_
+        :calls: `GET /users/{user}/events/public <http://docs.github.com/en/rest/reference/activity#events>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
         """
         return github.PaginatedList.PaginatedList(
@@ -516,7 +516,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
 
     def get_public_received_events(self):
         """
-        :calls: `GET /users/:user/received_events/public <http://developer.github.com/v3/activity/events>`_
+        :calls: `GET /users/{user}/received_events/public <http://docs.github.com/en/rest/reference/activity#events>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
         """
         return github.PaginatedList.PaginatedList(
@@ -528,7 +528,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
 
     def get_received_events(self):
         """
-        :calls: `GET /users/:user/received_events <http://developer.github.com/v3/activity/events>`_
+        :calls: `GET /users/{user}/received_events <http://docs.github.com/en/rest/reference/activity#events>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
         """
         return github.PaginatedList.PaginatedList(
@@ -537,7 +537,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
 
     def get_repo(self, name):
         """
-        :calls: `GET /repos/:owner/:repo <http://developer.github.com/v3/repos>`_
+        :calls: `GET /repos/{owner}/{repo} <http://docs.github.com/en/rest/reference/repos>`_
         :param name: string
         :rtype: :class:`github.Repository.Repository`
         """
@@ -556,7 +556,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
         direction=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /users/:user/repos <http://developer.github.com/v3/repos>`_
+        :calls: `GET /users/{user}/repos <http://docs.github.com/en/rest/reference/repos>`_
         :param type: string
         :param sort: string
         :param direction: string
@@ -583,7 +583,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
 
     def get_starred(self):
         """
-        :calls: `GET /users/:user/starred <http://developer.github.com/v3/activity/starring>`_
+        :calls: `GET /users/{user}/starred <http://docs.github.com/en/rest/reference/activity#starring>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
         """
         return github.PaginatedList.PaginatedList(
@@ -592,7 +592,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
 
     def get_subscriptions(self):
         """
-        :calls: `GET /users/:user/subscriptions <http://developer.github.com/v3/activity/watching>`_
+        :calls: `GET /users/{user}/subscriptions <http://docs.github.com/en/rest/reference/activity#watching>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
         """
         return github.PaginatedList.PaginatedList(
@@ -604,7 +604,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
 
     def get_watched(self):
         """
-        :calls: `GET /users/:user/watched <http://developer.github.com/v3/activity/starring>`_
+        :calls: `GET /users/{user}/watched <http://docs.github.com/en/rest/reference/activity#starring>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
         """
         return github.PaginatedList.PaginatedList(
@@ -613,7 +613,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
 
     def has_in_following(self, following):
         """
-        :calls: `GET /users/:user/following/:target_user <http://developer.github.com/v3/users/followers/#check-if-one-user-follows-another>`_
+        :calls: `GET /users/{user}/following/{target_user} <http://docs.github.com/en/rest/reference/users/followers#check-if-one-user-follows-another>`_
         :param following: :class:`github.NamedUser.NamedUser`
         :rtype: bool
         """
@@ -629,7 +629,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
 
     def get_organization_membership(self, org):
         """
-        :calls: `GET /orgs/:org/memberships/:username <https://developer.github.com/v3/orgs/members/#get-organization-membership>`_
+        :calls: `GET /orgs/{org}/memberships/{username} <https://docs.github.com/en/rest/reference/orgs/members#get-organization-membership>`_
         :param org: string or :class:`github.Organization.Organization`
         :rtype: :class:`github.Membership.Membership`
         """

--- a/github/Notification.py
+++ b/github/Notification.py
@@ -34,7 +34,7 @@ import github.Repository
 
 class Notification(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Notifications. The reference can be found here http://developer.github.com/v3/activity/notifications/
+    This class represents Notifications. The reference can be found here http://docs.github.com/en/rest/reference/activity#notifications
     """
 
     def __repr__(self):
@@ -114,7 +114,7 @@ class Notification(github.GithubObject.CompletableGithubObject):
 
     def mark_as_read(self):
         """
-        :calls: `PATCH /notifications/threads/:id <https://developer.github.com/v3/activity/notifications/>`_
+        :calls: `PATCH /notifications/threads/{id} <https://docs.github.com/en/rest/reference/activity#notifications>`_
         """
         headers, data = self._requester.requestJsonAndCheck(
             "PATCH",

--- a/github/NotificationSubject.py
+++ b/github/NotificationSubject.py
@@ -31,7 +31,7 @@ import github.GithubObject
 
 class NotificationSubject(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents Subjects of Notifications. The reference can be found here http://developer.github.com/v3/activity/notifications/#list-your-notifications
+    This class represents Subjects of Notifications. The reference can be found here http://docs.github.com/en/rest/reference/activity/notifications#list-your-notifications
     """
 
     def __repr__(self):

--- a/github/Organization.py
+++ b/github/Organization.py
@@ -55,7 +55,7 @@ from . import Consts
 
 class Organization(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Organizations. The reference can be found here http://developer.github.com/v3/orgs/
+    This class represents Organizations. The reference can be found here http://docs.github.com/en/rest/reference/orgs
     """
 
     def __repr__(self):
@@ -359,7 +359,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def add_to_members(self, member, role=github.GithubObject.NotSet):
         """
-        :calls: `PUT /orgs/:org/memberships/:user <https://developer.github.com/v3/orgs/members/#add-or-update-organization-membership>`_
+        :calls: `PUT /orgs/{org}/memberships/{user} <https://docs.github.com/en/rest/reference/orgs/members#add-or-update-organization-membership>`_
         :param member: :class:`github.NamedUser.NamedUser`
         :param role: string
         :rtype: None
@@ -375,7 +375,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def add_to_public_members(self, public_member):
         """
-        :calls: `PUT /orgs/:org/public_members/:user <http://developer.github.com/v3/orgs/members>`_
+        :calls: `PUT /orgs/{org}/public_members/{user} <http://docs.github.com/en/rest/reference/orgs#members>`_
         :param public_member: :class:`github.NamedUser.NamedUser`
         :rtype: None
         """
@@ -386,7 +386,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def create_fork(self, repo):
         """
-        :calls: `POST /repos/:owner/:repo/forks <http://developer.github.com/v3/repos/forks>`_
+        :calls: `POST /repos/{owner}/{repo}/forks <http://docs.github.com/en/rest/reference/repos#forks>`_
         :param repo: :class:`github.Repository.Repository`
         :rtype: :class:`github.Repository.Repository`
         """
@@ -411,7 +411,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
         active=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /orgs/:owner/hooks <http://developer.github.com/v3/orgs/hooks>`_
+        :calls: `POST /orgs/{owner}/hooks <http://docs.github.com/en/rest/reference/orgs#hooks>`_
         :param name: string
         :param config: dict
         :param events: list of string
@@ -439,7 +439,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def create_project(self, name, body=github.GithubObject.NotSet):
         """
-        :calls: `POST /orgs/:org/projects <https://developer.github.com/v3/projects/#create-an-organization-project>`_
+        :calls: `POST /orgs/{org}/projects <https://docs.github.com/en/rest/reference/projects#create-an-organization-project>`_
         :param name: string
         :param body: string
         :rtype: :class:`github.Project.Project`
@@ -477,7 +477,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
         delete_branch_on_merge=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /orgs/:org/repos <http://developer.github.com/v3/repos>`_
+        :calls: `POST /orgs/{org}/repos <http://docs.github.com/en/rest/reference/repos>`_
         :param name: string
         :param description: string
         :param homepage: string
@@ -591,7 +591,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
         description=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /orgs/:org/teams <http://developer.github.com/v3/orgs/teams>`_
+        :calls: `POST /orgs/{org}/teams <http://docs.github.com/en/rest/reference/orgs#teams>`_
         :param name: string
         :param repo_names: list of :class:`github.Repository.Repository`
         :param permission: string
@@ -632,7 +632,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def delete_hook(self, id):
         """
-        :calls: `DELETE /orgs/:owner/hooks/:id <http://developer.github.com/v3/orgs/hooks>`_
+        :calls: `DELETE /orgs/{owner}/hooks/{id} <http://docs.github.com/en/rest/reference/orgs#hooks>`_
         :param id: integer
         :rtype: None`
         """
@@ -652,7 +652,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
         name=github.GithubObject.NotSet,
     ):
         """
-        :calls: `PATCH /orgs/:org <http://developer.github.com/v3/orgs>`_
+        :calls: `PATCH /orgs/{org} <http://docs.github.com/en/rest/reference/orgs>`_
         :param billing_email: string
         :param blog: string
         :param company: string
@@ -706,7 +706,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
         active=github.GithubObject.NotSet,
     ):
         """
-        :calls: `PATCH /orgs/:owner/hooks/:id <http://developer.github.com/v3/orgs/hooks>`_
+        :calls: `PATCH /orgs/{owner}/hooks/{id} <http://docs.github.com/en/rest/reference/orgs#hooks>`_
         :param id: integer
         :param name: string
         :param config: dict
@@ -736,7 +736,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def get_events(self):
         """
-        :calls: `GET /orgs/:org/events <http://developer.github.com/v3/activity/events>`_
+        :calls: `GET /orgs/{org}/events <http://docs.github.com/en/rest/reference/activity#events>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
         """
         return github.PaginatedList.PaginatedList(
@@ -745,7 +745,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def get_hook(self, id):
         """
-        :calls: `GET /orgs/:owner/hooks/:id <http://developer.github.com/v3/orgs/hooks>`_
+        :calls: `GET /orgs/{owner}/hooks/{id} <http://docs.github.com/en/rest/reference/orgs#hooks>`_
         :param id: integer
         :rtype: :class:`github.Hook.Hook`
         """
@@ -757,7 +757,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def get_hooks(self):
         """
-        :calls: `GET /orgs/:owner/hooks <http://developer.github.com/v3/orgs/hooks>`_
+        :calls: `GET /orgs/{owner}/hooks <http://docs.github.com/en/rest/reference/orgs#hooks>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Hook.Hook`
         """
         return github.PaginatedList.PaginatedList(
@@ -774,7 +774,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
         since=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /orgs/:org/issues <http://developer.github.com/v3/issues>`_
+        :calls: `GET /orgs/{org}/issues <http://docs.github.com/en/rest/reference/issues>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Issue.Issue`
         :param filter: string
         :param state: string
@@ -817,7 +817,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
         self, filter_=github.GithubObject.NotSet, role=github.GithubObject.NotSet
     ):
         """
-        :calls: `GET /orgs/:org/members <http://developer.github.com/v3/orgs/members>`_
+        :calls: `GET /orgs/{org}/members <http://docs.github.com/en/rest/reference/orgs#members>`_
         :param filter_: string
         :param role: string
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
@@ -841,7 +841,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def get_projects(self, state=github.GithubObject.NotSet):
         """
-        :calls: `GET /orgs/:org/projects <https://developer.github.com/v3/projects/#list-organization-projects>`_
+        :calls: `GET /orgs/{org}/projects <https://docs.github.com/en/rest/reference/projects#list-organization-projects>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Project.Project`
         :param state: string
         """
@@ -860,7 +860,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def get_public_members(self):
         """
-        :calls: `GET /orgs/:org/public_members <http://developer.github.com/v3/orgs/members>`_
+        :calls: `GET /orgs/{org}/public_members <http://docs.github.com/en/rest/reference/orgs#members>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
         return github.PaginatedList.PaginatedList(
@@ -872,7 +872,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def get_outside_collaborators(self, filter_=github.GithubObject.NotSet):
         """
-        :calls: `GET /orgs/:org/outside_collaborators <http://developer.github.com/v3/orgs/outside_collaborators>`_
+        :calls: `GET /orgs/{org}/outside_collaborators <http://docs.github.com/en/rest/reference/orgs#outside_collaborators>`_
         :param filter_: string
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
@@ -892,7 +892,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def remove_outside_collaborator(self, collaborator):
         """
-        :calls: `DELETE /orgs/:org/outside_collaborators/:username <https://developer.github.com/v3/orgs/outside_collaborators>`_
+        :calls: `DELETE /orgs/{org}/outside_collaborators/{username} <https://docs.github.com/en/rest/reference/orgs#outside_collaborators>`_
         :param collaborator: :class:`github.NamedUser.NamedUser`
         :rtype: None
         """
@@ -903,7 +903,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def convert_to_outside_collaborator(self, member):
         """
-        :calls: `PUT /orgs/:org/outside_collaborators/:username <https://developer.github.com/v3/orgs/outside_collaborators>`_
+        :calls: `PUT /orgs/{org}/outside_collaborators/{username} <https://docs.github.com/en/rest/reference/orgs#outside_collaborators>`_
         :param member: :class:`github.NamedUser.NamedUser`
         :rtype: None
         """
@@ -914,7 +914,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def get_repo(self, name):
         """
-        :calls: `GET /repos/:owner/:repo <http://developer.github.com/v3/repos>`_
+        :calls: `GET /repos/{owner}/{repo} <http://docs.github.com/en/rest/reference/repos>`_
         :param name: string
         :rtype: :class:`github.Repository.Repository`
         """
@@ -933,7 +933,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
         direction=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /orgs/:org/repos <http://developer.github.com/v3/repos>`_
+        :calls: `GET /orgs/{org}/repos <http://docs.github.com/en/rest/reference/repos>`_
         :param type: string ('all', 'public', 'private', 'forks', 'sources', 'member')
         :param sort: string ('created', 'updated', 'pushed', 'full_name')
         :param direction: string ('asc', desc')
@@ -961,7 +961,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def get_team(self, id):
         """
-        :calls: `GET /teams/:id <http://developer.github.com/v3/orgs/teams>`_
+        :calls: `GET /teams/{id} <http://docs.github.com/en/rest/reference/orgs#teams>`_
         :param id: integer
         :rtype: :class:`github.Team.Team`
         """
@@ -971,7 +971,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def get_team_by_slug(self, slug):
         """
-        :calls: `GET /orgs/:org/teams/:team_slug <https://developer.github.com/v3/teams>`_
+        :calls: `GET /orgs/{org}/teams/{team_slug} <https://docs.github.com/en/rest/reference/teams>`_
         :param slug: string
         :rtype: :class:`github.Team.Team`
         """
@@ -983,7 +983,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def get_teams(self):
         """
-        :calls: `GET /orgs/:org/teams <http://developer.github.com/v3/orgs/teams>`_
+        :calls: `GET /orgs/{org}/teams <http://docs.github.com/en/rest/reference/orgs#teams>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Team.Team`
         """
         return github.PaginatedList.PaginatedList(
@@ -992,7 +992,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def invitations(self):
         """
-        :calls: `GET /orgs/:org/invitations <https://developer.github.com/v3/orgs/members>`_
+        :calls: `GET /orgs/{org}/invitations <https://docs.github.com/en/rest/reference/orgs#members>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
         return github.PaginatedList.PaginatedList(
@@ -1011,7 +1011,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
         teams=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /orgs/:org/invitations <http://developer.github.com/v3/orgs/members>`_
+        :calls: `POST /orgs/{org}/invitations <http://docs.github.com/en/rest/reference/orgs#members>`_
         :param user: :class:`github.NamedUser.NamedUser`
         :param email: string
         :param role: string
@@ -1046,7 +1046,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def has_in_members(self, member):
         """
-        :calls: `GET /orgs/:org/members/:user <http://developer.github.com/v3/orgs/members>`_
+        :calls: `GET /orgs/{org}/members/{user} <http://docs.github.com/en/rest/reference/orgs#members>`_
         :param member: :class:`github.NamedUser.NamedUser`
         :rtype: bool
         """
@@ -1062,7 +1062,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def has_in_public_members(self, public_member):
         """
-        :calls: `GET /orgs/:org/public_members/:user <http://developer.github.com/v3/orgs/members>`_
+        :calls: `GET /orgs/{org}/public_members/{user} <http://docs.github.com/en/rest/reference/orgs#members>`_
         :param public_member: :class:`github.NamedUser.NamedUser`
         :rtype: bool
         """
@@ -1074,7 +1074,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def remove_from_membership(self, member):
         """
-        :calls: `DELETE /orgs/:org/memberships/:user <https://developer.github.com/v3/orgs/members/#remove-organization-membership>`_
+        :calls: `DELETE /orgs/{org}/memberships/{user} <https://docs.github.com/en/rest/reference/orgs/members#remove-organization-membership>`_
         :param member: :class:`github.NamedUser.NamedUser`
         :rtype: None
         """
@@ -1085,7 +1085,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def remove_from_members(self, member):
         """
-        :calls: `DELETE /orgs/:org/members/:user <http://developer.github.com/v3/orgs/members>`_
+        :calls: `DELETE /orgs/{org}/members/{user} <http://docs.github.com/en/rest/reference/orgs#members>`_
         :param member: :class:`github.NamedUser.NamedUser`
         :rtype: None
         """
@@ -1096,7 +1096,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def remove_from_public_members(self, public_member):
         """
-        :calls: `DELETE /orgs/:org/public_members/:user <http://developer.github.com/v3/orgs/members>`_
+        :calls: `DELETE /orgs/{org}/public_members/{user} <http://docs.github.com/en/rest/reference/orgs#members>`_
         :param public_member: :class:`github.NamedUser.NamedUser`
         :rtype: None
         """
@@ -1112,7 +1112,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
         exclude_attachments=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /orgs/:org/migrations <https://developer.github.com/v3/migrations/users>`_
+        :calls: `POST /orgs/{org}/migrations <https://docs.github.com/en/rest/reference/migrations#users>`_
         :param repos: list or tuple of str
         :param lock_repositories: bool
         :param exclude_attachments: bool
@@ -1143,7 +1143,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def get_migrations(self):
         """
-        :calls: `GET /orgs/:org/migrations <https://developer.github.com/v3/migrations/users>`_
+        :calls: `GET /orgs/{org}/migrations <https://docs.github.com/en/rest/reference/migrations#users>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Migration.Migration`
         """
         return github.PaginatedList.PaginatedList(
@@ -1156,7 +1156,7 @@ class Organization(github.GithubObject.CompletableGithubObject):
 
     def get_installations(self):
         """
-        :calls: `GET /orgs/:org/installations <https://developer.github.com/v3/orgs/#list-app-installations-for-an-organization>`_
+        :calls: `GET /orgs/{org}/installations <https://docs.github.com/en/rest/reference/orgs#list-app-installations-for-an-organization>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Installation.Installation`
         """
 

--- a/github/PaginatedList.py
+++ b/github/PaginatedList.py
@@ -90,7 +90,7 @@ class PaginatedListBase:
 
 class PaginatedList(PaginatedListBase):
     """
-    This class abstracts the `pagination of the API <http://developer.github.com/v3/#pagination>`_.
+    This class abstracts the `pagination of the API <http://docs.github.com/en/rest/reference/#pagination>`_.
 
     You can simply enumerate through instances of this class::
 

--- a/github/Path.py
+++ b/github/Path.py
@@ -30,7 +30,7 @@ import github.GithubObject
 class Path(github.GithubObject.NonCompletableGithubObject):
     """
     This class represents a popular Path for a GitHub repository.
-    The reference can be found here https://developer.github.com/v3/repos/traffic/
+    The reference can be found here https://docs.github.com/en/rest/reference/repos#traffic
     """
 
     def __repr__(self):

--- a/github/Project.py
+++ b/github/Project.py
@@ -28,7 +28,7 @@ from . import Consts
 
 class Project(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Projects. The reference can be found here http://developer.github.com/v3/projects
+    This class represents Projects. The reference can be found here http://docs.github.com/en/rest/reference/projects
     """
 
     def __repr__(self):
@@ -140,7 +140,7 @@ class Project(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /projects/:project_id <https://developer.github.com/v3/projects/#delete-a-project>`_
+        :calls: `DELETE /projects/{project_id} <https://docs.github.com/en/rest/reference/projects#delete-a-project>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -156,7 +156,7 @@ class Project(github.GithubObject.CompletableGithubObject):
         private=github.GithubObject.NotSet,
     ):
         """
-        :calls: `PATCH /projects/:project_id <https://developer.github.com/v3/projects/#update-a-project>`_
+        :calls: `PATCH /projects/{project_id} <https://docs.github.com/en/rest/reference/projects#update-a-project>`_
         :param name: string
         :param body: string
         :param state: string
@@ -194,7 +194,7 @@ class Project(github.GithubObject.CompletableGithubObject):
 
     def get_columns(self):
         """
-        :calls: `GET /projects/:project_id/columns <https://developer.github.com/v3/projects/columns/#list-project-columns>`_
+        :calls: `GET /projects/{project_id}/columns <https://docs.github.com/en/rest/reference/projects/columns#list-project-columns>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.ProjectColumn.ProjectColumn`
         """
 
@@ -208,7 +208,7 @@ class Project(github.GithubObject.CompletableGithubObject):
 
     def create_column(self, name):
         """
-        calls: `POST /projects/:project_id/columns <https://developer.github.com/v3/projects/columns/#create-a-project-column>`_
+        calls: `POST /projects/{project_id}/columns <https://docs.github.com/en/rest/reference/projects/columns#create-a-project-column>`_
         :param name: string
         """
         assert isinstance(name, str), name

--- a/github/ProjectCard.py
+++ b/github/ProjectCard.py
@@ -33,7 +33,7 @@ from . import Consts
 
 class ProjectCard(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Project Cards. The reference can be found here https://developer.github.com/v3/projects/cards
+    This class represents Project Cards. The reference can be found here https://docs.github.com/en/rest/reference/projects#cards
     """
 
     def __repr__(self):
@@ -114,7 +114,7 @@ class ProjectCard(github.GithubObject.CompletableGithubObject):
     # the API doesn't make it clear which you are dealing with.
     def get_content(self, content_type=github.GithubObject.NotSet):
         """
-        :calls: `GET /repos/:owner/:repo/pulls/:number <https://developer.github.com/v3/pulls/#get-a-single-pull-request>`_
+        :calls: `GET /repos/{owner}/{repo}/pulls/{number} <https://docs.github.com/en/rest/reference/pulls#get-a-single-pull-request>`_
         :param content_type: string, optional
         :rtype: :class:`github.PullRequest.PullRequest` or :class:`github.Issue.Issue`
         """
@@ -137,7 +137,7 @@ class ProjectCard(github.GithubObject.CompletableGithubObject):
 
     def move(self, position, column):
         """
-        :calls: `POST /projects/columns/cards/:card_id/moves <https://developer.github.com/v3/projects/cards>`_
+        :calls: `POST /projects/columns/cards/{card_id}/moves <https://docs.github.com/en/rest/reference/projects#cards>`_
         :param position: string
         :param column: :class:`github.ProjectColumn.ProjectColumn` or int
         :rtype: bool
@@ -162,7 +162,7 @@ class ProjectCard(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /projects/columns/cards/:card_id <https://developer.github.com/v3/projects/cards>`_
+        :calls: `DELETE /projects/columns/cards/{card_id} <https://docs.github.com/en/rest/reference/projects#cards>`_
         :rtype: bool
         """
         status, _, _ = self._requester.requestJson(
@@ -176,7 +176,7 @@ class ProjectCard(github.GithubObject.CompletableGithubObject):
         self, note=github.GithubObject.NotSet, archived=github.GithubObject.NotSet
     ):
         """
-        :calls: `PATCH /projects/columns/cards/:card_id <http://developer.github.com/v3/projects/cards>`_
+        :calls: `PATCH /projects/columns/cards/{card_id} <http://docs.github.com/en/rest/reference/projects#cards>`_
         :param note: string
         :param archived: bool
         :rtype: None

--- a/github/ProjectColumn.py
+++ b/github/ProjectColumn.py
@@ -29,7 +29,7 @@ from . import Consts
 
 class ProjectColumn(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Project Columns. The reference can be found here http://developer.github.com/v3/projects/columns
+    This class represents Project Columns. The reference can be found here http://docs.github.com/en/rest/reference/projects#columns
     """
 
     def __repr__(self):
@@ -93,7 +93,7 @@ class ProjectColumn(github.GithubObject.CompletableGithubObject):
 
     def get_cards(self, archived_state=github.GithubObject.NotSet):
         """
-        :calls: `GET /projects/columns/:column_id/cards <https://developer.github.com/v3/projects/cards/#list-project-cards>`_
+        :calls: `GET /projects/columns/{column_id}/cards <https://docs.github.com/en/rest/reference/projects/cards#list-project-cards>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.ProjectCard.ProjectCard`
         :param archived_state: string
         """
@@ -120,7 +120,7 @@ class ProjectColumn(github.GithubObject.CompletableGithubObject):
         content_type=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /projects/columns/:column_id/cards <https://developer.github.com/v3/projects/cards/#create-a-project-card>`_
+        :calls: `POST /projects/columns/{column_id}/cards <https://docs.github.com/en/rest/reference/projects/cards#create-a-project-card>`_
         :param note: string
         :param content_id: integer
         :param content_type: string
@@ -147,7 +147,7 @@ class ProjectColumn(github.GithubObject.CompletableGithubObject):
 
     def move(self, position):
         """
-        :calls: `POST POST /projects/columns/:column_id/moves <https://developer.github.com/v3/projects/columns/#move-a-project-column>`_
+        :calls: `POST POST /projects/columns/{column_id}/moves <https://docs.github.com/en/rest/reference/projects/columns#move-a-project-column>`_
         :param position: string
 
         :rtype: bool
@@ -164,7 +164,7 @@ class ProjectColumn(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /projects/columns/:column_id <https://developer.github.com/v3/projects/columns/#delete-a-project-column>`_
+        :calls: `DELETE /projects/columns/{column_id} <https://docs.github.com/en/rest/reference/projects/columns#delete-a-project-column>`_
         :rtype: bool
         """
         status, _, _ = self._requester.requestJson(
@@ -176,7 +176,7 @@ class ProjectColumn(github.GithubObject.CompletableGithubObject):
 
     def edit(self, name):
         """
-        :calls: `PATCH /projects/columns/:column_id <https://developer.github.com/v3/projects/columns/#update-a-project-column>`_
+        :calls: `PATCH /projects/columns/{column_id} <https://docs.github.com/en/rest/reference/projects/columns#update-a-project-column>`_
         :param name: string
         :rtype: None
         """

--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -59,7 +59,7 @@ from . import Consts
 
 class PullRequest(github.GithubObject.CompletableGithubObject):
     """
-    This class represents PullRequests. The reference can be found here http://developer.github.com/v3/pulls/
+    This class represents PullRequests. The reference can be found here http://docs.github.com/en/rest/reference/pulls
     """
 
     def __repr__(self):
@@ -381,7 +381,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def as_issue(self):
         """
-        :calls: `GET /repos/:owner/:repo/issues/:number <http://developer.github.com/v3/issues>`_
+        :calls: `GET /repos/{owner}/{repo}/issues/{number} <http://docs.github.com/en/rest/reference/issues>`_
         :rtype: :class:`github.Issue.Issue`
         """
         headers, data = self._requester.requestJsonAndCheck("GET", self.issue_url)
@@ -389,7 +389,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def create_comment(self, body, commit_id, path, position):
         """
-        :calls: `POST /repos/:owner/:repo/pulls/:number/comments <http://developer.github.com/v3/pulls/comments>`_
+        :calls: `POST /repos/{owner}/{repo}/pulls/{number}/comments <http://docs.github.com/en/rest/reference/pulls#review-comments>`_
         :param body: string
         :param commit_id: :class:`github.Commit.Commit`
         :param path: string
@@ -400,7 +400,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def create_review_comment(self, body, commit_id, path, position):
         """
-        :calls: `POST /repos/:owner/:repo/pulls/:number/comments <http://developer.github.com/v3/pulls/comments>`_
+        :calls: `POST /repos/{owner}/{repo}/pulls/{number}/comments <http://docs.github.com/en/rest/reference/pulls#review-comments>`_
         :param body: string
         :param commit_id: :class:`github.Commit.Commit`
         :param path: string
@@ -426,7 +426,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def create_review_comment_reply(self, comment_id, body):
         """
-        :calls: `POST /repos/:owner/:repo/pulls/:pull_number/comments/:comment_id/replies <http://developer.github.com/v3/pulls/comments>`_
+        :calls: `POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies <http://docs.github.com/en/rest/reference/pulls#review-comments>`_
         :param comment_id: int
         :param body: string
         :rtype: :class:`github.PullRequestComment.PullRequestComment`
@@ -445,7 +445,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def create_issue_comment(self, body):
         """
-        :calls: `POST /repos/:owner/:repo/issues/:number/comments <http://developer.github.com/v3/issues/comments>`_
+        :calls: `POST /repos/{owner}/{repo}/issues/{number}/comments <http://docs.github.com/en/rest/reference/issues#comments>`_
         :param body: string
         :rtype: :class:`github.IssueComment.IssueComment`
         """
@@ -468,7 +468,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
         comments=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /repos/:owner/:repo/pulls/:number/reviews <https://developer.github.com/v3/pulls/reviews/>`_
+        :calls: `POST /repos/{owner}/{repo}/pulls/{number}/reviews <https://docs.github.com/en/rest/reference/pulls#reviews>`_
         :param commit: github.Commit.Commit
         :param body: string
         :param event: string
@@ -508,7 +508,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
         team_reviewers=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /repos/:owner/:repo/pulls/:number/requested_reviewers <https://developer.github.com/v3/pulls/review_requests/>`_
+        :calls: `POST /repos/{owner}/{repo}/pulls/{number}/requested_reviewers <https://docs.github.com/en/rest/reference/pulls#review_requests>`_
         :param reviewers: list of strings
         :param team_reviewers: list of strings
         :rtype: None
@@ -532,7 +532,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
         team_reviewers=github.GithubObject.NotSet,
     ):
         """
-        :calls: `DELETE /repos/:owner/:repo/pulls/:number/requested_reviewers <https://developer.github.com/v3/pulls/review_requests/>`_
+        :calls: `DELETE /repos/{owner}/{repo}/pulls/{number}/requested_reviewers <https://docs.github.com/en/rest/reference/pulls#review_requests>`_
         :param reviewers: list of strings
         :param team_reviewers: list of strings
         :rtype: None
@@ -559,7 +559,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
         maintainer_can_modify=github.GithubObject.NotSet,
     ):
         """
-        :calls: `PATCH /repos/:owner/:repo/pulls/:number <http://developer.github.com/v3/pulls>`_
+        :calls: `PATCH /repos/{owner}/{repo}/pulls/{number} <http://docs.github.com/en/rest/reference/pulls>`_
         :param title: string
         :param body: string
         :param state: string
@@ -592,7 +592,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def get_comment(self, id):
         """
-        :calls: `GET /repos/:owner/:repo/pulls/comments/:number <http://developer.github.com/v3/pulls/comments>`_
+        :calls: `GET /repos/{owner}/{repo}/pulls/comments/{number} <http://docs.github.com/en/rest/reference/pulls#review-comments>`_
         :param id: integer
         :rtype: :class:`github.PullRequestComment.PullRequestComment`
         """
@@ -600,7 +600,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def get_review_comment(self, id):
         """
-        :calls: `GET /repos/:owner/:repo/pulls/comments/:number <http://developer.github.com/v3/pulls/comments>`_
+        :calls: `GET /repos/{owner}/{repo}/pulls/comments/{number} <http://docs.github.com/en/rest/reference/pulls#review-comments>`_
         :param id: integer
         :rtype: :class:`github.PullRequestComment.PullRequestComment`
         """
@@ -616,14 +616,14 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
         """
         Warning: this only returns review comments. For normal conversation comments, use get_issue_comments.
 
-        :calls: `GET /repos/:owner/:repo/pulls/:number/comments <http://developer.github.com/v3/pulls/comments>`_
+        :calls: `GET /repos/{owner}/{repo}/pulls/{number}/comments <http://docs.github.com/en/rest/reference/pulls#review-comments>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.PullRequestComment.PullRequestComment`
         """
         return self.get_review_comments()
 
     def get_review_comments(self, since=github.GithubObject.NotSet):
         """
-        :calls: `GET /repos/:owner/:repo/pulls/:number/comments <http://developer.github.com/v3/pulls/comments>`_
+        :calls: `GET /repos/{owner}/{repo}/pulls/{number}/comments <http://docs.github.com/en/rest/reference/pulls#review-comments>`_
         :param since: datetime.datetime format YYYY-MM-DDTHH:MM:SSZ
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.PullRequestComment.PullRequestComment`
         """
@@ -642,7 +642,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def get_single_review_comments(self, id):
         """
-        :calls: `GET /repos/:owner/:repo/pulls/:number/review/:id/comments <https://developer.github.com/v3/pulls/reviews/>`_
+        :calls: `GET /repos/{owner}/{repo}/pulls/{number}/review/{id}/comments <https://docs.github.com/en/rest/reference/pulls#reviews>`_
         :param id: integer
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.PullRequestComment.PullRequestComment`
         """
@@ -656,7 +656,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def get_commits(self):
         """
-        :calls: `GET /repos/:owner/:repo/pulls/:number/commits <http://developer.github.com/v3/pulls>`_
+        :calls: `GET /repos/{owner}/{repo}/pulls/{number}/commits <http://docs.github.com/en/rest/reference/pulls>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Commit.Commit`
         """
         return github.PaginatedList.PaginatedList(
@@ -665,7 +665,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def get_files(self):
         """
-        :calls: `GET /repos/:owner/:repo/pulls/:number/files <http://developer.github.com/v3/pulls>`_
+        :calls: `GET /repos/{owner}/{repo}/pulls/{number}/files <http://docs.github.com/en/rest/reference/pulls>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.File.File`
         """
         return github.PaginatedList.PaginatedList(
@@ -674,7 +674,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def get_issue_comment(self, id):
         """
-        :calls: `GET /repos/:owner/:repo/issues/comments/:id <http://developer.github.com/v3/issues/comments>`_
+        :calls: `GET /repos/{owner}/{repo}/issues/comments/{id} <http://docs.github.com/en/rest/reference/issues#comments>`_
         :param id: integer
         :rtype: :class:`github.IssueComment.IssueComment`
         """
@@ -688,7 +688,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def get_issue_comments(self):
         """
-        :calls: `GET /repos/:owner/:repo/issues/:number/comments <http://developer.github.com/v3/issues/comments>`_
+        :calls: `GET /repos/{owner}/{repo}/issues/{number}/comments <http://docs.github.com/en/rest/reference/issues#comments>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.IssueComment.IssueComment`
         """
         return github.PaginatedList.PaginatedList(
@@ -700,7 +700,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def get_issue_events(self):
         """
-        :calls: `GET /repos/:owner/:repo/issues/:issue_number/events <http://developer.github.com/v3/issues/events>`_
+        :calls: `GET /repos/{owner}/{repo}/issues/{issue_number}/events <http://docs.github.com/en/rest/reference/issues#events>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.IssueEvent.IssueEvent`
         """
         return github.PaginatedList.PaginatedList(
@@ -713,7 +713,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def get_review(self, id):
         """
-        :calls: `GET /repos/:owner/:repo/pulls/:number/reviews/:id <https://developer.github.com/v3/pulls/reviews>`_
+        :calls: `GET /repos/{owner}/{repo}/pulls/{number}/reviews/{id} <https://docs.github.com/en/rest/reference/pulls#reviews>`_
         :param id: integer
         :rtype: :class:`github.PullRequestReview.PullRequestReview`
         """
@@ -728,7 +728,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def get_reviews(self):
         """
-        :calls: `GET /repos/:owner/:repo/pulls/:number/reviews <https://developer.github.com/v3/pulls/reviews/>`_
+        :calls: `GET /repos/{owner}/{repo}/pulls/{number}/reviews <https://docs.github.com/en/rest/reference/pulls#reviews>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.PullRequestReview.PullRequestReview`
         """
         return github.PaginatedList.PaginatedList(
@@ -740,7 +740,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def get_review_requests(self):
         """
-        :calls: `GET /repos/:owner/:repo/pulls/:number/requested_reviewers <https://developer.github.com/v3/pulls/review_requests/>`_
+        :calls: `GET /repos/{owner}/{repo}/pulls/{number}/requested_reviewers <https://docs.github.com/en/rest/reference/pulls#review_requests>`_
         :rtype: tuple of :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser` and of :class:`github.PaginatedList.PaginatedList` of :class:`github.Team.Team`
         """
         return (
@@ -762,7 +762,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def get_labels(self):
         """
-        :calls: `GET /repos/:owner/:repo/issues/:number/labels <http://developer.github.com/v3/issues/labels>`_
+        :calls: `GET /repos/{owner}/{repo}/issues/{number}/labels <http://docs.github.com/en/rest/reference/issues#labels>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Label.Label`
         """
         return github.PaginatedList.PaginatedList(
@@ -771,7 +771,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def add_to_labels(self, *labels):
         """
-        :calls: `POST /repos/:owner/:repo/issues/:number/labels <http://developer.github.com/v3/issues/labels>`_
+        :calls: `POST /repos/{owner}/{repo}/issues/{number}/labels <http://docs.github.com/en/rest/reference/issues#labels>`_
         :param label: :class:`github.Label.Label` or string
         :rtype: None
         """
@@ -788,7 +788,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def delete_labels(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/issues/:number/labels <http://developer.github.com/v3/issues/labels>`_
+        :calls: `DELETE /repos/{owner}/{repo}/issues/{number}/labels <http://docs.github.com/en/rest/reference/issues#labels>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -797,7 +797,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def remove_from_labels(self, label):
         """
-        :calls: `DELETE /repos/:owner/:repo/issues/:number/labels/:name <http://developer.github.com/v3/issues/labels>`_
+        :calls: `DELETE /repos/{owner}/{repo}/issues/{number}/labels/{name} <http://docs.github.com/en/rest/reference/issues#labels>`_
         :param label: :class:`github.Label.Label` or string
         :rtype: None
         """
@@ -812,7 +812,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def set_labels(self, *labels):
         """
-        :calls: `PUT /repos/:owner/:repo/issues/:number/labels <http://developer.github.com/v3/issues/labels>`_
+        :calls: `PUT /repos/{owner}/{repo}/issues/{number}/labels <http://docs.github.com/en/rest/reference/issues#labels>`_
         :param labels: list of :class:`github.Label.Label` or strings
         :rtype: None
         """
@@ -829,7 +829,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def is_merged(self):
         """
-        :calls: `GET /repos/:owner/:repo/pulls/:number/merge <http://developer.github.com/v3/pulls>`_
+        :calls: `GET /repos/{owner}/{repo}/pulls/{number}/merge <http://docs.github.com/en/rest/reference/pulls>`_
         :rtype: bool
         """
         status, headers, data = self._requester.requestJson("GET", f"{self.url}/merge")
@@ -843,7 +843,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
         sha=github.GithubObject.NotSet,
     ):
         """
-        :calls: `PUT /repos/:owner/:repo/pulls/:number/merge <http://developer.github.com/v3/pulls>`_
+        :calls: `PUT /repos/{owner}/{repo}/pulls/{number}/merge <http://docs.github.com/en/rest/reference/pulls>`_
         :param commit_message: string
         :param commit_title: string
         :param merge_method: string
@@ -878,7 +878,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def add_to_assignees(self, *assignees):
         """
-        :calls: `POST /repos/:owner/:repo/issues/:number/assignees <https://developer.github.com/v3/issues/assignees>`_
+        :calls: `POST /repos/{owner}/{repo}/issues/{number}/assignees <https://docs.github.com/en/rest/reference/issues#assignees>`_
         :param assignees: list of :class:`github.NamedUser.NamedUser` or string
         :rtype: None
         """
@@ -902,7 +902,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def remove_from_assignees(self, *assignees):
         """
-        :calls: `DELETE /repos/:owner/:repo/issues/:number/assignees <https://developer.github.com/v3/issues/assignees>`_
+        :calls: `DELETE /repos/{owner}/{repo}/issues/{number}/assignees <https://docs.github.com/en/rest/reference/issues#assignees>`_
         :param assignees: list of :class:`github.NamedUser.NamedUser` or string
         :rtype: None
         """
@@ -926,7 +926,7 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
 
     def update_branch(self, expected_head_sha=github.GithubObject.NotSet):
         """
-        :calls `PUT /repos/:owner/:repo/pulls/:pull_number/update-branch <https://developer.github.com/v3/pulls>`_
+        :calls `PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch <https://docs.github.com/en/rest/reference/pulls>`_
         :param expected_head_sha: string
         :rtype: bool
         """

--- a/github/PullRequestComment.py
+++ b/github/PullRequestComment.py
@@ -41,7 +41,7 @@ from . import Consts
 
 class PullRequestComment(github.GithubObject.CompletableGithubObject):
     """
-    This class represents PullRequestComments. The reference can be found here http://developer.github.com/v3/pulls/comments/
+    This class represents PullRequestComments. The reference can be found here http://docs.github.com/en/rest/reference/pulls#comments
     """
 
     def __repr__(self):
@@ -169,14 +169,14 @@ class PullRequestComment(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/pulls/comments/:number <http://developer.github.com/v3/pulls/comments>`_
+        :calls: `DELETE /repos/{owner}/{repo}/pulls/comments/{number} <http://docs.github.com/en/rest/reference/pulls#comments>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("DELETE", self.url)
 
     def edit(self, body):
         """
-        :calls: `PATCH /repos/:owner/:repo/pulls/comments/:number <http://developer.github.com/v3/pulls/comments>`_
+        :calls: `PATCH /repos/{owner}/{repo}/pulls/comments/{number} <http://docs.github.com/en/rest/reference/pulls#comments>`_
         :param body: string
         :rtype: None
         """
@@ -191,8 +191,8 @@ class PullRequestComment(github.GithubObject.CompletableGithubObject):
 
     def get_reactions(self):
         """
-        :calls: `GET /repos/:owner/:repo/pulls/comments/:number/reactions
-                <https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment>`_
+        :calls: `GET /repos/{owner}/{repo}/pulls/comments/{number}/reactions
+                <https://docs.github.com/en/rest/reference/reactions#list-reactions-for-a-pull-request-review-comment>`_
         :return: :class: :class:`github.PaginatedList.PaginatedList` of :class:`github.Reaction.Reaction`
         """
         return github.PaginatedList.PaginatedList(
@@ -205,8 +205,8 @@ class PullRequestComment(github.GithubObject.CompletableGithubObject):
 
     def create_reaction(self, reaction_type):
         """
-        :calls: `POST /repos/:owner/:repo/pulls/comments/:number/reactions
-                <https://developer.github.com/v3/reactions/#create-reaction-for-a-pull-request-review-comment>`_
+        :calls: `POST /repos/{owner}/{repo}/pulls/comments/{number}/reactions
+                <https://docs.github.com/en/rest/reference/reactions#create-reaction-for-a-pull-request-review-comment>`_
         :param reaction_type: string
         :rtype: :class:`github.Reaction.Reaction`
         """
@@ -224,8 +224,8 @@ class PullRequestComment(github.GithubObject.CompletableGithubObject):
 
     def delete_reaction(self, reaction_id):
         """
-        :calls: `DELETE /repos/:owner/:repo/pulls/comments/:comment_id/reactions/:reaction_id
-                <https://developer.github.com/v3/reactions/#delete-a-pull-request-comment-reaction>`_
+        :calls: `DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}
+                <https://docs.github.com/en/rest/reference/reactions#delete-a-pull-request-comment-reaction>`_
         :param reaction_id: integer
         :rtype: bool
         """

--- a/github/PullRequestMergeStatus.py
+++ b/github/PullRequestMergeStatus.py
@@ -34,7 +34,7 @@ import github.GithubObject
 
 class PullRequestMergeStatus(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents PullRequestMergeStatuses. The reference can be found here http://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged
+    This class represents PullRequestMergeStatuses. The reference can be found here http://docs.github.com/en/rest/reference/pulls#get-if-a-pull-request-has-been-merged
     """
 
     def __repr__(self):

--- a/github/PullRequestReview.py
+++ b/github/PullRequestReview.py
@@ -30,7 +30,7 @@ import github.NamedUser
 
 class PullRequestReview(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents PullRequestReviews. The reference can be found here https://developer.github.com/v3/pulls/reviews/
+    This class represents PullRequestReviews. The reference can be found here https://docs.github.com/en/rest/reference/pulls#reviews
     """
 
     def __repr__(self):
@@ -94,7 +94,7 @@ class PullRequestReview(github.GithubObject.NonCompletableGithubObject):
 
     def dismiss(self, message):
         """
-        :calls: `PUT /repos/:owner/:repo/pulls/:number/reviews/:review_id/dismissals <https://developer.github.com/v3/pulls/reviews/>`_
+        :calls: `PUT /repos/{owner}/{repo}/pulls/{number}/reviews/{review_id}/dismissals <https://docs.github.com/en/rest/reference/pulls#reviews>`_
         :rtype: None
         """
         assert isinstance(message, str), message

--- a/github/Rate.py
+++ b/github/Rate.py
@@ -30,7 +30,7 @@ import github.GithubObject
 
 class Rate(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents Rates. The reference can be found here http://developer.github.com/v3/rate_limit
+    This class represents Rates. The reference can be found here http://docs.github.com/en/rest/reference/rate_limit
     """
 
     def __repr__(self):

--- a/github/RateLimit.py
+++ b/github/RateLimit.py
@@ -31,7 +31,7 @@ import github.Rate
 
 class RateLimit(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents RateLimits. The reference can be found here http://developer.github.com/v3/rate_limit
+    This class represents RateLimits. The reference can be found here http://docs.github.com/en/rest/reference/rate_limit
     """
 
     def __repr__(self):

--- a/github/Reaction.py
+++ b/github/Reaction.py
@@ -30,7 +30,7 @@ from . import Consts
 
 class Reaction(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Reactions. The reference can be found here https://developer.github.com/v3/reactions/
+    This class represents Reactions. The reference can be found here https://docs.github.com/en/rest/reference/reactions
     """
 
     def __repr__(self):
@@ -70,7 +70,7 @@ class Reaction(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /reactions/:id <https://developer.github.com/v3/reactions/#delete-a-reaction>`_
+        :calls: `DELETE /reactions/{id} <https://docs.github.com/en/rest/reference/reactions#delete-a-reaction>`_
         :rtype: None
         """
         self._requester.requestJsonAndCheck(

--- a/github/Referrer.py
+++ b/github/Referrer.py
@@ -30,7 +30,7 @@ import github.GithubObject
 class Referrer(github.GithubObject.NonCompletableGithubObject):
     """
     This class represents a popylar Referrer for a GitHub repository.
-    The reference can be found here https://developer.github.com/v3/repos/traffic/
+    The reference can be found here https://docs.github.com/en/rest/reference/repos#traffic
     """
 
     def __repr__(self):

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -147,7 +147,7 @@ from . import Consts
 
 class Repository(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Repositories. The reference can be found here http://developer.github.com/v3/repos/
+    This class represents Repositories. The reference can be found here http://docs.github.com/en/rest/reference/repos
     """
 
     def __repr__(self):
@@ -805,7 +805,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def add_to_collaborators(self, collaborator, permission=github.GithubObject.NotSet):
         """
-        :calls: `PUT /repos/:owner/:repo/collaborators/:user <http://developer.github.com/v3/repos/collaborators>`_
+        :calls: `PUT /repos/{owner}/{repo}/collaborators/{user} <http://docs.github.com/en/rest/reference/repos#collaborators>`_
         :param collaborator: string or :class:`github.NamedUser.NamedUser`
         :param permission: string 'pull', 'push' or 'admin'
         :rtype: None
@@ -838,7 +838,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_collaborator_permission(self, collaborator):
         """
-        :calls: `GET /repos/:owner/:repo/collaborators/:username/permission <http://developer.github.com/v3/repos/collaborators>`_
+        :calls: `GET /repos/{owner}/{repo}/collaborators/{username}/permission <http://docs.github.com/en/rest/reference/repos#collaborators>`_
         :param collaborator: string or :class:`github.NamedUser.NamedUser`
         :rtype: string
         """
@@ -855,7 +855,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_pending_invitations(self):
         """
-        :calls: `GET /repos/:owner/:repo/invitations <https://developer.github.com/v3/repos/invitations>`_
+        :calls: `GET /repos/{owner}/{repo}/invitations <https://docs.github.com/en/rest/reference/repos#invitations>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Invitation.Invitation`
         """
         return github.PaginatedList.PaginatedList(
@@ -867,7 +867,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def remove_invitation(self, invite_id):
         """
-        :calls: `DELETE /repos/:owner/:repo/invitations/:invitation_id <https://developer.github.com/v3/repos/invitations>`_
+        :calls: `DELETE /repos/{owner}/{repo}/invitations/{invitation_id} <https://docs.github.com/en/rest/reference/repos#invitations>`_
         :rtype: None
         """
         assert isinstance(invite_id, int), invite_id
@@ -878,7 +878,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def compare(self, base, head):
         """
-        :calls: `GET /repos/:owner/:repo/compare/:base...:head <http://developer.github.com/v3/repos/commits>`_
+        :calls: `GET /repos/{owner}/{repo}/compare/{base...:head} <http://docs.github.com/en/rest/reference/repos#commits>`_
         :param base: string
         :param head: string
         :rtype: :class:`github.Comparison.Comparison`
@@ -894,7 +894,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def create_git_blob(self, content, encoding):
         """
-        :calls: `POST /repos/:owner/:repo/git/blobs <http://developer.github.com/v3/git/blobs>`_
+        :calls: `POST /repos/{owner}/{repo}/git/blobs <http://docs.github.com/en/rest/reference/git#blobs>`_
         :param content: string
         :param encoding: string
         :rtype: :class:`github.GitBlob.GitBlob`
@@ -919,7 +919,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         committer=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /repos/:owner/:repo/git/commits <http://developer.github.com/v3/git/commits>`_
+        :calls: `POST /repos/{owner}/{repo}/git/commits <http://docs.github.com/en/rest/reference/git#commits>`_
         :param message: string
         :param tree: :class:`github.GitTree.GitTree`
         :param parents: list of :class:`github.GitCommit.GitCommit`
@@ -956,7 +956,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def create_git_ref(self, ref, sha):
         """
-        :calls: `POST /repos/:owner/:repo/git/refs <http://developer.github.com/v3/git/refs>`_
+        :calls: `POST /repos/{owner}/{repo}/git/refs <http://docs.github.com/en/rest/reference/git#refs>`_
         :param ref: string
         :param sha: string
         :rtype: :class:`github.GitRef.GitRef`
@@ -1019,7 +1019,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         target_commitish=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /repos/:owner/:repo/releases <http://developer.github.com/v3/repos/releases>`_
+        :calls: `POST /repos/{owner}/{repo}/releases <http://docs.github.com/en/rest/reference/repos#releases>`_
         :param tag: string
         :param name: string
         :param message: string
@@ -1068,7 +1068,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         self, tag, message, object, type, tagger=github.GithubObject.NotSet
     ):
         """
-        :calls: `POST /repos/:owner/:repo/git/tags <http://developer.github.com/v3/git/tags>`_
+        :calls: `POST /repos/{owner}/{repo}/git/tags <http://docs.github.com/en/rest/reference/git#tags>`_
         :param tag: string
         :param message: string
         :param object: string
@@ -1098,7 +1098,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def create_git_tree(self, tree, base_tree=github.GithubObject.NotSet):
         """
-        :calls: `POST /repos/:owner/:repo/git/trees <http://developer.github.com/v3/git/trees>`_
+        :calls: `POST /repos/{owner}/{repo}/git/trees <http://docs.github.com/en/rest/reference/git#trees>`_
         :param tree: list of :class:`github.InputGitTreeElement.InputGitTreeElement`
         :param base_tree: :class:`github.GitTree.GitTree`
         :rtype: :class:`github.GitTree.GitTree`
@@ -1127,7 +1127,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         active=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /repos/:owner/:repo/hooks <http://developer.github.com/v3/repos/hooks>`_
+        :calls: `POST /repos/{owner}/{repo}/hooks <http://docs.github.com/en/rest/reference/repos#webhooks>`_
         :param name: string
         :param config: dict
         :param events: list of string
@@ -1163,7 +1163,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         assignees=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /repos/:owner/:repo/issues <http://developer.github.com/v3/issues>`_
+        :calls: `POST /repos/{owner}/{repo}/issues <http://docs.github.com/en/rest/reference/issues>`_
         :param title: string
         :param body: string
         :param assignee: string or :class:`github.NamedUser.NamedUser`
@@ -1222,7 +1222,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def create_key(self, title, key, read_only=False):
         """
-        :calls: `POST /repos/:owner/:repo/keys <http://developer.github.com/v3/repos/#deploy-keys>`_
+        :calls: `POST /repos/{owner}/{repo}/keys <http://docs.github.com/en/rest/reference/repos#deploy-keys>`_
         :param title: string
         :param key: string
         :param read_only: bool
@@ -1245,7 +1245,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def create_label(self, name, color, description=github.GithubObject.NotSet):
         """
-        :calls: `POST /repos/:owner/:repo/labels <http://developer.github.com/v3/issues/labels>`_
+        :calls: `POST /repos/{owner}/{repo}/labels <http://docs.github.com/en/rest/reference/issues#labels>`_
         :param name: string
         :param color: string
         :param description: string
@@ -1278,7 +1278,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         due_on=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /repos/:owner/:repo/milestones <http://developer.github.com/v3/issues/milestones>`_
+        :calls: `POST /repos/{owner}/{repo}/milestones <http://docs.github.com/en/rest/reference/issues#milestones>`_
         :param title: string
         :param state: string
         :param description: string
@@ -1314,7 +1314,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def create_project(self, name, body=github.GithubObject.NotSet):
         """
-        :calls: `POST /repos/:owner/:repo/projects <https://developer.github.com/v3/projects/#create-a-repository-project>`_
+        :calls: `POST /repos/{owner}/{repo}/projects <https://docs.github.com/en/rest/reference/projects#create-a-repository-project>`_
         :param name: string
         :param body: string
         :rtype: :class:`github.Project.Project`
@@ -1334,7 +1334,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def create_pull(self, *args, **kwds):
         """
-        :calls: `POST /repos/:owner/:repo/pulls <http://developer.github.com/v3/pulls>`_
+        :calls: `POST /repos/{owner}/{repo}/pulls <http://docs.github.com/en/rest/reference/pulls>`_
         :param title: string
         :param body: string
         :param issue: :class:`github.Issue.Issue`
@@ -1400,7 +1400,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         self, event_type, client_payload=github.GithubObject.NotSet
     ):
         """
-        :calls: POST /repos/:owner/:repo/dispatches <https://developer.github.com/v3/repos/#create-a-repository-dispatch-event>
+        :calls: POST /repos/{owner}/{repo}/dispatches <https://docs.github.com/en/rest/reference/repos#create-a-repository-dispatch-event>
         :param event_type: string
         :param client_payload: dict
         :rtype: bool
@@ -1419,7 +1419,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def create_secret(self, secret_name, unencrypted_value):
         """
-        :calls: `PUT /repos/:owner/:repo/actions/secrets/:secret_name <https://docs.github.com/en/rest/reference/actions#get-a-repository-secret>`_
+        :calls: `PUT /repos/{owner}/{repo}/actions/secrets/{secret_name} <https://docs.github.com/en/rest/reference/actions#get-a-repository-secret>`_
         :param secret_name: string
         :param unencrypted_value: string
         :rtype: bool
@@ -1439,7 +1439,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def delete_secret(self, secret_name):
         """
-        :calls: `DELETE /repos/:owner/:repo/actions/secrets/:secret_name <https://docs.github.com/en/rest/reference/actions#delete-a-repository-secret>`_
+        :calls: `DELETE /repos/{owner}/{repo}/actions/secrets/{secret_name} <https://docs.github.com/en/rest/reference/actions#delete-a-repository-secret>`_
         :param secret_name: string
         :rtype: bool
         """
@@ -1457,7 +1457,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         vcs_password=github.GithubObject.NotSet,
     ):
         """
-        :calls: `PUT /repos/:owner/:repo/import <https://developer.github.com/v3/migration/source_imports/#start-an-import>`_
+        :calls: `PUT /repos/{owner}/{repo}/import <https://docs.github.com/en/rest/reference/migration/source_imports#start-an-import>`_
         :param vcs: string
         :param vcs_url: string
         :param vcs_username: string
@@ -1492,7 +1492,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /repos/:owner/:repo <http://developer.github.com/v3/repos>`_
+        :calls: `DELETE /repos/{owner}/{repo} <http://docs.github.com/en/rest/reference/repos>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("DELETE", self.url)
@@ -1515,7 +1515,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         archived=github.GithubObject.NotSet,
     ):
         """
-        :calls: `PATCH /repos/:owner/:repo <http://developer.github.com/v3/repos>`_
+        :calls: `PATCH /repos/{owner}/{repo} <http://docs.github.com/en/rest/reference/repos>`_
         :param name: string
         :param description: string
         :param homepage: string
@@ -1529,7 +1529,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         :param allow_merge_commit: bool
         :param allow_rebase_merge: bool
         :param delete_branch_on_merge: bool
-        :param archived: bool. Unarchiving repositories is currently not supported through API (https://developer.github.com/v3/repos/#edit)
+        :param archived: bool. Unarchiving repositories is currently not supported through API (https://docs.github.com/en/rest/reference/repos#edit)
         :rtype: None
         """
         if name is None:
@@ -1610,7 +1610,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_archive_link(self, archive_format, ref=github.GithubObject.NotSet):
         """
-        :calls: `GET /repos/:owner/:repo/:archive_format/:ref <http://developer.github.com/v3/repos/contents>`_
+        :calls: `GET /repos/{owner}/{repo}/{archive_format}/{ref} <http://docs.github.com/en/rest/reference/repos#contents>`_
         :param archive_format: string
         :param ref: string
         :rtype: string
@@ -1625,7 +1625,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_assignees(self):
         """
-        :calls: `GET /repos/:owner/:repo/assignees <http://developer.github.com/v3/issues/assignees>`_
+        :calls: `GET /repos/{owner}/{repo}/assignees <http://docs.github.com/en/rest/reference/issues#assignees>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
         return github.PaginatedList.PaginatedList(
@@ -1634,7 +1634,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_branch(self, branch):
         """
-        :calls: `GET /repos/:owner/:repo/branches/:branch <https://developer.github.com/v3/repos/branches/#get-branch>`_
+        :calls: `GET /repos/{owner}/{repo}/branches/{branch} <https://docs.github.com/en/rest/reference/repos/branches#get-branch>`_
         :param branch: string
         :rtype: :class:`github.Branch.Branch`
         """
@@ -1646,7 +1646,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_branches(self):
         """
-        :calls: `GET /repos/:owner/:repo/branches <http://developer.github.com/v3/repos>`_
+        :calls: `GET /repos/{owner}/{repo}/branches <http://docs.github.com/en/rest/reference/repos>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Branch.Branch`
         """
         return github.PaginatedList.PaginatedList(
@@ -1655,7 +1655,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_collaborators(self, affiliation=github.GithubObject.NotSet):
         """
-        :calls: `GET /repos/:owner/:repo/collaborators <http://developer.github.com/v3/repos/collaborators>`_
+        :calls: `GET /repos/{owner}/{repo}/collaborators <http://docs.github.com/en/rest/reference/repos#collaborators>`_
         :param affiliation: string
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
@@ -1678,7 +1678,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_comment(self, id):
         """
-        :calls: `GET /repos/:owner/:repo/comments/:id <http://developer.github.com/v3/repos/comments>`_
+        :calls: `GET /repos/{owner}/{repo}/comments/{id} <http://docs.github.com/en/rest/reference/repos#comments>`_
         :param id: integer
         :rtype: :class:`github.CommitComment.CommitComment`
         """
@@ -1692,7 +1692,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_comments(self):
         """
-        :calls: `GET /repos/:owner/:repo/comments <http://developer.github.com/v3/repos/comments>`_
+        :calls: `GET /repos/{owner}/{repo}/comments <http://docs.github.com/en/rest/reference/repos#comments>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.CommitComment.CommitComment`
         """
         return github.PaginatedList.PaginatedList(
@@ -1704,7 +1704,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_commit(self, sha):
         """
-        :calls: `GET /repos/:owner/:repo/commits/:sha <http://developer.github.com/v3/repos/commits>`_
+        :calls: `GET /repos/{owner}/{repo}/commits/{sha} <http://docs.github.com/en/rest/reference/repos#commits>`_
         :param sha: string
         :rtype: :class:`github.Commit.Commit`
         """
@@ -1723,7 +1723,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         author=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /repos/:owner/:repo/commits <http://developer.github.com/v3/repos/commits>`_
+        :calls: `GET /repos/{owner}/{repo}/commits <http://docs.github.com/en/rest/reference/repos#commits>`_
         :param sha: string
         :param path: string
         :param since: datetime.datetime
@@ -1773,7 +1773,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_contents(self, path, ref=github.GithubObject.NotSet):
         """
-        :calls: `GET /repos/:owner/:repo/contents/:path <http://developer.github.com/v3/repos/contents>`_
+        :calls: `GET /repos/{owner}/{repo}/contents/{path} <http://docs.github.com/en/rest/reference/repos#contents>`_
         :param path: string
         :param ref: string
         :rtype: :class:`github.ContentFile.ContentFile` or a list of them
@@ -1819,7 +1819,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         environment=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /repos/:owner/:repo/deployments <https://developer.github.com/v3/repos/deployments/>`_
+        :calls: `GET /repos/{owner}/{repo}/deployments <https://docs.github.com/en/rest/reference/repos#deployments>`_
         :param: sha: string
         :param: ref: string
         :param: task: string
@@ -1851,7 +1851,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_deployment(self, id_):
         """
-        :calls: `GET /repos/:owner/:repo/deployments/:deployment_id <https://developer.github.com/v3/repos/deployments/>`_
+        :calls: `GET /repos/{owner}/{repo}/deployments/{deployment_id} <https://docs.github.com/en/rest/reference/repos#deployments>`_
         :param: id_: int
         :rtype: :class:`github.Deployment.Deployment`
         """
@@ -1878,7 +1878,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         production_environment=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /repos/:owner/:repo/deployments <https://developer.github.com/v3/repos/deployments/>`_
+        :calls: `POST /repos/{owner}/{repo}/deployments <https://docs.github.com/en/rest/reference/repos#deployments>`_
         :param: ref: string
         :param: task: string
         :param: auto_merge: bool
@@ -1945,7 +1945,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_top_referrers(self):
         """
-        :calls: `GET /repos/:owner/:repo/traffic/popular/referrers <https://developer.github.com/v3/repos/traffic/>`_
+        :calls: `GET /repos/{owner}/{repo}/traffic/popular/referrers <https://docs.github.com/en/rest/reference/repos#traffic>`_
         :rtype: :class:`list` of :class:`github.Referrer.Referrer`
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -1959,7 +1959,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_top_paths(self):
         """
-        :calls: `GET /repos/:owner/:repo/traffic/popular/paths <https://developer.github.com/v3/repos/traffic/>`_
+        :calls: `GET /repos/{owner}/{repo}/traffic/popular/paths <https://docs.github.com/en/rest/reference/repos#traffic>`_
         :rtype: :class:`list` of :class:`github.Path.Path`
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -1973,7 +1973,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_views_traffic(self, per=github.GithubObject.NotSet):
         """
-        :calls: `GET /repos/:owner/:repo/traffic/views <https://developer.github.com/v3/repos/traffic/>`_
+        :calls: `GET /repos/{owner}/{repo}/traffic/views <https://docs.github.com/en/rest/reference/repos#traffic>`_
         :param per: string, must be one of day or week, day by default
         :rtype: None or list of :class:`github.View.View`
         """
@@ -1999,7 +1999,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_clones_traffic(self, per=github.GithubObject.NotSet):
         """
-        :calls: `GET /repos/:owner/:repo/traffic/clones <https://developer.github.com/v3/repos/traffic/>`_
+        :calls: `GET /repos/{owner}/{repo}/traffic/clones <https://docs.github.com/en/rest/reference/repos#traffic>`_
         :param per: string, must be one of day or week, day by default
         :rtype: None or list of :class:`github.Clones.Clones`
         """
@@ -2025,7 +2025,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_projects(self, state=github.GithubObject.NotSet):
         """
-        :calls: `GET /repos/:owner/:repo/projects <https://developer.github.com/v3/projects/#list-repository-projects>`_
+        :calls: `GET /repos/{owner}/{repo}/projects <https://docs.github.com/en/rest/reference/projects#list-repository-projects>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Project.Project`
         :param state: string
         """
@@ -2053,7 +2053,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
     ):
         """Create a file in this repository.
 
-        :calls: `PUT /repos/:owner/:repo/contents/:path <http://developer.github.com/v3/repos/contents#create-a-file>`_
+        :calls: `PUT /repos/{owner}/{repo}/contents/{path} <https://docs.github.com/en/rest/reference/repos#create-or-update-file-contents>`_
         :param path: string, (required), path of the file in the repository
         :param message: string, (required), commit message
         :param content: string, (required), the actual data in the file
@@ -2114,7 +2114,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
     ):
         """This method updates a file in a repository
 
-        :calls: `PUT /repos/:owner/:repo/contents/:path <http://developer.github.com/v3/repos/contents#update-a-file>`_
+        :calls: `PUT /repos/{owner}/{repo}/contents/{path} <https://docs.github.com/en/rest/reference/repos#create-or-update-file-contents>`_
         :param path: string, Required. The content path.
         :param message: string, Required. The commit message.
         :param content: string, Required. The updated file content, either base64 encoded, or ready to be encoded.
@@ -2177,7 +2177,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
     ):
         """This method deletes a file in a repository
 
-        :calls: `DELETE /repos/:owner/:repo/contents/:path <https://developer.github.com/v3/repos/contents/#delete-a-file>`_
+        :calls: `DELETE /repos/{owner}/{repo}/contents/{path} <https://docs.github.com/en/rest/reference/repos/contents#delete-a-file>`_
         :param path: string, Required. The content path.
         :param message: string, Required. The commit message.
         :param sha: string, Required. The blob SHA of the file being replaced.
@@ -2230,7 +2230,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
     )
     def get_dir_contents(self, path, ref=github.GithubObject.NotSet):
         """
-        :calls: `GET /repos/:owner/:repo/contents/:path <http://developer.github.com/v3/repos/contents>`_
+        :calls: `GET /repos/{owner}/{repo}/contents/{path} <http://docs.github.com/en/rest/reference/repos#contents>`_
         :param path: string
         :param ref: string
         :rtype: list of :class:`github.ContentFile.ContentFile`
@@ -2239,7 +2239,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_contributors(self, anon=github.GithubObject.NotSet):
         """
-        :calls: `GET /repos/:owner/:repo/contributors <http://developer.github.com/v3/repos>`_
+        :calls: `GET /repos/{owner}/{repo}/contributors <http://docs.github.com/en/rest/reference/repos>`_
         :param anon: string
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
@@ -2256,7 +2256,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_download(self, id):
         """
-        :calls: `GET /repos/:owner/:repo/downloads/:id <http://developer.github.com/v3/repos/downloads>`_
+        :calls: `GET /repos/{owner}/{repo}/downloads/{id} <http://docs.github.com/en/rest/reference/repos>`_
         :param id: integer
         :rtype: :class:`github.Download.Download`
         """
@@ -2268,7 +2268,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_downloads(self):
         """
-        :calls: `GET /repos/:owner/:repo/downloads <http://developer.github.com/v3/repos/downloads>`_
+        :calls: `GET /repos/{owner}/{repo}/downloads <http://docs.github.com/en/rest/reference/repos>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Download.Download`
         """
         return github.PaginatedList.PaginatedList(
@@ -2277,7 +2277,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_events(self):
         """
-        :calls: `GET /repos/:owner/:repo/events <http://developer.github.com/v3/activity/events>`_
+        :calls: `GET /repos/{owner}/{repo}/events <http://docs.github.com/en/rest/reference/activity#events>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
         """
         return github.PaginatedList.PaginatedList(
@@ -2286,7 +2286,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_forks(self):
         """
-        :calls: `GET /repos/:owner/:repo/forks <http://developer.github.com/v3/repos/forks>`_
+        :calls: `GET /repos/{owner}/{repo}/forks <http://docs.github.com/en/rest/reference/repos#forks>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
         """
         return github.PaginatedList.PaginatedList(
@@ -2295,7 +2295,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def create_fork(self, organization=github.GithubObject.NotSet):
         """
-        :calls: `POST /repos/:owner/:repo/forks <http://developer.github.com/v3/repos/forks>`_
+        :calls: `POST /repos/{owner}/{repo}/forks <http://docs.github.com/en/rest/reference/repos#forks>`_
         :param organization: string or "none" or "*"
         :rtype: :class:`github.Repository.Repository`
         """
@@ -2314,7 +2314,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_git_blob(self, sha):
         """
-        :calls: `GET /repos/:owner/:repo/git/blobs/:sha <http://developer.github.com/v3/git/blobs>`_
+        :calls: `GET /repos/{owner}/{repo}/git/blobs/{sha} <http://docs.github.com/en/rest/reference/git#blobs>`_
         :param sha: string
         :rtype: :class:`github.GitBlob.GitBlob`
         """
@@ -2326,7 +2326,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_git_commit(self, sha):
         """
-        :calls: `GET /repos/:owner/:repo/git/commits/:sha <http://developer.github.com/v3/git/commits>`_
+        :calls: `GET /repos/{owner}/{repo}/git/commits/{sha} <http://docs.github.com/en/rest/reference/git#commits>`_
         :param sha: string
         :rtype: :class:`github.GitCommit.GitCommit`
         """
@@ -2340,7 +2340,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_git_ref(self, ref):
         """
-        :calls: `GET /repos/:owner/:repo/git/refs/:ref <http://developer.github.com/v3/git/refs>`_
+        :calls: `GET /repos/{owner}/{repo}/git/refs/{ref} <http://docs.github.com/en/rest/reference/git#refs>`_
         :param ref: string
         :rtype: :class:`github.GitRef.GitRef`
         """
@@ -2355,7 +2355,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_git_refs(self):
         """
-        :calls: `GET /repos/:owner/:repo/git/refs <http://developer.github.com/v3/git/refs>`_
+        :calls: `GET /repos/{owner}/{repo}/git/refs <http://docs.github.com/en/rest/reference/git#refs>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.GitRef.GitRef`
         """
         return github.PaginatedList.PaginatedList(
@@ -2364,7 +2364,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_git_matching_refs(self, ref):
         """
-        :calls: `GET /repos/:owner/:repo/git/matching-refs/:ref <https://developer.github.com/v3/git/refs/#list-matching-references>`
+        :calls: `GET /repos/{owner}/{repo}/git/matching-refs/{ref} <https://docs.github.com/en/rest/reference/git/refs#list-matching-references>`
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.GitRef.GitRef`
         """
         assert isinstance(ref, str), ref
@@ -2377,7 +2377,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_git_tag(self, sha):
         """
-        :calls: `GET /repos/:owner/:repo/git/tags/:sha <http://developer.github.com/v3/git/tags>`_
+        :calls: `GET /repos/{owner}/{repo}/git/tags/{sha} <http://docs.github.com/en/rest/reference/git#tags>`_
         :param sha: string
         :rtype: :class:`github.GitTag.GitTag`
         """
@@ -2389,7 +2389,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_git_tree(self, sha, recursive=github.GithubObject.NotSet):
         """
-        :calls: `GET /repos/:owner/:repo/git/trees/:sha <http://developer.github.com/v3/git/trees>`_
+        :calls: `GET /repos/{owner}/{repo}/git/trees/{sha} <http://docs.github.com/en/rest/reference/git#trees>`_
         :param sha: string
         :param recursive: bool
         :rtype: :class:`github.GitTree.GitTree`
@@ -2409,7 +2409,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_hook(self, id):
         """
-        :calls: `GET /repos/:owner/:repo/hooks/:id <http://developer.github.com/v3/repos/hooks>`_
+        :calls: `GET /repos/{owner}/{repo}/hooks/{id} <http://docs.github.com/en/rest/reference/repos#webhooks>`_
         :param id: integer
         :rtype: :class:`github.Hook.Hook`
         """
@@ -2421,7 +2421,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_hooks(self):
         """
-        :calls: `GET /repos/:owner/:repo/hooks <http://developer.github.com/v3/repos/hooks>`_
+        :calls: `GET /repos/{owner}/{repo}/hooks <http://docs.github.com/en/rest/reference/repos#webhooks>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Hook.Hook`
         """
         return github.PaginatedList.PaginatedList(
@@ -2430,7 +2430,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_issue(self, number):
         """
-        :calls: `GET /repos/:owner/:repo/issues/:number <http://developer.github.com/v3/issues>`_
+        :calls: `GET /repos/{owner}/{repo}/issues/{number} <http://docs.github.com/en/rest/reference/issues>`_
         :param number: integer
         :rtype: :class:`github.Issue.Issue`
         """
@@ -2453,7 +2453,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         creator=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /repos/:owner/:repo/issues <http://developer.github.com/v3/issues>`_
+        :calls: `GET /repos/{owner}/{repo}/issues <http://docs.github.com/en/rest/reference/issues>`_
         :param milestone: :class:`github.Milestone.Milestone` or "none" or "*"
         :param state: string. `open`, `closed`, or `all`. If this is not set the GitHub API default behavior will be used. At the moment this is to return only open issues. This might change anytime on GitHub API side and it could be clever to explicitly specify the state value.
         :param assignee: string or :class:`github.NamedUser.NamedUser` or "none" or "*"
@@ -2540,7 +2540,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         since=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /repos/:owner/:repo/issues/comments <http://developer.github.com/v3/issues/comments>`_
+        :calls: `GET /repos/{owner}/{repo}/issues/comments <http://docs.github.com/en/rest/reference/issues#comments>`_
         :param sort: string
         :param direction: string
         :param since: datetime.datetime
@@ -2569,7 +2569,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_issues_event(self, id):
         """
-        :calls: `GET /repos/:owner/:repo/issues/events/:id <http://developer.github.com/v3/issues/events>`_
+        :calls: `GET /repos/{owner}/{repo}/issues/events/{id} <http://docs.github.com/en/rest/reference/issues#events>`_
         :param id: integer
         :rtype: :class:`github.IssueEvent.IssueEvent`
         """
@@ -2585,7 +2585,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_issues_events(self):
         """
-        :calls: `GET /repos/:owner/:repo/issues/events <http://developer.github.com/v3/issues/events>`_
+        :calls: `GET /repos/{owner}/{repo}/issues/events <http://docs.github.com/en/rest/reference/issues#events>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.IssueEvent.IssueEvent`
         """
         return github.PaginatedList.PaginatedList(
@@ -2598,7 +2598,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_key(self, id):
         """
-        :calls: `GET /repos/:owner/:repo/keys/:id <http://developer.github.com/v3/repos/#deploy-keys>`_
+        :calls: `GET /repos/{owner}/{repo}/keys/{id} <http://docs.github.com/en/rest/reference/repos#deploy-keys>`_
         :param id: integer
         :rtype: :class:`github.RepositoryKey.RepositoryKey`
         """
@@ -2612,7 +2612,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_keys(self):
         """
-        :calls: `GET /repos/:owner/:repo/keys <http://developer.github.com/v3/repos/#deploy-keys>`_
+        :calls: `GET /repos/{owner}/{repo}/keys <http://docs.github.com/en/rest/reference/repos#deploy-keys>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.RepositoryKey.RepositoryKey`
         """
         return github.PaginatedList.PaginatedList(
@@ -2624,7 +2624,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_label(self, name):
         """
-        :calls: `GET /repos/:owner/:repo/labels/:name <http://developer.github.com/v3/issues/labels>`_
+        :calls: `GET /repos/{owner}/{repo}/labels/{name} <http://docs.github.com/en/rest/reference/issues#labels>`_
         :param name: string
         :rtype: :class:`github.Label.Label`
         """
@@ -2636,7 +2636,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_labels(self):
         """
-        :calls: `GET /repos/:owner/:repo/labels <http://developer.github.com/v3/issues/labels>`_
+        :calls: `GET /repos/{owner}/{repo}/labels <http://docs.github.com/en/rest/reference/issues#labels>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Label.Label`
         """
         return github.PaginatedList.PaginatedList(
@@ -2645,7 +2645,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_languages(self):
         """
-        :calls: `GET /repos/:owner/:repo/languages <http://developer.github.com/v3/repos>`_
+        :calls: `GET /repos/{owner}/{repo}/languages <http://docs.github.com/en/rest/reference/repos>`_
         :rtype: dict of string to integer
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -2655,7 +2655,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_license(self):
         """
-        :calls: `GET /repos/:owner/:repo/license <https://developer.github.com/v3/licenses>`_
+        :calls: `GET /repos/{owner}/{repo}/license <https://docs.github.com/en/rest/reference/licenses>`_
         :rtype: :class:`github.ContentFile.ContentFile`
         """
 
@@ -2668,7 +2668,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_milestone(self, number):
         """
-        :calls: `GET /repos/:owner/:repo/milestones/:number <http://developer.github.com/v3/issues/milestones>`_
+        :calls: `GET /repos/{owner}/{repo}/milestones/{number} <http://docs.github.com/en/rest/reference/issues#milestones>`_
         :param number: integer
         :rtype: :class:`github.Milestone.Milestone`
         """
@@ -2687,7 +2687,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         direction=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /repos/:owner/:repo/milestones <http://developer.github.com/v3/issues/milestones>`_
+        :calls: `GET /repos/{owner}/{repo}/milestones <http://docs.github.com/en/rest/reference/issues#milestones>`_
         :param state: string
         :param sort: string
         :param direction: string
@@ -2714,7 +2714,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_network_events(self):
         """
-        :calls: `GET /networks/:owner/:repo/events <http://developer.github.com/v3/activity/events>`_
+        :calls: `GET /networks/{owner}/{repo}/events <http://docs.github.com/en/rest/reference/activity#events>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
         """
         return github.PaginatedList.PaginatedList(
@@ -2726,7 +2726,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_public_key(self):
         """
-        :calls: `GET /repos/:owner/:repo/actions/secrets/public-key <https://docs.github.com/en/rest/reference/actions#get-a-repository-public-key>`_
+        :calls: `GET /repos/{owner}/{repo}/actions/secrets/public-key <https://docs.github.com/en/rest/reference/actions#get-a-repository-public-key>`_
         :rtype: :class:`github.PublicKey.PublicKey`
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -2738,7 +2738,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_pull(self, number):
         """
-        :calls: `GET /repos/:owner/:repo/pulls/:number <http://developer.github.com/v3/pulls>`_
+        :calls: `GET /repos/{owner}/{repo}/pulls/{number} <http://docs.github.com/en/rest/reference/pulls>`_
         :param number: integer
         :rtype: :class:`github.PullRequest.PullRequest`
         """
@@ -2759,7 +2759,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         head=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /repos/:owner/:repo/pulls <http://developer.github.com/v3/pulls>`_
+        :calls: `GET /repos/{owner}/{repo}/pulls <http://docs.github.com/en/rest/reference/pulls>`_
         :param state: string
         :param sort: string
         :param direction: string
@@ -2799,7 +2799,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         since=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /repos/:owner/:repo/pulls/comments <http://developer.github.com/v3/pulls/comments>`_
+        :calls: `GET /repos/{owner}/{repo}/pulls/comments <http://docs.github.com/en/rest/reference/pulls#comments>`_
         :param sort: string
         :param direction: string
         :param since: datetime.datetime
@@ -2814,7 +2814,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         since=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /repos/:owner/:repo/pulls/comments <http://developer.github.com/v3/pulls/comments>`_
+        :calls: `GET /repos/{owner}/{repo}/pulls/comments <http://docs.github.com/en/rest/reference/pulls#review-comments>`_
         :param sort: string
         :param direction: string
         :param since: datetime.datetime
@@ -2843,7 +2843,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_readme(self, ref=github.GithubObject.NotSet):
         """
-        :calls: `GET /repos/:owner/:repo/readme <http://developer.github.com/v3/repos/contents>`_
+        :calls: `GET /repos/{owner}/{repo}/readme <http://docs.github.com/en/rest/reference/repos#contents>`_
         :param ref: string
         :rtype: :class:`github.ContentFile.ContentFile`
         """
@@ -2860,7 +2860,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_self_hosted_runner(self, runner_id):
         """
-        :calls: `GET /repos/:owner/:repo/actions/runners/:id <https://docs.github.com/en/rest/reference/actions#get-a-self-hosted-runner-for-a-repository`_
+        :calls: `GET /repos/{owner}/{repo}/actions/runners/{id} <https://docs.github.com/en/rest/reference/actions#get-a-self-hosted-runner-for-a-repository>`_
         :param runner_id: int
         :rtype: :class:`github.SelfHostedActionsRunner.SelfHostedActionsRunner`
         """
@@ -2874,7 +2874,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_self_hosted_runners(self):
         """
-        :calls: `GET /repos/:owner/:repo/actions/runners <https://docs.github.com/en/rest/reference/actions#list-self-hosted-runners-for-a-repository`_
+        :calls: `GET /repos/{owner}/{repo}/actions/runners <https://docs.github.com/en/rest/reference/actions#list-self-hosted-runners-for-a-repository>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.SelfHostedActionsRunner.SelfHostedActionsRunner`
         """
         return github.PaginatedList.PaginatedList(
@@ -2887,7 +2887,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_source_import(self):
         """
-        :calls: `GET /repos/:owner/:repo/import <https://developer.github.com/v3/migration/source_imports/#get-import-progress>`_
+        :calls: `GET /repos/{owner}/{repo}/import <https://docs.github.com/en/rest/reference/migration/source_imports#get-import-progress>`_
         :rtype: :class:`github.SourceImport.SourceImport`
         """
         import_header = {"Accept": Consts.mediaTypeImportPreview}
@@ -2905,7 +2905,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_stargazers(self):
         """
-        :calls: `GET /repos/:owner/:repo/stargazers <http://developer.github.com/v3/activity/starring>`_
+        :calls: `GET /repos/{owner}/{repo}/stargazers <http://docs.github.com/en/rest/reference/activity#starring>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
         return github.PaginatedList.PaginatedList(
@@ -2914,7 +2914,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_stargazers_with_dates(self):
         """
-        :calls: `GET /repos/:owner/:repo/stargazers <http://developer.github.com/v3/activity/starring>`_
+        :calls: `GET /repos/{owner}/{repo}/stargazers <http://docs.github.com/en/rest/reference/activity#starring>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Stargazer.Stargazer`
         """
         return github.PaginatedList.PaginatedList(
@@ -2927,7 +2927,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_stats_contributors(self):
         """
-        :calls: `GET /repos/:owner/:repo/stats/contributors <http://developer.github.com/v3/repos/statistics/#get-contributors-list-with-additions-deletions-and-commit-counts>`_
+        :calls: `GET /repos/{owner}/{repo}/stats/contributors <http://docs.github.com/en/rest/reference/repos/statistics#get-contributors-list-with-additions-deletions-and-commit-counts>`_
         :rtype: None or list of :class:`github.StatsContributor.StatsContributor`
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -2945,7 +2945,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_stats_commit_activity(self):
         """
-        :calls: `GET /repos/:owner/:repo/stats/commit_activity <developer.github.com/v3/repos/statistics/#get-the-number-of-commits-per-hour-in-each-day>`_
+        :calls: `GET /repos/{owner}/{repo}/stats/commit_activity <docs.github.com/en/rest/reference/repos/statistics#get-the-number-of-commits-per-hour-in-each-day>`_
         :rtype: None or list of :class:`github.StatsCommitActivity.StatsCommitActivity`
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -2963,7 +2963,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_stats_code_frequency(self):
         """
-        :calls: `GET /repos/:owner/:repo/stats/code_frequency <http://developer.github.com/v3/repos/statistics/#get-the-number-of-additions-and-deletions-per-week>`_
+        :calls: `GET /repos/{owner}/{repo}/stats/code_frequency <http://docs.github.com/en/rest/reference/repos/statistics#get-the-number-of-additions-and-deletions-per-week>`_
         :rtype: None or list of :class:`github.StatsCodeFrequency.StatsCodeFrequency`
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -2981,7 +2981,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_stats_participation(self):
         """
-        :calls: `GET /repos/:owner/:repo/stats/participation <http://developer.github.com/v3/repos/statistics/#get-the-weekly-commit-count-for-the-repo-owner-and-everyone-else>`_
+        :calls: `GET /repos/{owner}/{repo}/stats/participation <http://docs.github.com/en/rest/reference/repos/statistics#get-the-weekly-commit-count-for-the-repo-owner-and-everyone-else>`_
         :rtype: None or :class:`github.StatsParticipation.StatsParticipation`
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -2996,7 +2996,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_stats_punch_card(self):
         """
-        :calls: `GET /repos/:owner/:repo/stats/punch_card <http://developer.github.com/v3/repos/statistics/#get-the-number-of-commits-per-hour-in-each-day>`_
+        :calls: `GET /repos/{owner}/{repo}/stats/punch_card <http://docs.github.com/en/rest/reference/repos/statistics#get-the-number-of-commits-per-hour-in-each-day>`_
         :rtype: None or :class:`github.StatsPunchCard.StatsPunchCard`
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -3011,7 +3011,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_subscribers(self):
         """
-        :calls: `GET /repos/:owner/:repo/subscribers <http://developer.github.com/v3/activity/watching>`_
+        :calls: `GET /repos/{owner}/{repo}/subscribers <http://docs.github.com/en/rest/reference/activity#watching>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
         return github.PaginatedList.PaginatedList(
@@ -3020,7 +3020,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_tags(self):
         """
-        :calls: `GET /repos/:owner/:repo/tags <http://developer.github.com/v3/repos>`_
+        :calls: `GET /repos/{owner}/{repo}/tags <http://docs.github.com/en/rest/reference/repos>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Tag.Tag`
         """
         return github.PaginatedList.PaginatedList(
@@ -3029,7 +3029,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_releases(self):
         """
-        :calls: `GET /repos/:owner/:repo/releases <https://developer.github.com/v3/repos/releases/#list-releases-for-a-repository>`_
+        :calls: `GET /repos/{owner}/{repo}/releases <https://docs.github.com/en/rest/reference/repos/releases#list-releases-for-a-repository>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.GitRelease.GitRelease`
         """
         return github.PaginatedList.PaginatedList(
@@ -3038,7 +3038,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_release(self, id):
         """
-        :calls: `GET /repos/:owner/:repo/releases/:id <https://developer.github.com/v3/repos/releases/#get-a-single-release>`_
+        :calls: `GET /repos/{owner}/{repo}/releases/{id} <https://docs.github.com/en/rest/reference/repos/releases#get-a-single-release>`_
         :param id: int (release id), str (tag name)
         :rtype: None or :class:`github.GitRelease.GitRelease`
         """
@@ -3059,7 +3059,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_latest_release(self):
         """
-        :calls: `GET /repos/:owner/:repo/releases/latest <https://developer.github.com/v3/repos/releases/#get-the-latest-release>`_
+        :calls: `GET /repos/{owner}/{repo}/releases/latest <https://docs.github.com/en/rest/reference/repos/releases#get-the-latest-release>`_
         :rtype: :class:`github.GitRelease.GitRelease`
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -3071,7 +3071,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_teams(self):
         """
-        :calls: `GET /repos/:owner/:repo/teams <http://developer.github.com/v3/repos>`_
+        :calls: `GET /repos/{owner}/{repo}/teams <http://docs.github.com/en/rest/reference/repos>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Team.Team`
         """
         return github.PaginatedList.PaginatedList(
@@ -3080,7 +3080,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_topics(self):
         """
-        :calls: `GET /repos/:owner/:repo/topics <https://developer.github.com/v3/repos/#list-all-topics-for-a-repository>`_
+        :calls: `GET /repos/{owner}/{repo}/topics <https://docs.github.com/en/rest/reference/repos#list-all-topics-for-a-repository>`_
         :rtype: list of strings
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -3092,7 +3092,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_watchers(self):
         """
-        :calls: `GET /repos/:owner/:repo/watchers <http://developer.github.com/v3/activity/starring>`_
+        :calls: `GET /repos/{owner}/{repo}/watchers <http://docs.github.com/en/rest/reference/activity#starring>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
         return github.PaginatedList.PaginatedList(
@@ -3101,7 +3101,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_workflows(self):
         """
-        :calls: `GET /repos/:owner/:repo/actions/workflows <https://developer.github.com/v3/actions/workflows>`_
+        :calls: `GET /repos/{owner}/{repo}/actions/workflows <https://docs.github.com/en/rest/reference/actions#workflows>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Workflow.Workflow`
         """
         return github.PaginatedList.PaginatedList(
@@ -3114,7 +3114,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_workflow(self, id_or_name):
         """
-        :calls: `GET /repos/:owner/:repo/actions/workflows/:workflow_id <https://developer.github.com/v3/actions/workflows>`_
+        :calls: `GET /repos/{owner}/{repo}/actions/workflows/{workflow_id} <https://docs.github.com/en/rest/reference/actions#workflows>`_
         :param id_or_name: int or string
 
         :rtype: :class:`github.Workflow.Workflow`
@@ -3133,7 +3133,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         status=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /repos/:owner/:repo/actions/runs <https://developer.github.com/v3/actions/workflow-runs/#list-workflow-runs-for-a-repository>`_
+        :calls: `GET /repos/{owner}/{repo}/actions/runs <https://docs.github.com/en/rest/reference/actions/workflow-runs#list-workflow-runs-for-a-repository>`_
         :param actor: :class:`github.NamedUser.NamedUser` or string
         :param branch: :class:`github.Branch.Branch` or string
         :param event: string
@@ -3180,7 +3180,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_workflow_run(self, id_):
         """
-        :calls: `GET /repos/:owner/:repo/actions/runs/:run_id <https://developer.github.com/v3/actions/workflow-runs>`_
+        :calls: `GET /repos/{owner}/{repo}/actions/runs/{run_id} <https://docs.github.com/en/rest/reference/actions#workflow-runs>`_
         :param id_: int
 
         :rtype: :class:`github.WorkflowRun.WorkflowRun`
@@ -3195,7 +3195,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def has_in_assignees(self, assignee):
         """
-        :calls: `GET /repos/:owner/:repo/assignees/:assignee <http://developer.github.com/v3/issues/assignees>`_
+        :calls: `GET /repos/{owner}/{repo}/assignees/{assignee} <http://docs.github.com/en/rest/reference/issues#assignees>`_
         :param assignee: string or :class:`github.NamedUser.NamedUser`
         :rtype: bool
         """
@@ -3213,7 +3213,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def has_in_collaborators(self, collaborator):
         """
-        :calls: `GET /repos/:owner/:repo/collaborators/:user <http://developer.github.com/v3/repos/collaborators>`_
+        :calls: `GET /repos/{owner}/{repo}/collaborators/{user} <http://docs.github.com/en/rest/reference/repos#collaborators>`_
         :param collaborator: string or :class:`github.NamedUser.NamedUser`
         :rtype: bool
         """
@@ -3249,7 +3249,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def legacy_search_issues(self, state, keyword):
         """
-        :calls: `GET /legacy/issues/search/:owner/:repository/:state/:keyword <http://developer.github.com/v3/search/legacy>`_
+        :calls: `GET /legacy/issues/search/{owner}/{repository}/{state}/{keyword} <http://docs.github.com/en/rest/reference/search#legacy>`_
         :param state: "open" or "closed"
         :param keyword: string
         :rtype: List of :class:`github.Issue.Issue`
@@ -3278,7 +3278,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         before=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /repos/:owner/:repo/notifications <http://developer.github.com/v3/activity/notifications>`_
+        :calls: `GET /repos/{owner}/{repo}/notifications <http://docs.github.com/en/rest/reference/activity#notifications>`_
         :param all: bool
         :param participating: bool
         :param since: datetime.datetime
@@ -3316,7 +3316,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def mark_notifications_as_read(self, last_read_at=datetime.datetime.utcnow()):
         """
-        :calls: `PUT /repos/:owner/:repo/notifications <https://developer.github.com/v3/activity/notifications>`_
+        :calls: `PUT /repos/{owner}/{repo}/notifications <https://docs.github.com/en/rest/reference/activity#notifications>`_
         :param last_read_at: datetime
         """
         assert isinstance(last_read_at, datetime.datetime)
@@ -3328,7 +3328,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def merge(self, base, head, commit_message=github.GithubObject.NotSet):
         """
-        :calls: `POST /repos/:owner/:repo/merges <http://developer.github.com/v3/repos/merging>`_
+        :calls: `POST /repos/{owner}/{repo}/merges <http://docs.github.com/en/rest/reference/repos#merging>`_
         :param base: string
         :param head: string
         :param commit_message: string
@@ -3355,7 +3355,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def replace_topics(self, topics):
         """
-        :calls: `PUT /repos/:owner/:repo/topics <http://developer.github.com/v3/repos>`_
+        :calls: `PUT /repos/{owner}/{repo}/topics <http://docs.github.com/en/rest/reference/repos>`_
         :param topics: list of strings
         :rtype: None
         """
@@ -3369,7 +3369,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_vulnerability_alert(self):
         """
-        :calls: `GET /repos/:owner/:repo/vulnerability-alerts <http://developer.github.com/v3/repos>`_
+        :calls: `GET /repos/{owner}/{repo}/vulnerability-alerts <http://docs.github.com/en/rest/reference/repos>`_
         :rtype: bool
         """
         status, _, _ = self._requester.requestJson(
@@ -3381,7 +3381,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def enable_vulnerability_alert(self):
         """
-        :calls: `PUT /repos/:owner/:repo/vulnerability-alerts <http://developer.github.com/v3/repos>`_
+        :calls: `PUT /repos/{owner}/{repo}/vulnerability-alerts <http://docs.github.com/en/rest/reference/repos>`_
         :rtype: bool
         """
         status, _, _ = self._requester.requestJson(
@@ -3393,7 +3393,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def disable_vulnerability_alert(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/vulnerability-alerts <http://developer.github.com/v3/repos>`_
+        :calls: `DELETE /repos/{owner}/{repo}/vulnerability-alerts <http://docs.github.com/en/rest/reference/repos>`_
         :rtype: bool
         """
         status, _, _ = self._requester.requestJson(
@@ -3405,7 +3405,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def enable_automated_security_fixes(self):
         """
-        :calls: `PUT /repos/:owner/:repo/automated-security-fixes <http://developer.github.com/v3/repos>`_
+        :calls: `PUT /repos/{owner}/{repo}/automated-security-fixes <http://docs.github.com/en/rest/reference/repos>`_
         :rtype: bool
         """
         status, _, _ = self._requester.requestJson(
@@ -3417,7 +3417,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def disable_automated_security_fixes(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/automated-security-fixes <http://developer.github.com/v3/repos>`_
+        :calls: `DELETE /repos/{owner}/{repo}/automated-security-fixes <http://docs.github.com/en/rest/reference/repos>`_
         :rtype: bool
         """
         status, _, _ = self._requester.requestJson(
@@ -3429,7 +3429,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def remove_from_collaborators(self, collaborator):
         """
-        :calls: `DELETE /repos/:owner/:repo/collaborators/:user <http://developer.github.com/v3/repos/collaborators>`_
+        :calls: `DELETE /repos/{owner}/{repo}/collaborators/{user} <http://docs.github.com/en/rest/reference/repos#collaborators>`_
         :param collaborator: string or :class:`github.NamedUser.NamedUser`
         :rtype: None
         """
@@ -3446,7 +3446,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def remove_self_hosted_runner(self, runner):
         """
-        :calls: `DELETE /repos/:owner/:repo/actions/runners/:runner_id <https://docs.github.com/en/rest/reference/actions#delete-a-self-hosted-runner-from-a-repository>`_
+        :calls: `DELETE /repos/{owner}/{repo}/actions/runners/{runner_id} <https://docs.github.com/en/rest/reference/actions#delete-a-self-hosted-runner-from-a-repository>`_
         :param runner: int or :class:`github.SelfHostedActionsRunner.SelfHostedActionsRunner`
         :rtype: bool
         """
@@ -3464,7 +3464,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def subscribe_to_hub(self, event, callback, secret=github.GithubObject.NotSet):
         """
-        :calls: `POST /hub <http://developer.github.com/>`_
+        :calls: `POST /hub <https://docs.github.com/en/rest/reference/repos#pubsubhubbub>`_
         :param event: string
         :param callback: string
         :param secret: string
@@ -3474,7 +3474,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def unsubscribe_from_hub(self, event, callback):
         """
-        :calls: `POST /hub <http://developer.github.com/>`_
+        :calls: `POST /hub <https://docs.github.com/en/rest/reference/repos#pubsubhubbub>`_
         :param event: string
         :param callback: string
         :param secret: string
@@ -3484,7 +3484,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def create_check_suite(self, head_sha):
         """
-        :calls: `POST /repos/:owner/:repo/check-suites <https://docs.github.com/en/rest/reference/checks#create-a-check-suite>`_
+        :calls: `POST /repos/{owner}/{repo}/check-suites <https://docs.github.com/en/rest/reference/checks#create-a-check-suite>`_
         :param head_sha: string
         :rtype: :class:`github.CheckSuite.CheckSuite`
         """
@@ -3500,7 +3500,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_check_suite(self, check_suite_id):
         """
-        :calls: `GET /repos/:owner/:repo/check-suites/:check_suite_id <https://docs.github.com/en/rest/reference/checks#get-a-check-suite>`_
+        :calls: `GET /repos/{owner}/{repo}/check-suites/{check_suite_id} <https://docs.github.com/en/rest/reference/checks#get-a-check-suite>`_
         :param check_suite_id: int
         :rtype: :class:`github.CheckSuite.CheckSuite`
         """
@@ -3517,7 +3517,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def update_check_suites_preferences(self, auto_trigger_checks):
         """
-        :calls: `PATCH /repos/:owner/:repo/check-suites/preferences <https://docs.github.com/en/rest/reference/checks#update-repository-preferences-for-check-suites>`_
+        :calls: `PATCH /repos/{owner}/{repo}/check-suites/preferences <https://docs.github.com/en/rest/reference/checks#update-repository-preferences-for-check-suites>`_
         :param auto_trigger_checks: list of dict
         :rtype: :class:`github.RepositoryPreferences.RepositoryPreferences`
         """
@@ -3580,7 +3580,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         actions=github.GithubObject.NotSet,
     ):
         """
-        :calls: `POST /repos/:owner/:repo/check-runs <https://docs.github.com/en/rest/reference/checks#create-a-check-run>`_
+        :calls: `POST /repos/{owner}/{repo}/check-runs <https://docs.github.com/en/rest/reference/checks#create-a-check-run>`_
         :param name: string
         :param head_sha: string
         :param details_url: string
@@ -3648,7 +3648,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_check_run(self, check_run_id):
         """
-        :calls: `GET /repos/:owner/:repo/check-runs/:check_run_id <https://docs.github.com/en/rest/reference/checks#get-a-check-run>`_
+        :calls: `GET /repos/{owner}/{repo}/check-runs/{check_run_id} <https://docs.github.com/en/rest/reference/checks#get-a-check-run>`_
         :param check_run_id: int
         :rtype: :class:`github.CheckRun.CheckRun`
         """

--- a/github/RepositoryKey.py
+++ b/github/RepositoryKey.py
@@ -38,7 +38,7 @@ import github.GithubObject
 
 class RepositoryKey(github.GithubObject.CompletableGithubObject):
     """
-    This class represents RepositoryKeys. The reference can be found here http://developer.github.com/v3/repos/#deploy-keys
+    This class represents RepositoryKeys. The reference can be found here http://docs.github.com/en/rest/reference/repos#deploy-keys
     """
 
     def __repr__(self):
@@ -102,7 +102,7 @@ class RepositoryKey(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /repos/:owner/:repo/keys/:id <http://developer.github.com/v3/repos/#deploy-keys>`_
+        :calls: `DELETE /repos/{owner}/{repo}/keys/{id} <http://docs.github.com/en/rest/reference/repos#deploy-keys>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("DELETE", self.url)

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -344,7 +344,7 @@ class Requester:
 
         assert user_agent is not None, (
             "github now requires a user-agent. "
-            "See http://developer.github.com/v3/#user-agent-required"
+            "See http://docs.github.com/en/rest/reference/#user-agent-required"
         )
         self.__userAgent = user_agent
         self.__verify = verify

--- a/github/RequiredPullRequestReviews.py
+++ b/github/RequiredPullRequestReviews.py
@@ -27,7 +27,7 @@ import github.Team
 
 class RequiredPullRequestReviews(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Required Pull Request Reviews. The reference can be found here https://developer.github.com/v3/repos/branches/#get-pull-request-review-enforcement-of-protected-branch
+    This class represents Required Pull Request Reviews. The reference can be found here https://docs.github.com/en/rest/reference/repos/branches#get-pull-request-review-enforcement-of-protected-branch
     """
 
     def __repr__(self):

--- a/github/RequiredStatusChecks.py
+++ b/github/RequiredStatusChecks.py
@@ -25,7 +25,7 @@ import github.GithubObject
 
 class RequiredStatusChecks(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Required Status Checks. The reference can be found here https://developer.github.com/v3/repos/branches/#get-required-status-checks-of-protected-branch
+    This class represents Required Status Checks. The reference can be found here https://docs.github.com/en/rest/reference/repos/branches#get-required-status-checks-of-protected-branch
     """
 
     def __repr__(self):

--- a/github/SourceImport.py
+++ b/github/SourceImport.py
@@ -26,7 +26,7 @@ from github import Consts
 
 class SourceImport(github.GithubObject.CompletableGithubObject):
     """
-    This class represents SourceImports. The reference can be found here https://developer.github.com/v3/migration/source_imports/
+    This class represents SourceImports. The reference can be found here https://docs.github.com/en/rest/reference/migration#source_imports
     """
 
     def __repr__(self):

--- a/github/Stargazer.py
+++ b/github/Stargazer.py
@@ -29,7 +29,7 @@ import github
 
 class Stargazer(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents Stargazers. The reference can be found here https://developer.github.com/v3/activity/starring/#alternative-response-with-star-creation-timestamps
+    This class represents Stargazers. The reference can be found here https://docs.github.com/en/rest/reference/activity/starring#alternative-response-with-star-creation-timestamps
     """
 
     def __repr__(self):

--- a/github/StatsCodeFrequency.py
+++ b/github/StatsCodeFrequency.py
@@ -29,7 +29,7 @@ import github.GithubObject
 
 class StatsCodeFrequency(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents statistics of StatsCodeFrequencies. The reference can be found here http://developer.github.com/v3/repos/statistics/#get-the-number-of-additions-and-deletions-per-week
+    This class represents statistics of StatsCodeFrequencies. The reference can be found here http://docs.github.com/en/rest/reference/repos/statistics#get-the-number-of-additions-and-deletions-per-week
     """
 
     @property

--- a/github/StatsCommitActivity.py
+++ b/github/StatsCommitActivity.py
@@ -29,7 +29,7 @@ import github.GithubObject
 
 class StatsCommitActivity(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents StatsCommitActivities. The reference can be found here http://developer.github.com/v3/repos/statistics/#get-the-last-year-of-commit-activity-data
+    This class represents StatsCommitActivities. The reference can be found here http://docs.github.com/en/rest/reference/repos/statistics#get-the-last-year-of-commit-activity-data
     """
 
     @property

--- a/github/StatsContributor.py
+++ b/github/StatsContributor.py
@@ -30,7 +30,7 @@ import github.NamedUser
 
 class StatsContributor(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents StatsContributors. The reference can be found here http://developer.github.com/v3/repos/statistics/#get-contributors-list-with-additions-deletions-and-commit-counts
+    This class represents StatsContributors. The reference can be found here http://docs.github.com/en/rest/reference/repos/statistics#get-contributors-list-with-additions-deletions-and-commit-counts
     """
 
     class Week(github.GithubObject.NonCompletableGithubObject):

--- a/github/StatsParticipation.py
+++ b/github/StatsParticipation.py
@@ -29,7 +29,7 @@ import github.GithubObject
 
 class StatsParticipation(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents StatsParticipations. The reference can be found here http://developer.github.com/v3/repos/statistics/#get-the-weekly-commit-count-for-the-repo-owner-and-everyone-else
+    This class represents StatsParticipations. The reference can be found here http://docs.github.com/en/rest/reference/repos/statistics#get-the-weekly-commit-count-for-the-repo-owner-and-everyone-else
     """
 
     @property

--- a/github/StatsPunchCard.py
+++ b/github/StatsPunchCard.py
@@ -30,7 +30,7 @@ import github.NamedUser  # TODO remove unused
 
 class StatsPunchCard(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents StatsPunchCards. The reference can be found here http://developer.github.com/v3/repos/statistics/#get-the-number-of-commits-per-hour-in-each-day
+    This class represents StatsPunchCards. The reference can be found here http://docs.github.com/en/rest/reference/repos/statistics#get-the-number-of-commits-per-hour-in-each-day
     """
 
     def get(self, day, hour):

--- a/github/Tag.py
+++ b/github/Tag.py
@@ -35,7 +35,7 @@ import github.GithubObject
 
 class Tag(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents Tags. The reference can be found here https://developer.github.com/v3/repos/#list-tags
+    This class represents Tags. The reference can be found here https://docs.github.com/en/rest/reference/repos#list-tags
     """
 
     def __repr__(self):

--- a/github/Team.py
+++ b/github/Team.py
@@ -54,7 +54,7 @@ from . import Consts
 
 class Team(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Teams. The reference can be found here http://developer.github.com/v3/orgs/teams/
+    This class represents Teams. The reference can be found here http://docs.github.com/en/rest/reference/teams
     """
 
     def __repr__(self):
@@ -167,9 +167,9 @@ class Team(github.GithubObject.CompletableGithubObject):
     def add_to_members(self, member):
         """
         This API call is deprecated. Use `add_membership` instead.
-        https://developer.github.com/v3/teams/members/#deprecation-notice-1
+        https://docs.github.com/en/rest/reference/teams#add-or-update-team-membership-for-a-user-legacy
 
-        :calls: `PUT /teams/:id/members/:user <http://developer.github.com/v3/orgs/teams>`_
+        :calls: `PUT /teams/{id}/members/{user} <http://docs.github.com/en/rest/reference/teams>`_
         :param member: :class:`github.NamedUser.NamedUser`
         :rtype: None
         """
@@ -180,7 +180,7 @@ class Team(github.GithubObject.CompletableGithubObject):
 
     def add_membership(self, member, role=github.GithubObject.NotSet):
         """
-        :calls: `PUT /teams/:id/memberships/:user <http://developer.github.com/v3/orgs/teams>`_
+        :calls: `PUT /teams/{id}/memberships/{user} <http://docs.github.com/en/rest/reference/teams>`_
         :param member: :class:`github.Nameduser.NamedUser`
         :param role: string
         :rtype: None
@@ -202,7 +202,7 @@ class Team(github.GithubObject.CompletableGithubObject):
 
     def get_team_membership(self, member):
         """
-        :calls: `GET /orgs/:org/memberships/team/:team_id/:username <https://docs.github.com/en/rest/reference/teams#get-team-membership-for-a-user>`_
+        :calls: `GET /orgs/{org}/memberships/team/{team_id}/{username} <https://docs.github.com/en/rest/reference/teams#get-team-membership-for-a-user>`_
         :param member: string or :class:`github.NamedUser.NamedUser`
         :rtype: :class:`github.Membership.Membership`
         """
@@ -220,7 +220,7 @@ class Team(github.GithubObject.CompletableGithubObject):
 
     def add_to_repos(self, repo):
         """
-        :calls: `PUT /teams/:id/repos/:org/:repo <http://developer.github.com/v3/orgs/teams>`_
+        :calls: `PUT /teams/{id}/repos/{org}/{repo} <http://docs.github.com/en/rest/reference/teams>`_
         :param repo: :class:`github.Repository.Repository`
         :rtype: None
         """
@@ -231,7 +231,7 @@ class Team(github.GithubObject.CompletableGithubObject):
 
     def get_repo_permission(self, repo):
         """
-        :calls: `GET /teams/:id/repos/:org/:repo <http://developer.github.com/v3/orgs/teams>`_
+        :calls: `GET /teams/{id}/repos/{org}/{repo} <http://docs.github.com/en/rest/reference/teams>`_
         :param repo: string or :class:`github.Repository.Repository`
         :rtype: None or :class:`github.Permissions.Permissions`
         """
@@ -259,7 +259,7 @@ class Team(github.GithubObject.CompletableGithubObject):
     )
     def set_repo_permission(self, repo, permission):
         """
-        :calls: `PUT /teams/:id/repos/:org/:repo <http://developer.github.com/v3/orgs/teams>`_
+        :calls: `PUT /teams/{id}/repos/{org}/{repo} <http://docs.github.com/en/rest/reference/teams>`_
         :param repo: :class:`github.Repository.Repository`
         :param permission: string
         :rtype: None
@@ -275,7 +275,7 @@ class Team(github.GithubObject.CompletableGithubObject):
 
     def update_team_repository(self, repo, permission):
         """
-        :calls: `PUT /orgs/:org/teams/:team_slug/repos/:owner/:repo <https://developer.github.com/v3/teams/#add-or-update-team-repository-permissions>`_
+        :calls: `PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo} <https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions>`_
         :param repo: string or :class:`github.Repository.Repository`
         :param permission: string
         :rtype: bool
@@ -299,7 +299,7 @@ class Team(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /teams/:id <http://developer.github.com/v3/orgs/teams>`_
+        :calls: `DELETE /teams/{id} <http://docs.github.com/en/rest/reference/teams>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("DELETE", self.url)
@@ -312,7 +312,7 @@ class Team(github.GithubObject.CompletableGithubObject):
         privacy=github.GithubObject.NotSet,
     ):
         """
-        :calls: `PATCH /teams/:id <http://developer.github.com/v3/orgs/teams>`_
+        :calls: `PATCH /teams/{id} <http://docs.github.com/en/rest/reference/teams>`_
         :param name: string
         :param description: string
         :param permission: string
@@ -345,7 +345,7 @@ class Team(github.GithubObject.CompletableGithubObject):
 
     def get_teams(self):
         """
-        :calls: `GET /teams/:id/teams <https://developer.github.com/v3/teams/#list-child-teams>`_
+        :calls: `GET /teams/{id}/teams <https://docs.github.com/en/rest/reference/teams#list-child-teams>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Team.Team`
         """
         return github.PaginatedList.PaginatedList(
@@ -357,7 +357,7 @@ class Team(github.GithubObject.CompletableGithubObject):
 
     def get_discussions(self):
         """
-        :calls: `GET /teams/:id/discussions <https://developer.github.com/v3/teams/discussions/#list-discussions>`_
+        :calls: `GET /teams/{id}/discussions <https://docs.github.com/en/rest/reference/teams/discussions#list-discussions>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.TeamDiscussion.TeamDiscussion`
         """
         return github.PaginatedList.PaginatedList(
@@ -370,7 +370,7 @@ class Team(github.GithubObject.CompletableGithubObject):
 
     def get_members(self, role=github.GithubObject.NotSet):
         """
-        :calls: `GET /teams/:id/members <https://developer.github.com/v3/teams/members/#list-team-members>`_
+        :calls: `GET /teams/{id}/members <https://docs.github.com/en/rest/reference/teams/members#list-team-members>`_
         :param role: string
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
@@ -388,7 +388,7 @@ class Team(github.GithubObject.CompletableGithubObject):
 
     def get_repos(self):
         """
-        :calls: `GET /teams/:id/repos <http://developer.github.com/v3/orgs/teams>`_
+        :calls: `GET /teams/{id}/repos <http://docs.github.com/en/rest/reference/teams>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Repository.Repository`
         """
         return github.PaginatedList.PaginatedList(
@@ -397,7 +397,7 @@ class Team(github.GithubObject.CompletableGithubObject):
 
     def invitations(self):
         """
-        :calls: `GET /teams/:id/invitations <https://developer.github.com/v3/teams/members>`_
+        :calls: `GET /teams/{id}/invitations <https://docs.github.com/en/rest/reference/teams#members>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
         return github.PaginatedList.PaginatedList(
@@ -410,7 +410,7 @@ class Team(github.GithubObject.CompletableGithubObject):
 
     def has_in_members(self, member):
         """
-        :calls: `GET /teams/:id/members/:user <http://developer.github.com/v3/orgs/teams>`_
+        :calls: `GET /teams/{id}/members/{user} <http://docs.github.com/en/rest/reference/teams>`_
         :param member: :class:`github.NamedUser.NamedUser`
         :rtype: bool
         """
@@ -422,7 +422,7 @@ class Team(github.GithubObject.CompletableGithubObject):
 
     def has_in_repos(self, repo):
         """
-        :calls: `GET /teams/:id/repos/:owner/:repo <http://developer.github.com/v3/orgs/teams>`_
+        :calls: `GET /teams/{id}/repos/{owner}/{repo} <http://docs.github.com/en/rest/reference/teams>`_
         :param repo: :class:`github.Repository.Repository`
         :rtype: bool
         """
@@ -434,7 +434,7 @@ class Team(github.GithubObject.CompletableGithubObject):
 
     def remove_membership(self, member):
         """
-        :calls: `DELETE /teams/:team_id/memberships/:username <https://developer.github.com/v3/teams/members/#remove-team-membership>`
+        :calls: `DELETE /teams/{team_id}/memberships/{username} <https://docs.github.com/en/rest/reference/teams/members#remove-team-membership>`
         :param member:
         :return:
         """
@@ -446,9 +446,9 @@ class Team(github.GithubObject.CompletableGithubObject):
     def remove_from_members(self, member):
         """
         This API call is deprecated. Use `remove_membership` instead:
-        https://developer.github.com/v3/teams/members/#deprecation-notice-2
+        https://docs.github.com/en/rest/reference/teams#add-or-update-team-membership-for-a-user-legacy
 
-        :calls: `DELETE /teams/:id/members/:user <http://developer.github.com/v3/orgs/teams>`_
+        :calls: `DELETE /teams/{id}/members/{user} <http://docs.github.com/en/rest/reference/teams>`_
         :param member: :class:`github.NamedUser.NamedUser`
         :rtype: None
         """
@@ -459,7 +459,7 @@ class Team(github.GithubObject.CompletableGithubObject):
 
     def remove_from_repos(self, repo):
         """
-        :calls: `DELETE /teams/:id/repos/:owner/:repo <http://developer.github.com/v3/orgs/teams>`_
+        :calls: `DELETE /teams/{id}/repos/{owner}/{repo} <http://docs.github.com/en/rest/reference/teams>`_
         :param repo: :class:`github.Repository.Repository`
         :rtype: None
         """

--- a/github/TeamDiscussion.py
+++ b/github/TeamDiscussion.py
@@ -27,7 +27,7 @@ import github.NamedUser
 
 class TeamDiscussion(github.GithubObject.CompletableGithubObject):
     """
-    This class represents TeamDiscussions. The reference can be found here https://developer.github.com/v3/teams/discussions/
+    This class represents TeamDiscussions. The reference can be found here https://docs.github.com/en/rest/reference/teams#discussions
     """
 
     def __repr__(self):

--- a/github/TimelineEvent.py
+++ b/github/TimelineEvent.py
@@ -27,7 +27,7 @@ import github.TimelineEventSource
 
 class TimelineEvent(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents IssueTimelineEvents. The reference can be found here https://developer.github.com/v3/issues/timeline/
+    This class represents IssueTimelineEvents. The reference can be found here https://docs.github.com/en/rest/reference/issues#timeline
     """
 
     def __repr__(self):

--- a/github/TimelineEventSource.py
+++ b/github/TimelineEventSource.py
@@ -26,7 +26,7 @@ import github.Issue
 
 class TimelineEventSource(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents IssueTimelineEventSource. The reference can be found here https://developer.github.com/v3/issues/timeline/
+    This class represents IssueTimelineEventSource. The reference can be found here https://docs.github.com/en/rest/reference/issues#timeline
     """
 
     def __repr__(self):

--- a/github/Topic.py
+++ b/github/Topic.py
@@ -25,7 +25,7 @@ import github.GithubObject
 
 class Topic(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents topics as used by https://github.com/topics. The object reference can be found here https://developer.github.com/v3/search/#search-topics
+    This class represents topics as used by https://github.com/topics. The object reference can be found here https://docs.github.com/en/rest/reference/search#search-topics
     """
 
     def __repr__(self):

--- a/github/UserKey.py
+++ b/github/UserKey.py
@@ -34,7 +34,7 @@ import github.GithubObject
 
 class UserKey(github.GithubObject.CompletableGithubObject):
     """
-    This class represents UserKeys. The reference can be found here http://developer.github.com/v3/users/keys/
+    This class represents UserKeys. The reference can be found here http://docs.github.com/en/rest/reference/users#keys
     """
 
     def __repr__(self):
@@ -82,7 +82,7 @@ class UserKey(github.GithubObject.CompletableGithubObject):
 
     def delete(self):
         """
-        :calls: `DELETE /user/keys/:id <http://developer.github.com/v3/users/keys>`_
+        :calls: `DELETE /user/keys/{id} <http://docs.github.com/en/rest/reference/users#keys>`_
         :rtype: None
         """
         headers, data = self._requester.requestJsonAndCheck("DELETE", self.url)

--- a/github/View.py
+++ b/github/View.py
@@ -30,7 +30,7 @@ import github.GithubObject
 class View(github.GithubObject.NonCompletableGithubObject):
     """
     This class represents a popular Path for a GitHub repository.
-    The reference can be found here https://developer.github.com/v3/repos/traffic/
+    The reference can be found here https://docs.github.com/en/rest/reference/repos#traffic
     """
 
     def __repr__(self):

--- a/github/Workflow.py
+++ b/github/Workflow.py
@@ -26,7 +26,7 @@ import github.WorkflowRun
 
 class Workflow(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Workflows. The reference can be found here https://developer.github.com/v3/actions/workflows/
+    This class represents Workflows. The reference can be found here https://docs.github.com/en/rest/reference/actions#workflows
     """
 
     def __repr__(self):
@@ -106,7 +106,7 @@ class Workflow(github.GithubObject.CompletableGithubObject):
 
     def create_dispatch(self, ref, inputs=github.GithubObject.NotSet):
         """
-        :calls: `POST /repos/:owner/:repo/actions/workflows/:workflow_id/dispatches`_
+        :calls: `POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches <https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event>`_
         :param ref: :class:`github.Branch.Branch` or :class:`github.Tag.Tag` or :class:`github.Commit.Commit` or string
         :param inputs: dict
         :rtype: bool
@@ -139,7 +139,7 @@ class Workflow(github.GithubObject.CompletableGithubObject):
         status=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /repos/:owner/:repo/actions/workflows/:workflow_id/runs <https://developer.github.com/v3/actions/workflow-runs>`_
+        :calls: `GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs <https://docs.github.com/en/rest/reference/actions#workflow-runs>`_
         :param actor: :class:`github.NamedUser.NamedUser` or string
         :param branch: :class:`github.Branch.Branch` or string
         :param event: string

--- a/github/WorkflowRun.py
+++ b/github/WorkflowRun.py
@@ -28,7 +28,7 @@ import github.PullRequest
 
 class WorkflowRun(github.GithubObject.CompletableGithubObject):
     """
-    This class represents Workflow Runs. The reference can be found here https://developer.github.com/v3/actions/workflow-runs/
+    This class represents Workflow Runs. The reference can be found here https://docs.github.com/en/rest/reference/actions#workflow-runs
     """
 
     def __repr__(self):
@@ -220,7 +220,7 @@ class WorkflowRun(github.GithubObject.CompletableGithubObject):
 
     def cancel(self):
         """
-        :calls: `POST /repos/:owner/:repo/actions/runs/:run_id/cancel <https://developer.github.com/v3/actions/workflow-runs/>`_
+        :calls: `POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel <https://docs.github.com/en/rest/reference/actions#workflow-runs>`_
         :rtype: bool
         """
         status, _, _ = self._requester.requestJson("POST", self.cancel_url)
@@ -228,7 +228,7 @@ class WorkflowRun(github.GithubObject.CompletableGithubObject):
 
     def rerun(self):
         """
-        :calls: `POST /repos/:owner/:repo/actions/runs/:run_id/rerun <https://developer.github.com/v3/actions/workflow-runs/>`_
+        :calls: `POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun <https://docs.github.com/en/rest/reference/actions#workflow-runs>`_
         :rtype: bool
         """
         status, _, _ = self._requester.requestJson("POST", self.rerun_url)
@@ -236,7 +236,7 @@ class WorkflowRun(github.GithubObject.CompletableGithubObject):
 
     def timing(self):
         """
-        :calls: `GET /repos/:owner/:repo/actions/runs/:run_id/timing <https://developer.github.com/v3/actions/workflow-runs/>`_
+        :calls: `GET /repos/{owner}/{repo}/actions/runs/{run_id}/timing <https://docs.github.com/en/rest/reference/actions#workflow-runs>`_
         :rtype: namedtuple with billable and run_duration_ms members
         """
         headers, data = self._requester.requestJsonAndCheck("GET", f"{self.url}/timing")


### PR DESCRIPTION
Now that GitHub have moved their documentation from
developer.github.com, we should update our links. I have also tried to
update the call strings to their new format, but since it was done via
regex, some of them may not match exactly.