### PR TITLE
update github api docs URL for Repository metrics and statistics

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -2957,7 +2957,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_stats_contributors(self):
         """
-        :calls: `GET /repos/{owner}/{repo}/stats/contributors <https://docs.github.com/en/rest/reference/repos#get-all-contributor-commit-activity>`_
+        :calls: `GET /repos/{owner}/{repo}/stats/contributors <https://docs.github.com/en/rest/reference/repository-metrics#get-all-contributor-commit-activity>`_
         :rtype: None or list of :class:`github.StatsContributor.StatsContributor`
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -2975,7 +2975,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_stats_commit_activity(self):
         """
-        :calls: `GET /repos/{owner}/{repo}/stats/commit_activity <https://docs.github.com/en/rest/reference/repos#get-the-last-year-of-commit-activity>`_
+        :calls: `GET /repos/{owner}/{repo}/stats/commit_activity <https://docs.github.com/en/rest/reference/repository-metrics#get-the-last-year-of-commit-activity>`_
         :rtype: None or list of :class:`github.StatsCommitActivity.StatsCommitActivity`
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -2993,7 +2993,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_stats_code_frequency(self):
         """
-        :calls: `GET /repos/{owner}/{repo}/stats/code_frequency <https://docs.github.com/en/rest/reference/repos#get-the-weekly-commit-activity>`_
+        :calls: `GET /repos/{owner}/{repo}/stats/code_frequency <https://docs.github.com/en/rest/reference/repository-metrics#get-the-weekly-commit-activity>`_
         :rtype: None or list of :class:`github.StatsCodeFrequency.StatsCodeFrequency`
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -3011,7 +3011,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_stats_participation(self):
         """
-        :calls: `GET /repos/{owner}/{repo}/stats/participation <https://docs.github.com/en/rest/reference/repos#get-the-weekly-commit-count>`_
+        :calls: `GET /repos/{owner}/{repo}/stats/participation <https://docs.github.com/en/rest/reference/repository-metrics#get-the-weekly-commit-count>`_
         :rtype: None or :class:`github.StatsParticipation.StatsParticipation`
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -3026,7 +3026,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_stats_punch_card(self):
         """
-        :calls: `GET /repos/{owner}/{repo}/stats/punch_card <https://docs.github.com/en/rest/reference/repos#get-the-hourly-commit-count-for-each-day>`_
+        :calls: `GET /repos/{owner}/{repo}/stats/punch_card <https://docs.github.com/en/rest/reference/repository-metrics#get-the-hourly-commit-count-for-each-day>`_
         :rtype: None or :class:`github.StatsPunchCard.StatsPunchCard`
         """
         headers, data = self._requester.requestJsonAndCheck(

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1974,7 +1974,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_top_referrers(self):
         """
-        :calls: `GET /repos/{owner}/{repo}/traffic/popular/referrers <https://docs.github.com/en/rest/reference/repos#traffic>`_
+        :calls: `GET /repos/{owner}/{repo}/traffic/popular/referrers <https://docs.github.com/en/rest/reference/repository-metrics#get-top-referral-sources>`_
         :rtype: :class:`list` of :class:`github.Referrer.Referrer`
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -1988,7 +1988,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_top_paths(self):
         """
-        :calls: `GET /repos/{owner}/{repo}/traffic/popular/paths <https://docs.github.com/en/rest/reference/repos#traffic>`_
+        :calls: `GET /repos/{owner}/{repo}/traffic/popular/paths <https://docs.github.com/en/rest/reference/repository-metrics#get-top-referral-paths>`_
         :rtype: :class:`list` of :class:`github.Path.Path`
         """
         headers, data = self._requester.requestJsonAndCheck(
@@ -2002,7 +2002,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_views_traffic(self, per=github.GithubObject.NotSet):
         """
-        :calls: `GET /repos/{owner}/{repo}/traffic/views <https://docs.github.com/en/rest/reference/repos#traffic>`_
+        :calls: `GET /repos/{owner}/{repo}/traffic/views <https://docs.github.com/en/rest/reference/repository-metrics#get-page-views>`_
         :param per: string, must be one of day or week, day by default
         :rtype: None or list of :class:`github.View.View`
         """
@@ -2028,7 +2028,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_clones_traffic(self, per=github.GithubObject.NotSet):
         """
-        :calls: `GET /repos/{owner}/{repo}/traffic/clones <https://docs.github.com/en/rest/reference/repos#traffic>`_
+        :calls: `GET /repos/{owner}/{repo}/traffic/clones <https://docs.github.com/en/rest/reference/repository-metrics#get-repository-clones>`_
         :param per: string, must be one of day or week, day by default
         :rtype: None or list of :class:`github.Clones.Clones`
         """

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -3050,7 +3050,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_tags(self):
         """
-        :calls: `GET /repos/{owner}/{repo}/tags <https://docs.github.com/en/rest/reference/repos>`_
+        :calls: `GET /repos/{owner}/{repo}/tags <https://docs.github.com/en/rest/reference/repos#list-repository-tags>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Tag.Tag`
         """
         return github.PaginatedList.PaginatedList(


### PR DESCRIPTION
docs.github.com moves these api docs to page https://docs.github.com/en/rest/reference/repository-metrics