### PR TITLE
Remove language_version for black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
     rev: 20.8b1
     hooks:
       - id: black
-        language_version: python3.6
   - repo: https://github.com/asottile/seed-isort-config
     rev: v1.9.4
     hooks:


### PR DESCRIPTION
When black was added, we did not want to run it under Python 3.5, since
upstream did not support it. We no longer support Python 3.5 ourselves,
so we no longer need to restrict the version black uses.