### PR TITLE
Fix: #1671 Convert Python Bool to API Parameter for Authenticated User Notifications

### DIFF
--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -973,9 +973,11 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
         params = dict()
         if all is not github.GithubObject.NotSet:
-            params["all"] = all
+            # convert True, False to true, false for api parameters
+            params["all"] = str(all).lower() if isinstance(all, bool) else all
         if participating is not github.GithubObject.NotSet:
-            params["participating"] = participating
+            # convert True, False to true, false for api parameters
+            params["participating"] = str(participating).lower() if isinstance(participating, bool) else participating
         if since is not github.GithubObject.NotSet:
             params["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
         if before is not github.GithubObject.NotSet:


### PR DESCRIPTION
Converts Python Bools `all` and `participating` to lower case string that are valid API parameters.  
`True` is converted to `"true"`