### PR TITLE
add automatic release notes generation

### DIFF
--- a/github/GitRelease.py
+++ b/github/GitRelease.py
@@ -107,6 +107,14 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
         return self._prerelease.value
 
     @property
+    def generate_release_notes(self):
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._generate_release_notes)
+        return self._generate_release_notes.value
+    
+    @property
     def author(self):
         """
         :type: :class:`github.NamedUser.NamedUser`
@@ -325,6 +333,7 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
         self._target_commitish = github.GithubObject.NotSet
         self._draft = github.GithubObject.NotSet
         self._prerelease = github.GithubObject.NotSet
+        self._generate_release_notes = github.GithubObject.NotSet
         self._author = github.GithubObject.NotSet
         self._url = github.GithubObject.NotSet
         self._upload_url = github.GithubObject.NotSet
@@ -351,6 +360,8 @@ class GitRelease(github.GithubObject.CompletableGithubObject):
             self._draft = self._makeBoolAttribute(attributes["draft"])
         if "prerelease" in attributes:
             self._prerelease = self._makeBoolAttribute(attributes["prerelease"])
+        if "generate_release_notes" in attributes:
+            self._generate_release_notes = self._makeBoolAttribute(attributes["generate_release_notes"])
         if "author" in attributes:
             self._author = self._makeClassAttribute(
                 github.NamedUser.NamedUser, attributes["author"]

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1058,6 +1058,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         message,
         draft=False,
         prerelease=False,
+        generate_release_notes=False,
         target_commitish=github.GithubObject.NotSet,
     ):
         """
@@ -1067,6 +1068,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         :param message: string
         :param draft: bool
         :param prerelease: bool
+        :param generate_release_notes: bool
         :param target_commitish: string or :class:`github.Branch.Branch` or :class:`github.Commit.Commit` or :class:`github.GitCommit.GitCommit`
         :rtype: :class:`github.GitRelease.GitRelease`
         """
@@ -1075,6 +1077,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         assert isinstance(message, str), message
         assert isinstance(draft, bool), draft
         assert isinstance(prerelease, bool), prerelease
+        assert isinstance(generate_release_notes, bool), generate_release_notes
         assert target_commitish is github.GithubObject.NotSet or isinstance(
             target_commitish,
             (
@@ -1090,6 +1093,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
             "body": message,
             "draft": draft,
             "prerelease": prerelease,
+            "generate_release_notes" : generate_release_notes,
         }
         if isinstance(target_commitish, str):
             post_parameters["target_commitish"] = target_commitish

--- a/github/Repository.pyi
+++ b/github/Repository.pyi
@@ -160,6 +160,7 @@ class Repository(CompletableGithubObject):
         message: str,
         draft: bool = ...,
         prerelease: bool = ...,
+        generate_release_notes = ...,
         target_commitish: Union[str, _NotSetType] = ...,
     ) -> GitRelease: ...
     def create_git_tag(

--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -363,6 +363,7 @@ class Repository(Framework.TestCase):
         self.assertEqual(release.body, "This release is created by PyGithub")
         self.assertEqual(release.draft, False)
         self.assertEqual(release.prerelease, False)
+        self.assertEqual(release.generate_release_notes, False)
 
     def testCreateGitReleaseWithAllArguments(self):
         release = self.repo.create_git_release(
@@ -371,6 +372,7 @@ class Repository(Framework.TestCase):
             "This release is also created by PyGithub",
             False,
             True,
+            True,
             "da9a285fd8b782461e56cba39ae8d2fa41ca7cdc",
         )
         self.assertEqual(release.tag_name, "vX.Y.Z-by-PyGithub-acctest2")
@@ -378,6 +380,7 @@ class Repository(Framework.TestCase):
         self.assertEqual(release.body, "This release is also created by PyGithub")
         self.assertEqual(release.draft, False)
         self.assertEqual(release.prerelease, True)
+        self.assertEqual(release.generate_release_notes, True)
         tag = [
             tag
             for tag in self.repo.get_tags()


### PR DESCRIPTION
The goal of this PR is to add ability of creating GitHub releases with automaticly generated notes, using create_git_release() function.