### PR TITLE
Add types libraries to lint deps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,8 @@ commands = pytest --cov=github --cov-report=xml {posargs}
 basepython = python3.6
 skip_install = true
 deps =
+    types-jwt
+    types-requests
     pre-commit
     mypy
 commands =


### PR DESCRIPTION
It appears recently that typing information for jwt and requests has
been split out into seperate projects on pypi, namely types-jwt and
types-requests. Since we utilise calling functions in their namespace,
we need to install them otherwise mypy will fail.