### PR TITLE
Add enable() method for workflows

### DIFF
--- a/github/Workflow.py
+++ b/github/Workflow.py
@@ -149,6 +149,16 @@ class Workflow(CompletableGithubObject):
         )
         return status == 204
 
+    def enable(self) -> bool:
+        """
+        :calls: `PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/enable <https://docs.github.com/en/rest/reference/actions#enable-a-workflow>`_
+        :rtype: bool
+        """
+        status, _, _ = self._requester.requestJson(
+            "PUT", f"{self.url}/enable"
+        )
+        return status == 204
+
     def get_runs(
         self,
         actor: Opt[github.NamedUser.NamedUser | str] = NotSet,


### PR DESCRIPTION
### The Problem

Workflows disabled due to the 60-day-long period of inactivity (`state: disabled_inactivity`) need to be re-enabled before using `create_dispatch()`.

### The Solution

Implement the `enable()` that hits the `/enable` endpoint of API with a PUT request.
I have not added tests due to lack of knowledge about them, sorry.

Cheers from [YunoHost-Apps](https://github.com/YunoHost-Apps) project, that has a tad-too-many repositories to be managed one-by-one. 🙂 