### PR TITLE
Exclude Requester.__auth_lock from serialization

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -314,7 +314,7 @@ class Requester:
         self.__app_auth = app_auth
         self.__base_url = base_url
 
-        self.__auth_lock = RLock()
+        self.__init_auth_lock()
 
         if password is not None:
             login = login_or_token
@@ -361,6 +361,19 @@ class Requester:
         )
         self.__userAgent = user_agent
         self.__verify = verify
+
+    def __init_auth_lock(self):
+        self.__auth_lock = RLock()
+
+    def __getstate__(self):
+        # do not serialize the lock
+        state = self.__dict__.copy()
+        del state['_Requester__auth_lock']
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.__init_auth_lock()
 
     def _must_refresh_token(self) -> bool:
         """Check if it is time to refresh the API token gotten from the GitHub app installation"""

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -368,7 +368,7 @@ class Requester:
     def __getstate__(self):
         # do not serialize the lock
         state = self.__dict__.copy()
-        del state['_Requester__auth_lock']
+        del state["_Requester__auth_lock"]
         return state
 
     def __setstate__(self, state):

--- a/tests/Framework.py
+++ b/tests/Framework.py
@@ -260,6 +260,7 @@ class ReplayingHttpsConnection(ReplayingConnection):
 class BasicTestCase(unittest.TestCase):
     recordMode = False
     tokenAuthMode = False
+    appAuthMode = False
     jwtAuthMode = False
     retry = None
     pool_size = None
@@ -285,6 +286,7 @@ class BasicTestCase(unittest.TestCase):
             self.login = GithubCredentials.login
             self.password = GithubCredentials.password
             self.oauth_token = GithubCredentials.oauth_token
+            self.app_auth = GithubCredentials.app_auth
             self.jwt = GithubCredentials.jwt
             self.app_id = GithubCredentials.app_id
             self.app_private_key = GithubCredentials.app_private_key

--- a/tests/Pickle.py
+++ b/tests/Pickle.py
@@ -1,0 +1,28 @@
+import pickle
+import unittest
+
+import github
+from github.AppAuthentication import AppAuthentication
+from github.Repository import Repository
+
+REPO_NAME = "PyGithub/PyGithub"
+
+
+# https://github.com/PyGithub/PyGithub/issues/2436
+# https://github.com/PyGithub/PyGithub/pull/2437
+class TestPickle(unittest.TestCase):
+    def test_pickle_github(self):
+        gh = github.Github("token")
+        gh2 = pickle.loads(pickle.dumps(gh))
+        self.assertIsInstance(gh2, github.Github)
+
+    def test_pickle_github_with_app_auth(self):
+        gh = github.Github("token", app_auth=AppAuthentication("id", "key", 123))
+        gh2 = pickle.loads(pickle.dumps(gh))
+        self.assertIsInstance(gh2, github.Github)
+
+    def test_pickle_repository(self):
+        gh = github.Github("token")
+        repo = gh.get_repo(REPO_NAME, lazy=True)
+        repo2 = pickle.loads(pickle.dumps(repo))
+        self.assertIsInstance(repo2, Repository)


### PR DESCRIPTION
Fixes #2436. Not needed if #2446 is merged to master.