### PR TITLE
break out get_installation into user and repo

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -866,6 +866,15 @@ class GithubIntegration:
         :param repo: str
         :rtype: :class:`github.Installation.Installation`
         """
+        return self.get_repo_installation(owner, repo)
+
+    def get_repo_installation(self, owner, repo):
+        """
+        :calls: `GET /repos/{owner}/{repo}/installation <https://docs.github.com/en/rest/reference/apps#get-a-repository-installation-for-the-authenticated-app>`_
+        :param owner: str
+        :param repo: str
+        :rtype: :class:`github.Installation.Installation`
+        """
         headers = {
             "Authorization": f"Bearer {self.create_jwt()}",
             "Accept": Consts.mediaTypeIntegrationPreview,
@@ -874,6 +883,25 @@ class GithubIntegration:
 
         response = requests.get(
             f"{self.base_url}/repos/{owner}/{repo}/installation",
+            headers=headers,
+        )
+        response_dict = response.json()
+        return Installation.Installation(None, headers, response_dict, True)
+
+    def get_user_installation(self, username):
+        """
+        :calls: `GET /users/{username}/installation <https://docs.github.com/en/rest/reference/apps#get-a-user-installation-for-the-authenticated-app>`_
+        :param username: str
+        :rtype: :class:`github.Installation.Installation`
+        """
+        headers = {
+            "Authorization": f"Bearer {self.create_jwt()}",
+            "Accept": Consts.mediaTypeIntegrationPreview,
+            "User-Agent": "PyGithub/Python",
+        }
+
+        response = requests.get(
+            f"{self.base_url}/users/{username}/installation",
             headers=headers,
         )
         response_dict = response.json()


### PR DESCRIPTION
I accidentally deleted the repo I had forked thinking [my last PR](https://github.com/PyGithub/PyGithub/pull/2307) had been merged, but it had not been. These are the same changes as last time.

Purpose from the old PR:
> GitHub app installations can be either repo or user installed, and the API offers endpoints for both. I added two methods to specify what type of installation you are getting. The original method now calls get_repo_installation for backward-compatibility.