### PR TITLE
Add support to pass proxies during object init.

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -104,6 +104,7 @@ class Github:
         verify=True,
         retry=None,
         pool_size=None,
+        proxies=None,
     ):
         """
         :param login_or_token: string
@@ -140,6 +141,7 @@ class Github:
             verify,
             retry,
             pool_size,
+            proxies
         )
 
     @property

--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -141,7 +141,7 @@ class Github:
             verify,
             retry,
             pool_size,
-            proxies
+            proxies,
         )
 
     @property

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -89,6 +89,7 @@ class HTTPSRequestsConnectionClass:
         timeout=None,
         retry=None,
         pool_size=None,
+        proxies=None,
         **kwargs,
     ):
         self.port = port if port else 443
@@ -97,6 +98,8 @@ class HTTPSRequestsConnectionClass:
         self.timeout = timeout
         self.verify = kwargs.get("verify", True)
         self.session = requests.Session()
+        if proxies:
+            self.session.proxies = proxies
 
         if retry is None:
             self.retry = requests.adapters.DEFAULT_RETRIES
@@ -148,6 +151,7 @@ class HTTPRequestsConnectionClass:
         timeout=None,
         retry=None,
         pool_size=None,
+        proxies=None,
         **kwargs,
     ):
         self.port = port if port else 80
@@ -156,6 +160,8 @@ class HTTPRequestsConnectionClass:
         self.timeout = timeout
         self.verify = kwargs.get("verify", True)
         self.session = requests.Session()
+        if proxies:
+            self.session.proxies = proxies
 
         if retry is None:
             self.retry = requests.adapters.DEFAULT_RETRIES
@@ -301,6 +307,7 @@ class Requester:
         verify,
         retry,
         pool_size,
+        proxies
     ):
         self._initializeDebugFeature()
 
@@ -329,6 +336,8 @@ class Requester:
         self.__retry = retry  # NOTE: retry can be either int or an urllib3 Retry object
         self.__pool_size = pool_size
         self.__scheme = o.scheme
+        self.__proxies = proxies
+
         if o.scheme == "https":
             self.__connectionClass = self.__httpsConnectionClass
         elif o.scheme == "http":
@@ -396,6 +405,7 @@ class Requester:
                         o.port,
                         retry=self.__retry,
                         pool_size=self.__pool_size,
+                        proxies=self.__proxies
                     )
                 elif o.scheme == "https":
                     cnx = self.__httpsConnectionClass(
@@ -403,6 +413,7 @@ class Requester:
                         o.port,
                         retry=self.__retry,
                         pool_size=self.__pool_size,
+                        proxies=self.__proxies
                     )
         return cnx
 
@@ -620,6 +631,7 @@ class Requester:
             self.__port,
             retry=self.__retry,
             pool_size=self.__pool_size,
+            proxies=self.__proxies,
             **kwds,
         )
 

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -307,7 +307,7 @@ class Requester:
         verify,
         retry,
         pool_size,
-        proxies
+        proxies,
     ):
         self._initializeDebugFeature()
 
@@ -405,7 +405,7 @@ class Requester:
                         o.port,
                         retry=self.__retry,
                         pool_size=self.__pool_size,
-                        proxies=self.__proxies
+                        proxies=self.__proxies,
                     )
                 elif o.scheme == "https":
                     cnx = self.__httpsConnectionClass(
@@ -413,7 +413,7 @@ class Requester:
                         o.port,
                         retry=self.__retry,
                         pool_size=self.__pool_size,
-                        proxies=self.__proxies
+                        proxies=self.__proxies,
                     )
         return cnx
 

--- a/github/Requester.pyi
+++ b/github/Requester.pyi
@@ -16,6 +16,7 @@ class HTTPRequestsConnectionClass:
         strict: bool = ...,
         timeout: Optional[int] = ...,
         retry: Any = ...,
+        proxies: Optional[dict] = None,
         **kwargs: str
     ) -> None: ...
     def close(self) -> None: ...
@@ -32,6 +33,7 @@ class HTTPSRequestsConnectionClass:
         strict: bool = ...,
         timeout: Optional[int] = ...,
         retry: Any = ...,
+        proxies: Optional[dict] = None,
         **kwargs: str
     ) -> None: ...
     def close(self) -> None: ...
@@ -107,6 +109,7 @@ class Requester:
         per_page: int,
         verify: bool,
         retry: Any,
+        proxies: Optional[dict]
     ) -> None: ...
     def _initializeDebugFeature(self) -> None: ...
     def check_me(self, obj: GithubObject) -> None: ...


### PR DESCRIPTION
This change allows to pass a proxy dict to Github class during object init. I needed a way to pass proxies since we are behind proxies, and this change works for us. I see other users were looking for a similar fix.

The new arg is `proxies` passed as a dict `{'http':'http://proxy.domain.som:80', 'https':'http://proxy.domain.com:80}`