### PR TITLE
Fix replay data for Organization.create_secret()

### DIFF
--- a/tests/ReplayData/Organization.testCreateSecretSelected.txt
+++ b/tests/ReplayData/Organization.testCreateSecretSelected.txt
@@ -3,7 +3,7 @@ GET
 api.github.com
 None
 /repos/BeaverSoftware/TestPyGithub
-{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python', 'Accept': 'application/vnd.github.nebula-preview+json'}
 None
 200
 [('status', '200 OK'), ('x-ratelimit-remaining', '4992'), ('content-length', '1431'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"4ecd2c151a469cfa6cd45e6beff1269b"'), ('date', 'Fri, 01 Jun 2012 19:40:56 GMT'), ('content-type', 'application/json; charset=utf-8')]
@@ -14,7 +14,7 @@ GET
 api.github.com
 None
 /repos/BeaverSoftware/FatherBeaver
-{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python', 'Accept': 'application/vnd.github.nebula-preview+json'}
 None
 200
 [('status', '200 OK'), ('x-ratelimit-remaining', '4992'), ('content-length', '1431'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"4ecd2c151a469cfa6cd45e6beff1269b"'), ('date', 'Fri, 01 Jun 2012 19:40:56 GMT'), ('content-type', 'application/json; charset=utf-8')]


### PR DESCRIPTION
A recently merged PR added a const, which will be used when fetching
repositories. Update replay data for a test that was not included in
that change.