### PR TITLE
The install commands error

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -38,7 +38,7 @@ be enough.  You can also clone it on `Github
 <http://github.com/PyGithub/PyGithub>`__.
 
 If you wish to use GitHub Integrations, you'll want to be sure to install the
-'integrations' option: ``pip install PyGithub['integrations']``
+'integrations' option: ``pip install PyGithub[integrations]``
 
 Licensing
 ---------


### PR DESCRIPTION
It should be pip install PyGithub[integrations] not pip install PyGithub['integrations']