### PR TITLE
Fix __log mutating requestHeaders

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -51,6 +51,7 @@
 ################################################################################
 
 import base64
+import copy
 import json
 import logging
 import mimetypes
@@ -628,6 +629,7 @@ class Requester:
     def __log(self, verb, url, requestHeaders, input, status, responseHeaders, output):
         if self.__logger is None:
             self.__logger = logging.getLogger(__name__)
+        requestHeaders = copy.deepcopy(requestHeaders)
         if self.__logger.isEnabledFor(logging.DEBUG):
             if "Authorization" in requestHeaders:
                 if requestHeaders["Authorization"].startswith("Basic"):


### PR DESCRIPTION
The requester log mutates the passed request headers if the logging level includes logging. This leads to the following bug:

* log level is debug
* we perform github operation on repo
* we get HTTP 301, redirection. The request is logged..and the log method mutates the requestHeaders
* requester tries again, now to the redirected URL...but with mutated requestHeaders
* The request fails, since the auth token has been sanitized