### PR TITLE
Import path update in Introduction

### DIFF
--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -13,7 +13,7 @@ please `open an issue <https://github.com/PyGithub/PyGithub/issues>`__.
 
 First create a Github instance::
 
-    from github import Github
+    from github.MainClass import Github
     
     # using an access token
     g = Github("access_token")


### PR DESCRIPTION
The import statement in the Introduction throws an error for me with Python 3.10.6 and PyGithub 1.55; qualifying with `MainClass` resolved the issue.