### PR TITLE
Please add my GitHub action to your projects section

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -76,6 +76,7 @@ Projects using PyGithub
 * https://github.com/plus3it/satsuki - Automate GitHub releases and uploading binary release assets
 * `check-in <https://github.com/webknjaz/check-in>`_ — Python CLI distribution that allows user to use GitHub Checks API as a bot.
 * https://github.com/hasii2011/gittodoistclone - Convert GitHub issues to Todoist tasks
+* https://github.com/EnricoMi/publish-unit-test-result-action>` - A GitHub Action that publishes test results on GitHub.
  
 They talk about PyGithub
 ------------------------


### PR DESCRIPTION
My [GitHub action](https://github.com/EnricoMi/publish-unit-test-result-action) uses PyGithub to publish test results from a GitHub CI workflow to GitHub pull requests or commit check statuses.

Please add it to the list of projects in the introduction section.