### PR TITLE
Remove RLock from Requester

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -60,7 +60,6 @@ import re
 import time
 import urllib
 from io import IOBase
-from multiprocessing import RLock
 
 import requests
 
@@ -314,8 +313,6 @@ class Requester:
         self.__app_auth = app_auth
         self.__base_url = base_url
 
-        self.__auth_lock = RLock()
-
         if password is not None:
             login = login_or_token
             b64 = (
@@ -388,10 +385,9 @@ class Requester:
         """Get a new access token from the GitHub app installation if the one we have is about to expire"""
         if not self.__installation_authorization:
             return
-        with self.__auth_lock:
-            if self._must_refresh_token():
-                logging.debug("Refreshing access token")
-                self._refresh_token()
+        if self._must_refresh_token():
+            logging.debug("Refreshing access token")
+            self._refresh_token()
 
     def _refresh_token(self) -> None:
         """In the context of a GitHub app, refresh the access token"""


### PR DESCRIPTION
Each process is refreshing its own copy of the token individually, with or without lock.

Fixes #2436.
Fixes #2430.