### PR TITLE
Remove enableRetry and setPoolSize from Framework

### DIFF
--- a/tests/Framework.py
+++ b/tests/Framework.py
@@ -363,6 +363,8 @@ class TestCase(BasicTestCase):
 
 # methods like these should only be used for test session wide setups
 # not individual tests as values set here will escape tests and impact subsequent tests
+# see https://github.com/PyGithub/PyGithub/pull/2147
+
 
 def activateRecordMode():  # pragma no cover (Function useful only when recording new tests, not used during automated tests)
     BasicTestCase.recordMode = True

--- a/tests/Framework.py
+++ b/tests/Framework.py
@@ -361,6 +361,9 @@ class TestCase(BasicTestCase):
             )
 
 
+# methods like these should only be used for test session wide setups
+# not individual tests as values set here will escape tests and impact subsequent tests
+
 def activateRecordMode():  # pragma no cover (Function useful only when recording new tests, not used during automated tests)
     BasicTestCase.recordMode = True
 
@@ -371,11 +374,3 @@ def activateTokenAuthMode():  # pragma no cover (Function useful only when recor
 
 def activateJWTAuthMode():  # pragma no cover (Function useful only when recording new tests, not used during automated tests)
     BasicTestCase.jwtAuthMode = True
-
-
-def enableRetry(retry):
-    BasicTestCase.retry = retry
-
-
-def setPoolSize(pool_size):
-    BasicTestCase.pool_size = pool_size

--- a/tests/PoolSize.py
+++ b/tests/PoolSize.py
@@ -7,7 +7,7 @@ REPO_NAME = "PyGithub/PyGithub"
 
 class PoolSize(Framework.TestCase):
     def setUp(self):
-        Framework.setPoolSize(20)
+        self.pool_size = 20
         super().setUp()
 
     def testReturnsRepoAfterSettingPoolSize(self):

--- a/tests/Retry.py
+++ b/tests/Retry.py
@@ -43,7 +43,7 @@ class Retry(Framework.TestCase):
             total=3, read=3, connect=3, status_forcelist=status_forcelist
         )
 
-        Framework.enableRetry(retry)
+        self.retry = retry
         super().setUp()
 
     def testShouldNotRetryWhenStatusNotOnList(self):


### PR DESCRIPTION
Using these methods in a test has side-effects on subsequent tests.

For instance, after calling `Framework.setPoolSize(20)` in test `PollSize.py`, all subsequent tests run with `Github.__requester.__pool_size = 20`. All tests before `PoolSize.py` run with `Github.__requester.__pool_size = None`.

The same holds for `Framework.enableRetry`.

Added a comment to avoid adding similar methods in the future (as I was about to do for `per_page`, which escaped and broke all subsequent tests).