### PR TITLE
Link to stable docs, update introduction in package used by pypi, move auth arg front

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/PyGithub.svg)](https://pypi.python.org/pypi/PyGithub)
 ![CI](https://github.com/PyGithub/PyGithub/workflows/CI/badge.svg)
-[![readthedocs](https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat)](https://pygithub.readthedocs.io/en/latest/?badge=latest)
+[![readthedocs](https://img.shields.io/badge/docs-stable-brightgreen.svg?style=flat)](https://pygithub.readthedocs.io/en/stable/?badge=stable)
 [![License](https://img.shields.io/badge/license-LGPL-blue.svg)](https://en.wikipedia.org/wiki/GNU_Lesser_General_Public_License)
 [![Slack](https://img.shields.io/badge/Slack%20channel-%20%20-blue.svg)](https://join.slack.com/t/pygithub-project/shared_invite/zt-duj89xtx-uKFZtgAg209o6Vweqm8xeQ)
 [![Open Source Helpers](https://www.codetriage.com/pygithub/pygithub/badges/users.svg)](https://www.codetriage.com/pygithub/pygithub)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ for repo in g.get_user().get_repos():
 
 ## Documentation
 
-More information can be found on the [PyGitHub documentation site.](https://pygithub.readthedocs.io/en/latest/introduction.html)
+More information can be found on the [PyGitHub documentation site.](https://pygithub.readthedocs.io/en/stable/introduction.html)
 
 ## Development
 

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -25,7 +25,7 @@ First create a Github instance::
     g = Github(auth=auth)
 
     # Github Enterprise with custom hostname
-    g = Github(base_url="https://{hostname}/api/v3", auth=auth)
+    g = Github(auth=auth, base_url="https://{hostname}/api/v3")
 
 Then play with your Github objects::
 

--- a/setup.py
+++ b/setup.py
@@ -67,22 +67,30 @@ if __name__ == "__main__":
 
                 from github import Github
 
-                # using username and password
-                g = Github("user", "password")
+                # Authentication is defined via github.Auth
+                from github import Auth
 
-                # or using an access token
-                g = Github("access_token")
+                # using an access token
+                auth = Auth.Token("access_token")
+
+                # Public Web Github
+                g = Github(auth=auth)
+
+                # Github Enterprise with custom hostname
+                g = Github(auth=auth, base_url="https://{hostname}/api/v3")
 
             Then play with your Github objects::
 
                 for repo in g.get_user().get_repos():
                     print(repo.name)
                     repo.edit(has_wiki=False)
+                    # to see all the available attributes and methods
+                    print(dir(repo))
 
             Reference documentation
             =======================
 
-            See http://pygithub.readthedocs.io/en/latest/"""
+            See http://pygithub.readthedocs.io/en/stable/"""
         ),
         packages=["github"],
         package_data={"github": ["py.typed", "*.pyi"]},

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
         author_email="vincent@vincent-jacques.net",
         url="https://github.com/pygithub/pygithub",
         project_urls={
-            "Documentation": "http://pygithub.readthedocs.io/en/latest/",
+            "Documentation": "http://pygithub.readthedocs.io/en/stable/",
             "Source": "https://github.com/pygithub/pygithub",
             "Tracker": "https://github.com/pygithub/pygithub/issues",
         },


### PR DESCRIPTION
Pypi and README.md link to the latest docs, which is confusing, as it might include non-released code: #2550

This changes links to stable docs, which are least surprising.

Also Updates example in `setup.py`, that is used by Pypi, which is not up-to-date with docs.