### PR TITLE
link to GH docs fixed: rate_limit → rate-limit

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -195,7 +195,7 @@ class Github:
         """
         Rate limit status for different resources (core/search/graphql).
 
-        :calls: `GET /rate_limit <http://docs.github.com/en/rest/reference/rate_limit>`_
+        :calls: `GET /rate_limit <http://docs.github.com/en/rest/reference/rate-limit>`_
         :rtype: :class:`github.RateLimit.RateLimit`
         """
         headers, data = self.__requester.requestJsonAndCheck("GET", "/rate_limit")

--- a/github/Rate.py
+++ b/github/Rate.py
@@ -30,7 +30,7 @@ import github.GithubObject
 
 class Rate(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents Rates. The reference can be found here http://docs.github.com/en/rest/reference/rate_limit
+    This class represents Rates. The reference can be found here http://docs.github.com/en/rest/reference/rate-limit
     """
 
     def __repr__(self):

--- a/github/RateLimit.py
+++ b/github/RateLimit.py
@@ -31,7 +31,7 @@ import github.Rate
 
 class RateLimit(github.GithubObject.NonCompletableGithubObject):
     """
-    This class represents RateLimits. The reference can be found here http://docs.github.com/en/rest/reference/rate_limit
+    This class represents RateLimits. The reference can be found here http://docs.github.com/en/rest/reference/rate-limit
     """
 
     def __repr__(self):


### PR DESCRIPTION
http://docs.github.com/en/rest/reference/rate_limit does not work for me, while http://docs.github.com/en/rest/reference/rate-limit does.
So I used `grep -R "docs.github.com/en/rest/reference/rate_limit"` to find and update all occurrences of that URL. :)
