### PR TITLE
bypass pr review user team

### DIFF
--- a/github/Branch.py
+++ b/github/Branch.py
@@ -114,6 +114,8 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         strict=github.GithubObject.NotSet,
         contexts=github.GithubObject.NotSet,
         enforce_admins=github.GithubObject.NotSet,
+        bypass_pull_request_users=github.GithubObject.NotSet,
+        bypass_pull_request_teams=github.GithubObject.NotSet,
         dismissal_users=github.GithubObject.NotSet,
         dismissal_teams=github.GithubObject.NotSet,
         dismiss_stale_reviews=github.GithubObject.NotSet,
@@ -127,6 +129,8 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         :strict: bool
         :contexts: list of strings
         :enforce_admins: bool
+        :bypass_pull_request_users: list of strings
+        :bypass_pull_request_teams: list of strings
         :dismissal_users: list of strings
         :dismissal_teams: list of strings
         :dismiss_stale_reviews: bool
@@ -146,6 +150,12 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         assert enforce_admins is github.GithubObject.NotSet or isinstance(
             enforce_admins, bool
         ), enforce_admins
+        assert bypass_pull_request_users is github.GithubObject.NotSet or all(
+            isinstance(element, str) for element in bypass_pull_request_users
+        ), bypass_pull_request_users
+        assert bypass_pull_request_teams is github.GithubObject.NotSet or all(
+            isinstance(element, str) for element in bypass_pull_request_teams
+        ), bypass_pull_request_teams
         assert dismissal_users is github.GithubObject.NotSet or all(
             isinstance(element, str) for element in dismissal_users
         ), dismissal_users
@@ -185,7 +195,9 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
             post_parameters["enforce_admins"] = None
 
         if (
-            dismissal_users is not github.GithubObject.NotSet
+            bypass_pull_request_users is not github.GithubObject.NotSet
+            or bypass_pull_request_teams is not github.GithubObject.NotSet
+            or dismissal_users is not github.GithubObject.NotSet
             or dismissal_teams is not github.GithubObject.NotSet
             or dismiss_stale_reviews is not github.GithubObject.NotSet
             or require_code_owner_reviews is not github.GithubObject.NotSet
@@ -219,6 +231,20 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
                 post_parameters["required_pull_request_reviews"][
                     "dismissal_restrictions"
                 ]["teams"] = dismissal_teams
+            if (
+                bypass_pull_request_users is not github.GithubObject.NotSet
+                or bypass_pull_request_teams is not github.GithubObject.NotSet
+            ):
+                if bypass_pull_request_users is github.GithubObject.NotSet:
+                    bypass_pull_request_users = []
+                if bypass_pull_request_teams is github.GithubObject.NotSet:
+                    bypass_pull_request_teams = []
+                post_parameters["required_pull_request_reviews"][
+                    "bypass_pull_request_allowances"
+                ] = {
+                    "users": bypass_pull_request_users,
+                    "teams": bypass_pull_request_teams,
+                }
         else:
             post_parameters["required_pull_request_reviews"] = None
         if (
@@ -313,6 +339,8 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def edit_required_pull_request_reviews(
         self,
+        bypass_pull_request_users=github.GithubObject.NotSet,
+        bypass_pull_request_teams=github.GithubObject.NotSet,
         dismissal_users=github.GithubObject.NotSet,
         dismissal_teams=github.GithubObject.NotSet,
         dismiss_stale_reviews=github.GithubObject.NotSet,
@@ -321,12 +349,20 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
     ):
         """
         :calls: `PATCH /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews <https://docs.github.com/en/rest/reference/repos#branches>`_
+        :bypass_pull_request_users: list of strings
+        :bypass_pull_request_teams: list of strings
         :dismissal_users: list of strings
         :dismissal_teams: list of strings
         :dismiss_stale_reviews: bool
         :require_code_owner_reviews: bool
         :required_approving_review_count: int
         """
+        assert bypass_pull_request_users is github.GithubObject.NotSet or all(
+            isinstance(element, str) for element in bypass_pull_request_users
+        ), bypass_pull_request_users
+        assert bypass_pull_request_teams is github.GithubObject.NotSet or all(
+            isinstance(element, str) for element in bypass_pull_request_teams
+        ), bypass_pull_request_teams
         assert dismissal_users is github.GithubObject.NotSet or all(
             isinstance(element, str) for element in dismissal_users
         ), dismissal_users
@@ -345,6 +381,18 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
         ), (required_approving_review_count)
 
         post_parameters = {}
+        if (
+            bypass_pull_request_users is not github.GithubObject.NotSet
+            or bypass_pull_request_users is not github.GithubObject.NotSet
+        ):
+            if bypass_pull_request_users is github.GithubObject.NotSet:
+                bypass_pull_request_users = []
+            if bypass_pull_request_teams is github.GithubObject.NotSet:
+                bypass_pull_request_teams = []
+            post_parameters["bypass_pull_request_allowances"] = {
+                "users": bypass_pull_request_users,
+                "teams": bypass_pull_request_teams,
+            }
         if dismissal_users is not github.GithubObject.NotSet:
             post_parameters["dismissal_restrictions"] = {"users": dismissal_users}
         if dismissal_teams is not github.GithubObject.NotSet:

--- a/github/BranchProtection.py
+++ b/github/BranchProtection.py
@@ -109,7 +109,9 @@ class BranchProtection(github.GithubObject.CompletableGithubObject):
         """
         if self._team_push_restrictions is github.GithubObject.NotSet:
             return None
-        return github.PaginatedList.PaginatedList(github.Team.Team, self._requester, self._team_push_restrictions, None)
+        return github.PaginatedList.PaginatedList(
+            github.Team.Team, self._requester, self._team_push_restrictions, None
+        )
 
     def _initAttributes(self):
         self._url = github.GithubObject.NotSet
@@ -130,7 +132,9 @@ class BranchProtection(github.GithubObject.CompletableGithubObject):
                 attributes["required_status_checks"],
             )
         if "enforce_admins" in attributes:  # pragma no branch
-            self._enforce_admins = self._makeBoolAttribute(attributes["enforce_admins"]["enabled"])
+            self._enforce_admins = self._makeBoolAttribute(
+                attributes["enforce_admins"]["enabled"]
+            )
         if "required_pull_request_reviews" in attributes:  # pragma no branch
             self._required_pull_request_reviews = self._makeClassAttribute(
                 github.RequiredPullRequestReviews.RequiredPullRequestReviews,

--- a/github/BranchProtection.py
+++ b/github/BranchProtection.py
@@ -67,6 +67,29 @@ class BranchProtection(github.GithubObject.CompletableGithubObject):
         self._completeIfNotSet(self._required_pull_request_reviews)
         return self._required_pull_request_reviews.value
 
+    def get_bypass_pull_request_users(self):
+        """
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
+        """
+        if self.get_bypass_pull_request_users is github.GithubObject.NotSet:
+            return None
+        return github.PaginatedList.PaginatedList(
+            github.NamedUser.NamedUser,
+            self._requester,
+            self.get_bypass_pull_request_users,
+            None,
+        )
+
+    def get_bypass_pull_request_teams(self):
+        """
+        :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Team.Team`
+        """
+        if self.get_bypass_pull_request_teams is github.GithubObject.NotSet:
+            return None
+        return github.PaginatedList.PaginatedList(
+            github.Team.Team, self._requester, self.get_bypass_pull_request_teams, None
+        )
+
     def get_user_push_restrictions(self):
         """
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.NamedUser.NamedUser`
@@ -86,15 +109,15 @@ class BranchProtection(github.GithubObject.CompletableGithubObject):
         """
         if self._team_push_restrictions is github.GithubObject.NotSet:
             return None
-        return github.PaginatedList.PaginatedList(
-            github.Team.Team, self._requester, self._team_push_restrictions, None
-        )
+        return github.PaginatedList.PaginatedList(github.Team.Team, self._requester, self._team_push_restrictions, None)
 
     def _initAttributes(self):
         self._url = github.GithubObject.NotSet
         self._required_status_checks = github.GithubObject.NotSet
         self._enforce_admins = github.GithubObject.NotSet
         self._required_pull_request_reviews = github.GithubObject.NotSet
+        self.get_bypass_pull_request_users = github.GithubObject.NotSet
+        self.get_bypass_pull_request_teams = github.GithubObject.NotSet
         self._user_push_restrictions = github.GithubObject.NotSet
         self._team_push_restrictions = github.GithubObject.NotSet
 
@@ -107,9 +130,7 @@ class BranchProtection(github.GithubObject.CompletableGithubObject):
                 attributes["required_status_checks"],
             )
         if "enforce_admins" in attributes:  # pragma no branch
-            self._enforce_admins = self._makeBoolAttribute(
-                attributes["enforce_admins"]["enabled"]
-            )
+            self._enforce_admins = self._makeBoolAttribute(attributes["enforce_admins"]["enabled"])
         if "required_pull_request_reviews" in attributes:  # pragma no branch
             self._required_pull_request_reviews = self._makeClassAttribute(
                 github.RequiredPullRequestReviews.RequiredPullRequestReviews,

--- a/github/RequiredPullRequestReviews.py
+++ b/github/RequiredPullRequestReviews.py
@@ -72,6 +72,22 @@ class RequiredPullRequestReviews(github.GithubObject.CompletableGithubObject):
         return self._url.value
 
     @property
+    def bypass_pull_request_users(self):
+        """
+        :type: list of :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._bypass_pull_request_users)
+        return self._bypass_pull_request_users.value
+
+    @property
+    def bypass_pull_request_teams(self):
+        """
+        :type: list of :class:`github.NamedUser.NamedUser`
+        """
+        self._completeIfNotSet(self._bypass_pull_request_teams)
+        return self._bypass_pull_request_teams.value
+
+    @property
     def dismissal_users(self):
         """
         :type: list of :class:`github.NamedUser.NamedUser`
@@ -91,6 +107,8 @@ class RequiredPullRequestReviews(github.GithubObject.CompletableGithubObject):
         self._dismiss_stale_reviews = github.GithubObject.NotSet
         self._require_code_owner_reviews = github.GithubObject.NotSet
         self._required_approving_review_count = github.GithubObject.NotSet
+        self._bypass_pull_request_users = github.GithubObject.NotSet
+        self._bypass_pull_request_teams = github.GithubObject.NotSet
         self._users = github.GithubObject.NotSet
         self._teams = github.GithubObject.NotSet
 
@@ -112,6 +130,15 @@ class RequiredPullRequestReviews(github.GithubObject.CompletableGithubObject):
         if "require_code_owner_reviews" in attributes:  # pragma no branch
             self._require_code_owner_reviews = self._makeBoolAttribute(
                 attributes["require_code_owner_reviews"]
+            )
+        if "bypass_pull_request_allowances" in attributes:  # pragma no branch
+            self._bypass_pull_request_users = self._makeListOfClassesAttribute(
+                github.NamedUser.NamedUser,
+                attributes["bypass_pull_request_allowances"]["users"],
+            )
+            self._bypass_pull_request_teams = self._makeListOfClassesAttribute(
+                github.Team.Team,
+                attributes["bypass_pull_request_allowances"]["teams"],
             )
         if "required_approving_review_count" in attributes:  # pragma no branch
             self._required_approving_review_count = self._makeIntAttribute(

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ import textwrap
 
 import setuptools
 
-version = "1.55"
+version = "1.55a0"
 
 
 if __name__ == "__main__":

--- a/tests/Branch.py
+++ b/tests/Branch.py
@@ -133,13 +133,13 @@ class Branch(Framework.TestCase):
         self.assertListKeyEqual(
             branch_protection.get_team_push_restrictions(), lambda u: u.slug, []
         )
-    
+
     def testEditProtectionBypassPullRequestUserTeam(self):
         self.organization_branch.edit_protection(
             bypass_pull_request_users=["jacquev6"],
             bypass_pull_request_teams=["pygithub-owners"],
             user_push_restrictions=[],
-            team_push_restrictions=[]
+            team_push_restrictions=[],
         )
         branch_protection = self.organization_branch.get_protection()
         self.assertListKeyEqual(
@@ -152,7 +152,7 @@ class Branch(Framework.TestCase):
             lambda u: u.slug,
             ["pygithub-owners"],
         )
-    
+
     def testRemoveProtection(self):
         self.assertTrue(self.protected_branch.protected)
         self.protected_branch.remove_protection()

--- a/tests/Branch.py
+++ b/tests/Branch.py
@@ -133,7 +133,26 @@ class Branch(Framework.TestCase):
         self.assertListKeyEqual(
             branch_protection.get_team_push_restrictions(), lambda u: u.slug, []
         )
-
+    
+    def testEditProtectionBypassPullRequestUserTeam(self):
+        self.organization_branch.edit_protection(
+            bypass_pull_request_users=["jacquev6"],
+            bypass_pull_request_teams=["pygithub-owners"],
+            user_push_restrictions=[],
+            team_push_restrictions=[]
+        )
+        branch_protection = self.organization_branch.get_protection()
+        self.assertListKeyEqual(
+            branch_protection.required_pull_request_reviews.bypass_pull_request_users,
+            lambda u: u.login,
+            ["jacquev6"],
+        )
+        self.assertListKeyEqual(
+            branch_protection.required_pull_request_reviews.bypass_pull_request_teams,
+            lambda u: u.slug,
+            ["pygithub-owners"],
+        )
+    
     def testRemoveProtection(self):
         self.assertTrue(self.protected_branch.protected)
         self.protected_branch.remove_protection()

--- a/tests/ReplayData/Branch.testEditProtectionBypassPullRequestUserTeam.txt
+++ b/tests/ReplayData/Branch.testEditProtectionBypassPullRequestUserTeam.txt
@@ -1,0 +1,21 @@
+https
+PUT
+api.github.com
+None
+/repos/PyGithub/PyGithub/branches/master/protection
+{'Authorization': 'Basic login_and_password_removed', 'Content-Type': 'application/json', 'User-Agent': 'PyGithub/Python', 'Accept': 'application/vnd.github.luke-cage-preview+json'}
+{"required_pull_request_reviews": {"bypass_pull_request_allowances": {"teams": ["pygithub-owners"], "users": ["jacquev6"]}}, "required_status_checks": null, "enforce_admins": null, "restrictions": {"users": [], "teams": []}}
+200
+[('status', '200 OK'), ('x-ratelimit-remaining', '4994'), ('content-length', '0'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"e0dc2dfc56971f4a36de1216356ea98b"'), ('date', 'Sun, 13 May 2018 13:21:24 GMT'), ('content-type', 'application/json; charset=utf-8')]
+''
+
+https
+GET
+api.github.com
+None
+/repos/PyGithub/PyGithub/branches/master/protection
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python', 'Accept': 'application/vnd.github.luke-cage-preview+json'}
+None
+200
+[('x-runtime-rack', '0.049160'), ('vary', 'Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding'), ('x-oauth-scopes', 'public_repo, repo:status'), ('x-xss-protection', '1; mode=block'), ('x-content-type-options', 'nosniff'), ('x-accepted-oauth-scopes', ''), ('etag', 'W/"a4ef2f2bcfdf33fadd5c8fa6867ebc3a"'), ('cache-control', 'private, max-age=60, s-maxage=60'), ('referrer-policy', 'origin-when-cross-origin, strict-origin-when-cross-origin'), ('status', '200 OK'), ('x-ratelimit-remaining', '4986'), ('x-github-media-type', 'github.v3; format=json'), ('access-control-expose-headers', 'ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval'), ('transfer-encoding', 'chunked'), ('x-github-request-id', '860C:2DC5:28789D:34E3E8:5AF7FF18'), ('date', 'Sun, 13 May 2018 09:02:17 GMT'), ('access-control-allow-origin', '*'), ('content-security-policy', "default-src 'none'"), ('content-encoding', 'gzip'), ('strict-transport-security', 'max-age=31536000; includeSubdomains; preload'), ('server', 'GitHub.com'), ('x-ratelimit-limit', '5000'), ('x-frame-options', 'deny'), ('content-type', 'application/json; charset=utf-8'), ('x-ratelimit-reset', '1526204223')]
+{"url":"https://api.github.com/repos/PyGithub/PyGithub/branches/master/protection","required_pull_request_reviews":{"url":"https://api.github.com/repos/PyGithub/PyGithub/branches/master/protection/required_pull_request_reviews","dismiss_stale_reviews":false,"require_code_owner_reviews":false,"bypass_pull_request_allowances":{"url":"https://api.github.com/repos/PyGithub/PyGithub/branches/master/protection/bypass_pull_request_allowances","users_url":"https://api.github.com/repos/PyGithub/PyGithub/branches/master/protection/bypass_pull_request_allowances/users","teams":[{"name":"pygithub-owners","slug":"pygithub-owners"}],"teams_url":"https://api.github.com/repos/PyGithub/PyGithub/branches/master/protection/bypass_pull_request_allowances/teams","users":[{"login":"jacquev6"}]}},"enforce_admins":{"url":"https://api.github.com/repos/PyGithub/PyGithub/branches/master/protection/enforce_admins","enabled":false}}

--- a/tests/RequiredPullRequestReviews.py
+++ b/tests/RequiredPullRequestReviews.py
@@ -45,8 +45,12 @@ class RequiredPullRequestReviews(Framework.TestCase):
         )
         self.assertIs(self.required_pull_request_reviews.dismissal_users, None)
         self.assertIs(self.required_pull_request_reviews.dismissal_teams, None)
-        self.assertIs(self.required_pull_request_reviews.bypass_pull_request_users, None)
-        self.assertIs(self.required_pull_request_reviews.bypass_pull_request_users, None)
+        self.assertIs(
+            self.required_pull_request_reviews.bypass_pull_request_users, None
+        )
+        self.assertIs(
+            self.required_pull_request_reviews.bypass_pull_request_users, None
+        )
         self.assertEqual(
             self.required_pull_request_reviews.__repr__(),
             'RequiredPullRequestReviews(url="https://api.github.com/repos/jacquev6/PyGithub/branches/integrations/protection/required_pull_request_reviews", require_code_owner_reviews=True, dismiss_stale_reviews=True)',

--- a/tests/RequiredPullRequestReviews.py
+++ b/tests/RequiredPullRequestReviews.py
@@ -45,6 +45,8 @@ class RequiredPullRequestReviews(Framework.TestCase):
         )
         self.assertIs(self.required_pull_request_reviews.dismissal_users, None)
         self.assertIs(self.required_pull_request_reviews.dismissal_teams, None)
+        self.assertIs(self.required_pull_request_reviews.bypass_pull_request_users, None)
+        self.assertIs(self.required_pull_request_reviews.bypass_pull_request_users, None)
         self.assertEqual(
             self.required_pull_request_reviews.__repr__(),
             'RequiredPullRequestReviews(url="https://api.github.com/repos/jacquev6/PyGithub/branches/integrations/protection/required_pull_request_reviews", require_code_owner_reviews=True, dismiss_stale_reviews=True)',


### PR DESCRIPTION
Currently PyGithub cannot set branch protection to allow bypass pull request review users or teams. This is done against the GitHub API with a PUT @ [/repos/{owner}/{repo}/branches/{branch}/protection](https://docs.github.com/en/rest/reference/branches#update-branch-protection), which `Branch.edit_protection()` already hits. I've added new parameters to that method and `Branch.edit_required_pull_request_reviews()` following existing patterns that result in including a `bypass_pull_request_reviews` object in the payload.

I am having trouble generating the ReplayData for a new test because of an auth issue, but have curated it manually to allow the test to pass. I also did some additional local testing with a project that uses PyGithub.

- support to set bypass pr review users or teams
- manually created replay data