### PR TITLE
Use timezone-aware reset datetime in GithubRetry.py

### DIFF
--- a/github/GithubRetry.py
+++ b/github/GithubRetry.py
@@ -137,8 +137,8 @@ class GithubRetry(Retry):
                                 if "X-RateLimit-Reset" in response.headers:
                                     value = response.headers.get("X-RateLimit-Reset")
                                     if value and value.isdigit():
-                                        reset = self.__datetime.utcfromtimestamp(
-                                            int(value)
+                                        reset = self.__datetime.fromtimestamp(
+                                            int(value), timezone.utc
                                         )
                                         delta = reset - self.__datetime.now(
                                             timezone.utc

--- a/tests/GithubRetry.py
+++ b/tests/GithubRetry.py
@@ -22,7 +22,7 @@
 import contextlib
 import sys
 import unittest
-from datetime import datetime, timezone
+from datetime import datetime
 from io import BytesIO
 from unittest import mock
 

--- a/tests/GithubRetry.py
+++ b/tests/GithubRetry.py
@@ -132,7 +132,7 @@ class GithubRetry(unittest.TestCase):
         else:
             attr = "github.GithubRetry._GithubRetry__datetime"
         with mock.patch(attr) as dt:
-            dt.now = mock.Mock(return_value=datetime.fromtimestamp(now, timezone.utc))
+            dt.now = lambda tz=None: datetime.fromtimestamp(now, tz=tz)
             dt.fromtimestamp = datetime.fromtimestamp
             yield
 

--- a/tests/GithubRetry.py
+++ b/tests/GithubRetry.py
@@ -22,7 +22,7 @@
 import contextlib
 import sys
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from io import BytesIO
 from unittest import mock
 
@@ -95,7 +95,7 @@ class GithubRetry(unittest.TestCase):
                         mock.call(20, "Request TEST URL failed with 403: None"),
                         mock.call(10, f"Response body indicates retry-able {'primary' if is_primary else 'secondary'} rate limit error: {expected_rate_limit_error}"),
                     ] + ([
-                        mock.call(10, "Reset occurs in 0:00:12 (1644768012 / 2022-02-13 16:00:12)")
+                        mock.call(10, "Reset occurs in 0:00:12 (1644768012 / 2022-02-13 16:00:12+00:00)")
                     ] if has_reset else []) + ([
                         mock.call(10, f"Retry backoff of {expected_retry_backoff}s exceeds required rate limit backoff of {expected_backoff}s")
                     ] if expected_retry_backoff and expected_backoff > 0 else []) + ([
@@ -132,8 +132,8 @@ class GithubRetry(unittest.TestCase):
         else:
             attr = "github.GithubRetry._GithubRetry__datetime"
         with mock.patch(attr) as dt:
-            dt.now = mock.Mock(return_value=datetime.utcfromtimestamp(now))
-            dt.utcfromtimestamp = datetime.utcfromtimestamp
+            dt.now = mock.Mock(return_value=datetime.fromtimestamp(now, timezone.utc))
+            dt.fromtimestamp = datetime.fromtimestamp
             yield
 
     def test_primary_rate_error_with_reset(self):


### PR DESCRIPTION
`reset` and the current datetime used to compute the time delta after which retry should happen were timezone-unaware and timezone-aware respectively, resulting in 

`TypeError: can't subtract offset-naive and offset-aware datetimes` being thrown.

This PR changes `datetime.utcfromtimestamp(int)` to `datetime.fromtimestamp(int, timezone.utc)` making both `reset` and current datetimes timezone-aware.

Tests have been updated to reflect that.