### PR TITLE
tox.ini: Ignoring long lines and setting max-line-length?

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ deps = -rrequirements.txt
 commands = sphinx-build doc build
 
 [flake8]
-max-line-length = 88
+max-line-length = 1109
 select = C,E,F,W
 ignore = E266, W503
 

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands = sphinx-build doc build
 [flake8]
 max-line-length = 88
 select = C,E,F,W
-ignore = E266, E501, W503
+ignore = E266, W503
 
 [mypy]
 python_version = 3.6


### PR DESCRIPTION
Better to set flake8 `max-line-length` to the actual value to discourage contributors from adding even longer lines.