### PR TITLE
Fix broken urls in docstrings

### DIFF
--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -1088,7 +1088,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
         direction=github.GithubObject.NotSet,
     ):
         """
-        :calls: `GET /user/repos <http://docs.github.com/en/rest/reference/repos>`
+        :calls: `GET /user/repos <http://docs.github.com/en/rest/reference/repos>`_
         :param visibility: string
         :param affiliation: string
         :param type: string
@@ -1299,7 +1299,7 @@ class AuthenticatedUser(github.GithubObject.CompletableGithubObject):
 
     def accept_invitation(self, invitation):
         """
-        :calls: `PATCH /user/repository_invitations/{invitation_id} <https://docs.github.com/en/rest/reference/repos/invitations#>`
+        :calls: `PATCH /user/repository_invitations/{invitation_id} <https://docs.github.com/en/rest/reference/repos/invitations#>`_
         :param invitation: :class:`github.Invitation.Invitation` or int
         :rtype: None
         """

--- a/github/Branch.py
+++ b/github/Branch.py
@@ -637,7 +637,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def get_required_signatures(self):
         """
-        :calls: `GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures <https://docs.github.com/en/rest/reference/repos#branches>`
+        :calls: `GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures <https://docs.github.com/en/rest/reference/repos#branches>`_
         """
         headers, data = self._requester.requestJsonAndCheck(
             "GET",
@@ -648,7 +648,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def add_required_signatures(self):
         """
-        :calls: `POST /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures <https://docs.github.com/en/rest/reference/repos#branches>`
+        :calls: `POST /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures <https://docs.github.com/en/rest/reference/repos#branches>`_
         """
         headers, data = self._requester.requestJsonAndCheck(
             "POST",
@@ -658,7 +658,7 @@ class Branch(github.GithubObject.NonCompletableGithubObject):
 
     def remove_required_signatures(self):
         """
-        :calls: `DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures <https://docs.github.com/en/rest/reference/repos#branches>`
+        :calls: `DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures <https://docs.github.com/en/rest/reference/repos#branches>`_
         """
         headers, data = self._requester.requestJsonAndCheck(
             "DELETE",

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1742,7 +1742,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def rename_branch(self, branch, new_name):
         """
-        :calls: `POST /repos/{owner}/{repo}/branches/{branch}/rename <https://docs.github.com/en/rest/reference/repos#branches>`
+        :calls: `POST /repos/{owner}/{repo}/branches/{branch}/rename <https://docs.github.com/en/rest/reference/repos#branches>`_
         :param branch: :class:`github.Branch.Branch` or string
         :param new_name: string
         :rtype: bool
@@ -2506,7 +2506,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
 
     def get_git_matching_refs(self, ref):
         """
-        :calls: `GET /repos/{owner}/{repo}/git/matching-refs/{ref} <https://docs.github.com/en/rest/reference/git#list-matching-references>`
+        :calls: `GET /repos/{owner}/{repo}/git/matching-refs/{ref} <https://docs.github.com/en/rest/reference/git#list-matching-references>`_
         :rtype: :class:`github.PaginatedList.PaginatedList` of :class:`github.GitRef.GitRef`
         """
         assert isinstance(ref, str), ref

--- a/github/Team.py
+++ b/github/Team.py
@@ -442,7 +442,7 @@ class Team(github.GithubObject.CompletableGithubObject):
 
     def remove_membership(self, member):
         """
-        :calls: `DELETE /teams/{team_id}/memberships/{username} <https://docs.github.com/en/rest/reference/teams#remove-team-membership-for-a-user>`
+        :calls: `DELETE /teams/{team_id}/memberships/{username} <https://docs.github.com/en/rest/reference/teams#remove-team-membership-for-a-user>`_
         :param member:
         :return:
         """


### PR DESCRIPTION
I noticed that the URLs for accept_invitation and get_repos are broken on ReadTheDocs.

By adding the underscore at the end, it fixes the link when rendered with Sphinx