### PR TITLE
Move CI to Python 3.11 release and 3.12 dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: test (Python ${{ matrix.python-version }})
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python


### PR DESCRIPTION
Python 3.11 has been released, 3.12 is the new dev.

@s-t-e-v-e-n-k @sfdye please add `test (Python 3.11)` to the required checks when merging this.