### PR TITLE
Use generic for expected_type in BadAttributeException

### DIFF
--- a/github/GithubException.pyi
+++ b/github/GithubException.pyi
@@ -1,39 +1,30 @@
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union
 
 class GithubException(Exception):
-    def __init__(self, status: Union[int, str], data: Any, headers: Optional[Dict[str, str]]) -> None: ...
+    def __init__(
+        self, status: Union[int, str], data: Any, headers: Optional[Dict[str, str]]
+    ) -> None: ...
     def __str__(self) -> str: ...
     @property
     def data(self) -> Dict[str, Union[str, List[str], List[Dict[str, str]]]]: ...
     @property
     def status(self) -> int: ...
-
     @property
     def headers(self) -> Union[None, Dict[str, str]]: ...
 
-class BadAttributeException(GithubException):
+T = TypeVar("T")
+
+class BadAttributeException(GithubException, Generic[T]):
     def __init__(
         self,
         actualValue: Any,
-        expectedType: Union[
-            Dict[Tuple[Type[str], Type[str]], Type[dict]],
-            Tuple[Type[str], Type[str]],
-            List[Type[dict]],
-            List[Tuple[Type[str], Type[str]]],
-        ],
+        expectedType: T,
         transformationException: Optional[ValueError],
     ) -> None: ...
     @property
     def actual_value(self) -> Any: ...
     @property
-    def expected_type(
-        self,
-    ) -> Union[
-        List[Type[dict]],
-        Tuple[Type[str], Type[str]],
-        Dict[Tuple[Type[str], Type[str]], Type[dict]],
-        List[Tuple[Type[str], Type[str]]],
-    ]: ...
+    def expected_type(self) -> T: ...
     @property
     def transformation_exception(self) -> Optional[ValueError]: ...
 


### PR DESCRIPTION
The expected_type return value is bound to expected_type argument on
init.  This will type the return of expected_type to the type passed to
the init function.

I'm choosing to not bind TypeVar to anything explicit, as in theory
the exception should not be limited to any specific expected type, and
the union quickly balloons and was already significant.

This fixes the implicit Any generic dict in Type[dict], that turns into
Type[dict[Any, Any]] and is disallowed when setting
--disallow-any-generics (this still allows explicitly defined Any
generics).  The generic also means consumption of the returned value
doesn't require handling all listed types in the Union as the type will
be specifically the type of expected_type.

Included is a couple lines of black formatting as they occurred on
write and are insignificant in number.