### PR TITLE
Add support for get_app endpoint with app authentication

### DIFF
--- a/github/GithubIntegration.py
+++ b/github/GithubIntegration.py
@@ -4,6 +4,7 @@ import deprecated
 import jwt
 
 from github import Consts
+from github.GithubApp import GithubApp
 from github.GithubException import GithubException
 from github.Installation import Installation
 from github.InstallationAuthorization import InstallationAuthorization
@@ -84,6 +85,24 @@ class GithubIntegration:
         )
 
         return Installation(
+            requester=self.__requester,
+            headers=headers,
+            attributes=response,
+            completed=True,
+        )
+
+    def _get_app(self):
+        """
+        Get app.
+
+        :param url: str
+        :rtype: :class:`github.GithubApp.GithubApp`
+        """
+        headers, response = self.__requester.requestJsonAndCheck(
+            "GET", "/app", headers=self._get_headers()
+        )
+
+        return GithubApp(
             requester=self.__requester,
             headers=headers,
             attributes=response,

--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -769,9 +769,7 @@ class Github:
         """
         assert slug is github.GithubObject.NotSet or isinstance(slug, str), slug
         if slug is github.GithubObject.NotSet:
-            return GithubApp.GithubApp(
-                self.__requester, {}, {"url": "/app"}, completed=False
-            )
+            return self.__requester.get_app()
         else:
             headers, data = self.__requester.requestJsonAndCheck("GET", f"/apps/{slug}")
             return GithubApp.GithubApp(self.__requester, headers, data, completed=True)

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -381,6 +381,15 @@ class Requester:
             permissions=self.__app_auth.token_permissions,
         )
 
+    def get_app(self):
+        assert self.__app_auth is not None
+        integration = GithubIntegration.GithubIntegration(
+            self.__app_auth.app_id,
+            self.__app_auth.private_key,
+            base_url=self.__base_url,
+        )
+        return integration._get_app()
+
     def _refresh_token_if_needed(self) -> None:
         """Get a new access token from the GitHub app installation if the one we have is about to expire"""
         if not self.__installation_authorization:

--- a/tests/GithubApp.py
+++ b/tests/GithubApp.py
@@ -22,6 +22,8 @@
 
 from datetime import datetime
 
+import github
+
 from . import Framework
 
 
@@ -99,12 +101,19 @@ class GithubApp(Framework.TestCase):
         self.assertEqual(app.url, "/apps/github-actions")
 
     def testGetAuthenticatedApp(self):
+        g = github.Github(
+            app_auth=github.AppAuthentication(
+                app_id=self.app_id,
+                private_key=self.app_private_key,
+                installation_id=29782936,
+            ),
+        )
         # For this to work correctly in record mode, this test must be run with --auth_with_jwt
-        app = self.g.get_app()
+        app = g.get_app()
         # At this point the GithubApp object is not complete.
         # The url should change when the object is completed - after pulling it down
         # from the github API
-        self.assertEqual(app.url, "/app")
+        self.assertEqual(app.url, "/apps/pygithubtest")
         self.assertEqual(app.created_at, datetime(2020, 8, 1, 17, 23, 46))
         self.assertEqual(app.description, "Sample App to test PyGithub")
         self.assertListEqual(
@@ -134,3 +143,7 @@ class GithubApp(Framework.TestCase):
         self.assertEqual(app.slug, "pygithubtest")
         self.assertEqual(app.updated_at, datetime(2020, 8, 1, 17, 44, 31))
         self.assertEqual(app.url, "/apps/pygithubtest")
+
+    def testGetNonAuthenticatedApp(self):
+        with self.assertRaises(AssertionError):
+            self.g.get_app()

--- a/tests/ReplayData/GithubApp.testGetAuthenticatedApp.txt
+++ b/tests/ReplayData/GithubApp.testGetAuthenticatedApp.txt
@@ -1,9 +1,20 @@
 https
+POST
+api.github.com
+None
+/app/installations/29782936/access_tokens
+{'Authorization': 'Bearer jwt_removed', 'User-Agent': 'PyGithub/Python', 'Content-Type': 'application/json'}
+{"permissions": {}}
+201
+[('status', '201 CREATED'), ('server', 'Github.com'), ('date', 'Mon, 24 Oct 2022 23:11:45 GMT'), ('content-type', 'application/json; charset=utf-8'), ('connection', 'keep-alive'), ('content-length', '1962'), ('etag', 'W/"b11a1c9caabe35f1de0a13e597a3022d27d2bff0694c2ccb5a65edc3b4d18837"'), ('cache-control', 'public, max-age=60, s-maxage=60'), ('vary', 'Accept'), ('x-github-media-type', 'github.v3; format=json'), ('access-control-expose-headers', 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset'), ('access-control-allow-origin', '*'), ('strict-transport-security', 'max-age=31536000; includeSubdomains; preload'), ('x-frame-options', 'deny'), ('x-content-type-options', 'nosniff'), ('x-xss-protection', '0'), ('referrer-policy', 'origin-when-cross-origin, strict-origin-when-cross-origin'), ('x-github-request-id', "E475:53DD:8B7A89E:11E38A79:63571BB0"), ('vary', 'Accept-Encoding, Accept, X-Requested-With'), ('content-security-policy', "default-src 'none'")]
+{"token":"ghs_1llwuELtXN5HDOB99XhpcTXdJxbOuF0ZlSmj", "expires_at":"2024-11-25T01:00:02Z", "permissions":{"issues":"read","metadata":"read"}, "repository_selection":"selected"}
+
+https
 GET
 api.github.com
 None
 /app
-{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+{'Accept': 'application/vnd.github.machine-man-preview+json', 'Authorization': 'Bearer jwt_removed', 'User-Agent': 'PyGithub/Python'}
 None
 200
 [('Date', 'Sun, 02 Aug 2020 04:57:48 GMT'), ('Content-Type', 'application/json; charset=utf-8'), ('Transfer-Encoding', 'chunked'), ('Server', 'GitHub.com'), ('Status', '200 OK'), ('Cache-Control', 'public, max-age=60, s-maxage=60'), ('Vary', 'Accept, Accept-Encoding, Accept, X-Requested-With, Accept-Encoding'), ('ETag', 'W/"76244215f77fc6f3d9262dea400b2567"'), ('X-GitHub-Media-Type', 'github.v3; format=json'), ('Access-Control-Expose-Headers', 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset'), ('Access-Control-Allow-Origin', '*'), ('Strict-Transport-Security', 'max-age=31536000; includeSubdomains; preload'), ('X-Frame-Options', 'deny'), ('X-Content-Type-Options', 'nosniff'), ('X-XSS-Protection', '1; mode=block'), ('Referrer-Policy', 'origin-when-cross-origin, strict-origin-when-cross-origin'), ('Content-Security-Policy', "default-src 'none'"), ('Content-Encoding', 'gzip'), ('X-GitHub-Request-Id', 'C28A:25FE:11739F:15A3E5:5F2647CC')]


### PR DESCRIPTION
add support for get_app endpoint for app authenticated applications
    
The /app endpoint requires the use of a JWT to be accessed: https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-the-authenticated-app
    
This change creates a new GithubIntegration and calls the `/app`
endpoint through it so the `requester` used uses JWT and not a token.
    
* Updated exiting GithubApp testGetAuthenticatedApp to use authentication
* added test to validate assertion is raised when not called by an authenticated app.
    
Prior to this, an authenticated application would fail to get access to
its attribute with the following error: https://gist.github.com/chantra/f84e6981e2ab732a5e7acb2978872109
