### PR TITLE
Fix AuthenticatedUser ReplayData with parameters

### DIFF
--- a/tests/ReplayData/AuthenticatedUser.testGetNotifications.txt
+++ b/tests/ReplayData/AuthenticatedUser.testGetNotifications.txt
@@ -2,7 +2,7 @@ https
 GET
 api.github.com
 None
-/notifications?participating=True
+/notifications?participating=true
 {'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 None
 200

--- a/tests/ReplayData/AuthenticatedUser.testGetNotificationsWithOtherArguments.txt
+++ b/tests/ReplayData/AuthenticatedUser.testGetNotificationsWithOtherArguments.txt
@@ -2,7 +2,7 @@ https
 GET
 api.github.com
 None
-/notifications?all=True
+/notifications?all=true
 {'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 None
 200


### PR DESCRIPTION
A recently merged change modified AuthenticatedUser.get_notifications()
in how it passes boolean parameters, but did not modify the replay data.
Do so now.