### PR TITLE
create_secret: also return true for status 204

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1435,7 +1435,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         status, headers, data = self._requester.requestJson(
             "PUT", f"{self.url}/actions/secrets/{secret_name}", input=put_parameters
         )
-        return status == 201
+        return status == 201 or status == 204
 
     def delete_secret(self, secret_name):
         """


### PR DESCRIPTION
204 is the status code for updating. Right now updated secrets
return `False` which doesn't distinguish between successful
and failed operations
https://docs.github.com/en/rest/reference/actions#create-or-update-a-repository-secret

> Response when creating a secret
>  Status: 201 Created
>Response when updating a secret
>  Status: 204 No Content