### PR TITLE
Add type to OrderedDict

### DIFF
--- a/github/Requester.pyi
+++ b/github/Requester.pyi
@@ -158,7 +158,7 @@ class Requester:
         url: str,
         parameters: Optional[Dict[str, Any]] = ...,
         headers: Optional[Dict[str, Any]] = ...,
-        input: Optional[OrderedDict] = ...,
+        input: Optional[OrderedDict[str, str]] = ...,
         cnx: Optional[
             Union[HTTPRequestsConnectionClass, HTTPSRequestsConnectionClass]
         ] = ...,
@@ -169,7 +169,7 @@ class Requester:
         url: str,
         parameters: Optional[Dict[str, Any]] = ...,
         headers: Optional[Dict[str, Any]] = ...,
-        input: Optional[OrderedDict] = ...,
+        input: Optional[OrderedDict[str, str]] = ...,
     ) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]: ...
     @classmethod
     def resetConnectionClasses(cls) -> None: ...


### PR DESCRIPTION
OrderedDict needs to be typed just like Dict needs to be typed.  The
OrderedDict "input" variable key and value are used to append to a
string without any processing, so it seems unlikely that something other
than a string would be valid.