### PR TITLE
Fixing all stubs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,17 +24,6 @@ jobs:
         run: tox
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2.1.0
-
-  stub_test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install stubs
-        run: python3 -m pip install types-requests
-        shell: bash
-      - name: Run stubtest
-        run: stubtest github
-        shell: run
-
   draft:
     runs-on: ubuntu-latest
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,17 @@ jobs:
         run: tox
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2.1.0
+
+  stub_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install stubs
+        run: python3 -m pip install types-requests
+        shell: bash
+      - name: Run stubtest
+        run: stubtest github
+        shell: run
+
   draft:
     runs-on: ubuntu-latest
     needs: test

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,14 @@
 [tox]
 envlist =
     lint,
+    stubtest,
     py{37,38,39,310,311},
     docs
 
 [gh-actions]
 python =
     3.7: py37
-    3.8: py38, docs, lint
+    3.8: py38, docs, lint, stubtest
     3.9: py39
     3.10: py310
     3.11: py311
@@ -29,6 +30,16 @@ commands =
     ; Run mypy outside pre-commit because pre-commit runs mypy in a venv
     ; that doesn't have dependencies or their type annotations installed.
     mypy github tests
+
+[testenv:stubtest]
+basepython = python3.8
+skip_install = false
+deps =
+    types-jwt
+    types-requests
+    mypy
+commands =
+    stubtest github
 
 [testenv:docs]
 basepython = python3.8


### PR DESCRIPTION
Adds `stubtest` to tox and CI, finds 98 `.pyi` related errors.