### PR TITLE
update docs for create_issue

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1213,7 +1213,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         :param assignee: string or :class:`github.NamedUser.NamedUser`
         :param assignees: list of string or :class:`github.NamedUser.NamedUser`
         :param milestone: :class:`github.Milestone.Milestone`
-        :param labels: list of :class:`github.Label.Label`
+        :param labels: list of string or :class:`github.Label.Label`
         :rtype: :class:`github.Issue.Issue`
         """
         assert isinstance(title, str), title


### PR DESCRIPTION
Docs on repository.create_issue don't reflect the possibility to list labels as strings. This option is added to https://pygithub.readthedocs.io/en/latest/github_objects/Repository.html#github.Repository.Repository.create_issue in this PR. For more details, see #2355

Edit: I can't find the connection between the pipeline failing and the PR. How can I fix the pipeline?