### PR TITLE
Fix :rtype: directive in ProjectColumn docs

### DIFF
--- a/github/ProjectColumn.py
+++ b/github/ProjectColumn.py
@@ -125,7 +125,7 @@ class ProjectColumn(github.GithubObject.CompletableGithubObject):
         :param content_id: integer
         :param content_type: string
 
-        :rtype :class:`github.ProjectCard.ProjectCard`:
+        :rtype: :class:`github.ProjectCard.ProjectCard`:
         """
         if isinstance(note, str):
             assert content_id is github.GithubObject.NotSet, content_id


### PR DESCRIPTION
This PR fixes a missing colon after `:rtype` in the ProjectColumn docs which was causing the documentation to misrender.

<img width="542" alt="Screenshot 2021-04-23 at 10 54 42 AM" src="https://user-images.githubusercontent.com/16580576/115822523-506b8880-a422-11eb-8580-07e9c67c1a3c.png">
