### PR TITLE
precommit: move `flake8` as last

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,10 +19,6 @@ repos:
     rev: v5.10.1
     hooks:
       - id: isort
-  - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
-    hooks:
-      - id: flake8
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.1
     hooks:
@@ -37,3 +33,7 @@ repos:
       - id: pyupgrade
         args:
           - --py37-plus
+  - repo: https://github.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8


### PR DESCRIPTION
`flake8` is just a read-only check so does not perform any changes compared to pyupgrade so it makes better sense to move it as last as, eventually, pyuprade could make a change after flake validation, and based on the actual flake8 configuration it may not be compatible so next user will see failing lint even any of his changes...