### PR TITLE
Fix stub for creator param in Repository.get_issues()

### DIFF
--- a/github/Repository.pyi
+++ b/github/Repository.pyi
@@ -379,7 +379,7 @@ class Repository(CompletableGithubObject):
         sort: Union[str, _NotSetType] = ...,
         direction: Union[str, _NotSetType] = ...,
         since: Union[_NotSetType, datetime] = ...,
-        creator: Union[NamedUser, _NotSetType] = ...,
+        creator: Union[NamedUser, str, _NotSetType] = ...,
     ) -> PaginatedList[Issue]: ...
     def get_issues_comments(
         self,


### PR DESCRIPTION
[The `creator` parameter seems to accept a string](https://github.com/PyGithub/PyGithub/blob/001970d/github/Repository.py#L2495), but the `Repository.pyi` stub does not show this as an allowed type, which results in mypy errors when a string is used.  This PR adds that missing type.