### PR TITLE
Parameter name change in create_review_comment.

### DIFF
--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -398,33 +398,33 @@ class PullRequest(github.GithubObject.CompletableGithubObject):
         headers, data = self._requester.requestJsonAndCheck("GET", self.issue_url)
         return github.Issue.Issue(self._requester, headers, data, completed=True)
 
-    def create_comment(self, body, commit_id, path, position):
+    def create_comment(self, body, commit, path, position):
         """
         :calls: `POST /repos/{owner}/{repo}/pulls/{number}/comments <https://docs.github.com/en/rest/reference/pulls#review-comments>`_
         :param body: string
-        :param commit_id: :class:`github.Commit.Commit`
+        :param commit: :class:`github.Commit.Commit`
         :param path: string
         :param position: integer
         :rtype: :class:`github.PullRequestComment.PullRequestComment`
         """
-        return self.create_review_comment(body, commit_id, path, position)
+        return self.create_review_comment(body, commit, path, position)
 
-    def create_review_comment(self, body, commit_id, path, position):
+    def create_review_comment(self, body, commit, path, position):
         """
         :calls: `POST /repos/{owner}/{repo}/pulls/{number}/comments <https://docs.github.com/en/rest/reference/pulls#review-comments>`_
         :param body: string
-        :param commit_id: :class:`github.Commit.Commit`
+        :param commit: :class:`github.Commit.Commit`
         :param path: string
         :param position: integer
         :rtype: :class:`github.PullRequestComment.PullRequestComment`
         """
         assert isinstance(body, str), body
-        assert isinstance(commit_id, github.Commit.Commit), commit_id
+        assert isinstance(commit, github.Commit.Commit), commit_id
         assert isinstance(path, str), path
         assert isinstance(position, int), position
         post_parameters = {
             "body": body,
-            "commit_id": commit_id._identity,
+            "commit_id": commit._identity,
             "path": path,
             "position": position,
         }


### PR DESCRIPTION
Intuitively, commit_id refers to the sha of the commit, but it is the commit object itself that is required here.