### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: test (Python ${{ matrix.python-version }})
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
             "Topic :: Software Development",
         ],
         python_requires=">=3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint,
-    py{36,37,38,39},
+    py{36,37,38,39,310},
     docs
 
 [gh-actions]
@@ -10,6 +10,7 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [testenv]
 deps = -rtest-requirements.txt


### PR DESCRIPTION
Now that Python 3.10 has been released, we should test it in CI.