### PR TITLE
Added support for http/s proxies

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -104,6 +104,7 @@ class Github:
         verify=True,
         retry=None,
         pool_size=None,
+        proxies=None,
     ):
         """
         :param login_or_token: string
@@ -115,6 +116,7 @@ class Github:
         :param verify: boolean or string
         :param retry: int or urllib3.util.retry.Retry object
         :param pool_size: int
+        :param proxies: dict
         """
 
         assert login_or_token is None or isinstance(login_or_token, str), login_or_token
@@ -129,6 +131,7 @@ class Github:
             or isinstance(retry, (urllib3.util.Retry))
         )
         assert pool_size is None or isinstance(pool_size, (int)), pool_size
+        assert proxies is None or isinstance(proxies, (dict)), proxies
         self.__requester = Requester(
             login_or_token,
             password,
@@ -140,6 +143,7 @@ class Github:
             verify,
             retry,
             pool_size,
+            proxies,
         )
 
     @property

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -97,6 +97,7 @@ class HTTPSRequestsConnectionClass:
         self.timeout = timeout
         self.verify = kwargs.get("verify", True)
         self.session = requests.Session()
+        self.session.proxies = kwargs.get("proxies", {})
 
         if retry is None:
             self.retry = requests.adapters.DEFAULT_RETRIES
@@ -156,6 +157,7 @@ class HTTPRequestsConnectionClass:
         self.timeout = timeout
         self.verify = kwargs.get("verify", True)
         self.session = requests.Session()
+        self.session.proxies = kwargs.get("proxies", {})
 
         if retry is None:
             self.retry = requests.adapters.DEFAULT_RETRIES
@@ -301,6 +303,7 @@ class Requester:
         verify,
         retry,
         pool_size,
+        proxies,
     ):
         self._initializeDebugFeature()
 
@@ -348,6 +351,7 @@ class Requester:
         )
         self.__userAgent = user_agent
         self.__verify = verify
+        self.__proxies = proxies
 
     def requestJsonAndCheck(self, verb, url, parameters=None, headers=None, input=None):
         return self.__check(
@@ -611,6 +615,7 @@ class Requester:
         kwds = {}
         kwds["timeout"] = self.__timeout
         kwds["verify"] = self.__verify
+        kwds["proxies"] = self.__proxies
 
         if self.__persist and self.__connection is not None:
             return self.__connection


### PR DESCRIPTION
Added support for proxies servers. Useful for organisations that enforce IP whitelisting to internal IP's (VPN excluded).
The Github object has been enhanced to include proxies as a kwarg, the proxies arg expects a dictionary and is a passthrough for the standard requests library way of implementing proxies i.e. 

```
proxies = { 
              "http"  : http_proxy, 
              "https" : https_proxy, 
              "ftp"   : ftp_proxy
            }
```

Usage: 

```
proxy_dict = { 
              "https"  :'http://username:password@proxy.company.com:80',
            }
g = Github("access_token", proxies=proxy_dict)
```

