### PR TITLE
Test on Windows and macOS, don't fail fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,21 @@ jobs:
         run: tox
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+
+  test_success:
+    # this aggregates success state of all jobs listed in `needs`
+    # this is the only required check to pass CI
+    name: "Test success"
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - name: "Noop"
+        run: true
+        shell: bash
+
   draft:
     runs-on: ubuntu-latest
-    needs: test
+    needs: test_success
     if: github.ref == 'refs/heads/main'
     steps:
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,22 @@ on:
   pull_request:
 jobs:
   test:
-    runs-on: ubuntu-latest
-    name: test (Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    name: test (Python ${{ matrix.python-version }} on ${{ matrix.os-label }})
     strategy:
+      fail-fast: false
       matrix:
         # keey it sync with tox.ini [gh-actions] section
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        os: ["ubuntu-latest"]
+        os-label: ["Ubuntu"]
+        include:
+          - python-version: "3.8"
+            os: "windows-latest"
+            os-label: "Windows"
+          - python-version: "3.8"
+            os: "macos-latest"
+            os-label: "macOS"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,8 @@ jobs:
         os: ["ubuntu-latest"]
         os-label: ["Ubuntu"]
         include:
-          - python-version: "3.8"
-            os: "windows-latest"
-            os-label: "Windows"
-          - python-version: "3.8"
-            os: "macos-latest"
-            os-label: "macOS"
+          - {python-version: "3.8", os: "windows-latest", os-label: "Windows"}
+          - {python-version: "3.8", os: "macos-latest", os-label: "macOS"}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python


### PR DESCRIPTION
The `Test success` check aggregates all test jobs outcome and allows to require a single check. Then we can modify job names and configure final CI success through workflow file and not repo settings.

This requires removing `CI/test (Python x.y)` as required checks and adding `test success` instead.

This would have discovered #2587 before merge.