### PR TITLE
Add unarchiving support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,6 @@
 /doc/doctrees/
 .vscode*
 .venv
+venv
 .tox/
 .mypy_cache/

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1582,7 +1582,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         :param allow_merge_commit: bool
         :param allow_rebase_merge: bool
         :param delete_branch_on_merge: bool
-        :param archived: bool. Unarchiving repositories is currently not supported through API (https://docs.github.com/en/rest/reference/repos#update-a-repository)
+        :param archived: bool
         :rtype: None
         """
         if name is None:
@@ -1627,8 +1627,8 @@ class Repository(github.GithubObject.CompletableGithubObject):
         assert delete_branch_on_merge is github.GithubObject.NotSet or isinstance(
             delete_branch_on_merge, bool
         ), delete_branch_on_merge
-        assert archived is github.GithubObject.NotSet or (
-            isinstance(archived, bool) and archived is True
+        assert archived is github.GithubObject.NotSet or isinstance(
+            archived, bool
         ), archived
         post_parameters = {
             "name": name,


### PR DESCRIPTION
The github API now allows unarchiving an archived repo. This removes the check so that we ar able to unarchive repos using pygithub.

https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#update-a-repository