### PR TITLE
Require pyjwt>=2.4.0 to avoid CVE-2022-29217

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pynacl>=1.4.0
 requests>=2.14.0
-pyjwt>=2.0
+pyjwt>=2.4.0
 sphinx<3
 Jinja2<3.1
 sphinx-rtd-theme<1.1

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
         python_requires=">=3.7",
         install_requires=[
             "deprecated",
-            "pyjwt>=2.0",
+            "pyjwt>=2.4.0",
             "pynacl>=1.4.0",
             "requests>=2.14.0",
         ],


### PR DESCRIPTION
Fixes https://github.com/PyGithub/PyGithub/issues/2260.

Avoid  CVE-2022-29217 by requiring pyjwt>=2.4.0.

PyGithub requires `pyjwt>=2.0`, so there's nothing to stop end users updating, and if they do a fresh install they'll get a newer version.

But it's a good idea to require at least the fixed 2.4.0 as a minimum version too.