### PR TITLE
Fix missing parameter to exceptions in GithubIntegration

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -843,6 +843,7 @@ class GithubIntegration:
             },
             json=body,
         )
+        response_headers = {k.lower(): v for k, v in response.headers.items()}
 
         if response.status_code == 201:
             return InstallationAuthorization.InstallationAuthorization(
@@ -853,14 +854,18 @@ class GithubIntegration:
             )
         elif response.status_code == 403:
             raise GithubException.BadCredentialsException(
-                status=response.status_code, data=response.text
+                status=response.status_code,
+                data=response.text,
+                headers=response_headers,
             )
         elif response.status_code == 404:
             raise GithubException.UnknownObjectException(
-                status=response.status_code, data=response.text
+                status=response.status_code,
+                data=response.text,
+                headers=response_headers,
             )
         raise GithubException.GithubException(
-            status=response.status_code, data=response.text
+            status=response.status_code, data=response.text, headers=response_headers
         )
 
     def get_installation(self, owner, repo):

--- a/tests/GithubIntegration.py
+++ b/tests/GithubIntegration.py
@@ -64,6 +64,10 @@ class GithubIntegration(unittest.TestCase):
                 return json.loads(self.text)
 
             @property
+            def headers(self):
+                return {"foo": "bar"}
+
+            @property
             def text(self):
                 return (
                     '{"token": "v1.ce63424bc55028318325caac4f4c3a5378ca0038",'


### PR DESCRIPTION
It looks like these instantiations of GithubException were missed when
adding the new required "headers" parameter in ddd437a7c.