### PR TITLE
Move lint and docs to Python 3.8

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,6 @@ sphinx:
   configuration: doc/conf.py
 
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,9 @@ envlist =
 
 [gh-actions]
 python =
-    3.6: py36, docs, lint
+    3.6: py36
     3.7: py37
-    3.8: py38
+    3.8: py38, docs, lint
     3.9: py39
     3.10: py310
 
@@ -17,7 +17,7 @@ deps = -rtest-requirements.txt
 commands = pytest --cov=github --cov-report=xml {posargs}
 
 [testenv:lint]
-basepython = python3.6
+basepython = python3.8
 skip_install = true
 deps =
     types-jwt
@@ -31,7 +31,7 @@ commands =
     mypy github tests
 
 [testenv:docs]
-basepython = python3.6
+basepython = python3.8
 skip_install = true
 deps = -rrequirements.txt
 commands = sphinx-build doc build
@@ -42,6 +42,6 @@ select = C,E,F,W
 ignore = E266, E501, W503
 
 [mypy]
-python_version = 3.6
+python_version = 3.8
 ignore_missing_imports = True
 namespace_packages = True


### PR DESCRIPTION
With Python 3.6 rapidly approaching end of life, move the docs and lint
tox targets to Python 3.8, and also switch readthedocs to match.