### PR TITLE
Move RLock initialization

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -314,7 +314,8 @@ class Requester:
         self.__app_auth = app_auth
         self.__base_url = base_url
 
-        self.__auth_lock = RLock()
+        if self.__app_auth is not None:
+            self.__auth_lock = RLock()
 
         if password is not None:
             login = login_or_token


### PR DESCRIPTION
Since Requester.__init__ is called everywhere ever and may be used in restricted environments, we can not depend on semaphore locks being available. Set it to None, and initialize it when we need it, keeping it around.

Fixes #2430