### PR TITLE
Fixes issue #2521

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1588,6 +1588,7 @@ class Repository(github.GithubObject.CompletableGithubObject):
         :param has_wiki: bool
         :param has_downloads: bool
         :param default_branch: string
+        :param allow_forking: bool
         :param allow_squash_merge: bool
         :param allow_merge_commit: bool
         :param allow_rebase_merge: bool

--- a/github/Repository.pyi
+++ b/github/Repository.pyi
@@ -287,10 +287,12 @@ class Repository(CompletableGithubObject):
         has_wiki: Union[bool, _NotSetType] = ...,
         has_downloads: Union[bool, _NotSetType] = ...,
         default_branch: Union[str, _NotSetType] = ...,
+        allow_forking: Union[bool, _NotSetType] = ...,
         allow_squash_merge: Union[bool, _NotSetType] = ...,
         allow_merge_commit: Union[bool, _NotSetType] = ...,
         allow_rebase_merge: Union[bool, _NotSetType] = ...,
         delete_branch_on_merge: Union[bool, _NotSetType] = ...,
+        allow_update_branch: Union[bool, _NotSetType] = ...,
         archived: Union[bool, _NotSetType] = ...,
     ) -> None: ...
     def enable_automated_security_fixes(self) -> bool: ...


### PR DESCRIPTION
The Repository interface was behind the function itself and would not allow a couple of the options to be used.  This PR brings them inline.