### PR TITLE
Implement hash for CompletableGithubObject

### DIFF
--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -286,6 +286,9 @@ class CompletableGithubObject(GithubObject):
     def __eq__(self, other):
         return other.__class__ is self.__class__ and other._url.value == self._url.value
 
+    def __hash__(self):
+        return hash(self._url.value)
+
     def __ne__(self, other):
         return not self == other
 

--- a/tests/Equality.py
+++ b/tests/Equality.py
@@ -30,16 +30,14 @@ class Equality(Framework.TestCase):
     def testUserEquality(self):
         u1 = self.g.get_user("jacquev6")
         u2 = self.g.get_user("jacquev6")
-        self.assertTrue(u1 == u2)
-        self.assertFalse(u1 != u2)
         self.assertEqual(u1, u2)
+        self.assertEqual(hash(u1), hash(u2))
 
     def testUserDifference(self):
         u1 = self.g.get_user("jacquev6")
         u2 = self.g.get_user("OddBloke")
-        self.assertFalse(u1 == u2)
-        self.assertTrue(u1 != u2)
         self.assertNotEqual(u1, u2)
+        self.assertNotEqual(hash(u1), hash(u2))
 
     def testBranchEquality(self):
         # Erf, equality of NonCompletableGithubObjects will be difficult to implement


### PR DESCRIPTION
Since CompletableGithubObject already uses its URL attribute to
implement equality, extend it to also use that attribute for hashing.

Fixes #1826