### PR TITLE
Fix get events not returning user events

### DIFF
--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -778,13 +778,24 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         itemdata = namedtuple("EmailData", data[0].keys())
         return [itemdata._make(item.values()) for item in data]
 
-    def get_events(self):
+    def get_events(self, public=github.GithubObject.NotSet):
         """
-        :calls: `GET /events <http://docs.github.com/en/rest/reference/activity#events>`_
+        :calls: `GET /users/{user}/events{/privacy} <http://docs.github.com/en/rest/reference/activity#events>`_
+        :param public: bool
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
         """
+
+
+        assert public is github.GithubObject.NotSet or isinstance(public, bool), public
+
+        privacy = ""
+        if public is not github.GithubObject.NotSet and public is True :
+            privacy = "/public"
         return github.PaginatedList.PaginatedList(
-            github.Event.Event, self._requester, "/events", None
+            github.Event.Event,
+            self._requester,
+            f"/users/{self.login}/events{privacy}",
+            None,
         )
 
     def get_followers(self):

--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -784,13 +784,11 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         :param public: bool
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.Event.Event`
         """
-
-
         assert public is github.GithubObject.NotSet or isinstance(public, bool), public
-
-        privacy = ""
-        if public is not github.GithubObject.NotSet and public is True :
+        if public is not github.GithubObject.NotSet and public is True:
             privacy = "/public"
+        else:
+            privacy = ""
         return github.PaginatedList.PaginatedList(
             github.Event.Event,
             self._requester,


### PR DESCRIPTION
The `get_events()` function from the `AuthenticatedUser` class doesn't return events of only the user, it returns all events. 

I have modified the function to return user events only, with a flag on getting Private and Public events (`False`), or just Public events (`True`, Default). 

The original functionality is covered by `Github.get_events()`. 