### PR TITLE
Raise a `RateLimitExceededException` when a secondary rate limit is hit

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -424,6 +424,9 @@ class Requester:
             or output.get("message")
             .lower()
             .endswith("please wait a few minutes before you try again.")
+            or output.get("message")
+            .lower()
+            .startswith("you have exceeded a secondary rate limit")
         ):
             cls = GithubException.RateLimitExceededException
         elif status == 404 and output.get("message") == "Not Found":

--- a/tests/Exceptions.py
+++ b/tests/Exceptions.py
@@ -133,6 +133,17 @@ class SpecificExceptions(Framework.TestCase):
 
         self.assertRaises(github.RateLimitExceededException, exceed)
 
+    def testSecondaryRateLimitExceeded(self):
+        g = github.Github()
+
+        def exceed():
+            for i in range(100):
+                g.get_user("jacquev6")
+
+        self.assertRaisesRegexp(
+            github.RateLimitExceededException, ".*secondary rate limit.*", exceed
+        )
+
     def testAuthenticatedRateLimitExceeded(self):
         def exceed():
             for i in range(100):

--- a/tests/ReplayData/SpecificExceptions.testSecondaryRateLimitExceeded.txt
+++ b/tests/ReplayData/SpecificExceptions.testSecondaryRateLimitExceeded.txt
@@ -1,0 +1,55 @@
+https
+GET
+api.github.com
+None
+/users/jacquev6
+{'User-Agent': 'PyGithub/Python'}
+None
+200
+[('status', '200 OK'), ('x-ratelimit-remaining', '2'), ('x-github-media-type', 'github.beta; format=json'), ('x-content-type-options', 'nosniff'), ('access-control-expose-headers', 'Link, X-RateLimit-Limit, X-RateLimit-Remaining, X-OAuth-Scopes, X-Accepted-OAuth-Scopes'), ('access-control-allow-credentials', 'true'), ('vary', 'Accept, Accept-Encoding'), ('content-length', '1299'), ('server', 'GitHub.com'), ('last-modified', 'Fri, 17 May 2013 12:09:51 GMT'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '60'), ('etag', '"de9347ae9c0c83b44d6c81d05aba4877"'), ('cache-control', 'public, max-age=60, s-maxage=60'), ('date', 'Fri, 17 May 2013 12:23:52 GMT'), ('access-control-allow-origin', '*'), ('content-type', 'application/json; charset=utf-8')]
+{"login":"jacquev6","id":327146,"avatar_url":"https://secure.gravatar.com/avatar/b68de5ae38616c296fa345d2b9df2225?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png","gravatar_id":"b68de5ae38616c296fa345d2b9df2225","url":"https://api.github.com/users/jacquev6","html_url":"https://github.com/jacquev6","followers_url":"https://api.github.com/users/jacquev6/followers","following_url":"https://api.github.com/users/jacquev6/following{/other_user}","gists_url":"https://api.github.com/users/jacquev6/gists{/gist_id}","starred_url":"https://api.github.com/users/jacquev6/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jacquev6/subscriptions","organizations_url":"https://api.github.com/users/jacquev6/orgs","repos_url":"https://api.github.com/users/jacquev6/repos","events_url":"https://api.github.com/users/jacquev6/events{/privacy}","received_events_url":"https://api.github.com/users/jacquev6/received_events","type":"User","name":"Vincent Jacques","company":"Criteo","blog":"http://vincent-jacques.net","location":"Paris, France","email":"vincent@vincent-jacques.net","hireable":false,"bio":"","public_repos":16,"followers":27,"following":39,"created_at":"2010-07-09T06:10:06Z","updated_at":"2013-05-17T12:09:51Z","public_gists":3}
+
+https
+GET
+api.github.com
+None
+/users/jacquev6
+{'User-Agent': 'PyGithub/Python'}
+None
+200
+[('status', '200 OK'), ('x-ratelimit-remaining', '1'), ('x-github-media-type', 'github.beta; format=json'), ('x-content-type-options', 'nosniff'), ('access-control-expose-headers', 'Link, X-RateLimit-Limit, X-RateLimit-Remaining, X-OAuth-Scopes, X-Accepted-OAuth-Scopes'), ('access-control-allow-credentials', 'true'), ('vary', 'Accept, Accept-Encoding'), ('content-length', '1299'), ('server', 'GitHub.com'), ('last-modified', 'Fri, 17 May 2013 12:09:51 GMT'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '60'), ('etag', '"de9347ae9c0c83b44d6c81d05aba4877"'), ('cache-control', 'public, max-age=60, s-maxage=60'), ('date', 'Fri, 17 May 2013 12:23:53 GMT'), ('access-control-allow-origin', '*'), ('content-type', 'application/json; charset=utf-8')]
+{"login":"jacquev6","id":327146,"avatar_url":"https://secure.gravatar.com/avatar/b68de5ae38616c296fa345d2b9df2225?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png","gravatar_id":"b68de5ae38616c296fa345d2b9df2225","url":"https://api.github.com/users/jacquev6","html_url":"https://github.com/jacquev6","followers_url":"https://api.github.com/users/jacquev6/followers","following_url":"https://api.github.com/users/jacquev6/following{/other_user}","gists_url":"https://api.github.com/users/jacquev6/gists{/gist_id}","starred_url":"https://api.github.com/users/jacquev6/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jacquev6/subscriptions","organizations_url":"https://api.github.com/users/jacquev6/orgs","repos_url":"https://api.github.com/users/jacquev6/repos","events_url":"https://api.github.com/users/jacquev6/events{/privacy}","received_events_url":"https://api.github.com/users/jacquev6/received_events","type":"User","name":"Vincent Jacques","company":"Criteo","blog":"http://vincent-jacques.net","location":"Paris, France","email":"vincent@vincent-jacques.net","hireable":false,"bio":"","public_repos":16,"followers":27,"following":39,"created_at":"2010-07-09T06:10:06Z","updated_at":"2013-05-17T12:09:51Z","public_gists":3}
+
+https
+GET
+api.github.com
+None
+/users/jacquev6
+{'User-Agent': 'PyGithub/Python'}
+None
+200
+[('status', '200 OK'), ('x-ratelimit-remaining', '0'), ('x-github-media-type', 'github.beta; format=json'), ('x-content-type-options', 'nosniff'), ('access-control-expose-headers', 'Link, X-RateLimit-Limit, X-RateLimit-Remaining, X-OAuth-Scopes, X-Accepted-OAuth-Scopes'), ('access-control-allow-credentials', 'true'), ('vary', 'Accept, Accept-Encoding'), ('content-length', '1299'), ('server', 'GitHub.com'), ('last-modified', 'Fri, 17 May 2013 12:09:51 GMT'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '60'), ('etag', '"de9347ae9c0c83b44d6c81d05aba4877"'), ('cache-control', 'public, max-age=60, s-maxage=60'), ('date', 'Fri, 17 May 2013 12:23:54 GMT'), ('access-control-allow-origin', '*'), ('content-type', 'application/json; charset=utf-8')]
+{"login":"jacquev6","id":327146,"avatar_url":"https://secure.gravatar.com/avatar/b68de5ae38616c296fa345d2b9df2225?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png","gravatar_id":"b68de5ae38616c296fa345d2b9df2225","url":"https://api.github.com/users/jacquev6","html_url":"https://github.com/jacquev6","followers_url":"https://api.github.com/users/jacquev6/followers","following_url":"https://api.github.com/users/jacquev6/following{/other_user}","gists_url":"https://api.github.com/users/jacquev6/gists{/gist_id}","starred_url":"https://api.github.com/users/jacquev6/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jacquev6/subscriptions","organizations_url":"https://api.github.com/users/jacquev6/orgs","repos_url":"https://api.github.com/users/jacquev6/repos","events_url":"https://api.github.com/users/jacquev6/events{/privacy}","received_events_url":"https://api.github.com/users/jacquev6/received_events","type":"User","name":"Vincent Jacques","company":"Criteo","blog":"http://vincent-jacques.net","location":"Paris, France","email":"vincent@vincent-jacques.net","hireable":false,"bio":"","public_repos":16,"followers":27,"following":39,"created_at":"2010-07-09T06:10:06Z","updated_at":"2013-05-17T12:09:51Z","public_gists":3}
+
+https
+GET
+api.github.com
+None
+/users/jacquev6
+{'User-Agent': 'PyGithub/Python'}
+None
+200
+[('status', '200 OK'), ('x-ratelimit-remaining', '0'), ('x-github-media-type', 'github.beta; format=json'), ('x-content-type-options', 'nosniff'), ('access-control-expose-headers', 'Link, X-RateLimit-Limit, X-RateLimit-Remaining, X-OAuth-Scopes, X-Accepted-OAuth-Scopes'), ('access-control-allow-credentials', 'true'), ('vary', 'Accept, Accept-Encoding'), ('content-length', '1299'), ('server', 'GitHub.com'), ('last-modified', 'Fri, 17 May 2013 12:09:51 GMT'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '60'), ('etag', '"de9347ae9c0c83b44d6c81d05aba4877"'), ('cache-control', 'public, max-age=60, s-maxage=60'), ('date', 'Fri, 17 May 2013 12:23:55 GMT'), ('access-control-allow-origin', '*'), ('content-type', 'application/json; charset=utf-8')]
+{"login":"jacquev6","id":327146,"avatar_url":"https://secure.gravatar.com/avatar/b68de5ae38616c296fa345d2b9df2225?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png","gravatar_id":"b68de5ae38616c296fa345d2b9df2225","url":"https://api.github.com/users/jacquev6","html_url":"https://github.com/jacquev6","followers_url":"https://api.github.com/users/jacquev6/followers","following_url":"https://api.github.com/users/jacquev6/following{/other_user}","gists_url":"https://api.github.com/users/jacquev6/gists{/gist_id}","starred_url":"https://api.github.com/users/jacquev6/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/jacquev6/subscriptions","organizations_url":"https://api.github.com/users/jacquev6/orgs","repos_url":"https://api.github.com/users/jacquev6/repos","events_url":"https://api.github.com/users/jacquev6/events{/privacy}","received_events_url":"https://api.github.com/users/jacquev6/received_events","type":"User","name":"Vincent Jacques","company":"Criteo","blog":"http://vincent-jacques.net","location":"Paris, France","email":"vincent@vincent-jacques.net","hireable":false,"bio":"","public_repos":16,"followers":27,"following":39,"created_at":"2010-07-09T06:10:06Z","updated_at":"2013-05-17T12:09:51Z","public_gists":3}
+
+https
+GET
+api.github.com
+None
+/users/jacquev6
+{'User-Agent': 'PyGithub/Python'}
+None
+403
+[('status', '403 Forbidden'), ('x-ratelimit-remaining', '0'), ('x-github-media-type', 'github.beta; format=json'), ('x-content-type-options', 'nosniff'), ('access-control-expose-headers', 'Link, X-RateLimit-Limit, X-RateLimit-Remaining, X-OAuth-Scopes, X-Accepted-OAuth-Scopes'), ('content-length', '56'), ('server', 'GitHub.com'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '60'), ('access-control-allow-credentials', 'true'), ('date', 'Fri, 17 May 2013 12:23:56 GMT'), ('access-control-allow-origin', '*'), ('content-type', 'application/json; charset=utf-8')]
+{"message":"You have exceeded a secondary rate limit and have been temporarily blocked from content creation. Please retry your request again later."}
+


### PR DESCRIPTION
I have been writing some new code that ended up hitting github's secondary rate limit,
and was confused why it was being returned as a generic `GithubException` instead of a `RateLimitExceededException`.

I dug into the code, figured out why, and put together this patch.

Let me know if there's anything I can do to improve it, especially with the replay data