### PR TITLE
Add https://github.com/packit/ogr to 'Projects using PyGithub'

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -76,6 +76,7 @@ Projects using PyGithub
 * https://github.com/plus3it/satsuki - Automate GitHub releases and uploading binary release assets
 * `check-in <https://github.com/webknjaz/check-in>`_ — Python CLI distribution that allows user to use GitHub Checks API as a bot.
 * https://github.com/hasii2011/gittodoistclone - Convert GitHub issues to Todoist tasks
+* `OGR <https://github.com/packit/ogr>`__ is a library for one API for many git forges (e.g. GitHub, GitLab, Pagure).
  
 They talk about PyGithub
 ------------------------


### PR DESCRIPTION
BTW, the http://devassistant.org says that 'DevAssistant is dead' and [its repo](https://github.com/devassistant/devassistant) has been archived (the last commit is 6 years old) so you might consider removing it from the list - I can do that in this PR if you want.