### PR TITLE
Add retry issue to GithubException, don't log it

### DIFF
--- a/github/GithubRetry.py
+++ b/github/GithubRetry.py
@@ -112,7 +112,15 @@ class GithubRetry(Retry):
                         content = self.get_content(response, url)
                         content = json.loads(content)
                         message = content.get("message")
+                    except Exception as e:
+                        # we want to fall back to the actual github exception (probably a rate limit error)
+                        # but provide some context why we could not deal with it without another exception
+                        try:
+                            raise RuntimeError("Failed to inspect response message") from e
+                        except RuntimeError as e:
+                            raise GithubException(response.status, content, response.headers) from e
 
+                    try:
                         if Requester.isRateLimitError(message):
                             rate_type = (
                                 "primary"
@@ -191,11 +199,12 @@ class GithubRetry(Retry):
                     except (MaxRetryError, GithubException):
                         raise
                     except Exception as e:
-                        self.__log(
-                            logging.WARNING,
-                            "Failed to inspect response message",
-                            exc_info=e,
-                        )
+                        # we want to fall back to the actual github exception (probably a rate limit error)
+                        # but provide some context why we could not deal with it without another exception
+                        try:
+                            raise RuntimeError("Failed to determine retry backoff") from e
+                        except RuntimeError as e:
+                            raise GithubException(response.status, content, response.headers) from e
 
                     raise GithubException(response.status, content, response.headers)
 

--- a/github/GithubRetry.py
+++ b/github/GithubRetry.py
@@ -116,9 +116,13 @@ class GithubRetry(Retry):
                         # we want to fall back to the actual github exception (probably a rate limit error)
                         # but provide some context why we could not deal with it without another exception
                         try:
-                            raise RuntimeError("Failed to inspect response message") from e
+                            raise RuntimeError(
+                                "Failed to inspect response message"
+                            ) from e
                         except RuntimeError as e:
-                            raise GithubException(response.status, content, response.headers) from e
+                            raise GithubException(
+                                response.status, content, response.headers
+                            ) from e
 
                     try:
                         if Requester.isRateLimitError(message):
@@ -202,9 +206,13 @@ class GithubRetry(Retry):
                         # we want to fall back to the actual github exception (probably a rate limit error)
                         # but provide some context why we could not deal with it without another exception
                         try:
-                            raise RuntimeError("Failed to determine retry backoff") from e
+                            raise RuntimeError(
+                                "Failed to determine retry backoff"
+                            ) from e
                         except RuntimeError as e:
-                            raise GithubException(response.status, content, response.headers) from e
+                            raise GithubException(
+                                response.status, content, response.headers
+                            ) from e
 
                     raise GithubException(response.status, content, response.headers)
 

--- a/tests/GithubRetry.py
+++ b/tests/GithubRetry.py
@@ -408,9 +408,16 @@ class GithubRetry(unittest.TestCase):
             self.assertEqual({}, exp.exception.headers)
 
             self.assertIsInstance(exp.exception.__cause__, RuntimeError)
-            self.assertEqual(("Failed to inspect response message", ), exp.exception.__cause__.args)
+            self.assertEqual(
+                ("Failed to inspect response message",), exp.exception.__cause__.args
+            )
 
             self.assertIsInstance(exp.exception.__cause__.__cause__, ValueError)
-            self.assertEqual(("Unable to determine whether fp is closed.", ), exp.exception.__cause__.__cause__.args)
+            self.assertEqual(
+                ("Unable to determine whether fp is closed.",),
+                exp.exception.__cause__.__cause__.args,
+            )
 
-        log.assert_called_once_with(logging.INFO, "Request TEST URL failed with 403: NOT GOOD")
+        log.assert_called_once_with(
+            logging.INFO, "Request TEST URL failed with 403: NOT GOOD"
+        )

--- a/tests/GithubRetry.py
+++ b/tests/GithubRetry.py
@@ -20,6 +20,7 @@
 #                                                                              #
 ################################################################################
 import contextlib
+import logging
 import sys
 import unittest
 from datetime import datetime
@@ -406,15 +407,10 @@ class GithubRetry(unittest.TestCase):
             self.assertEqual("NOT GOOD", exp.exception.data)
             self.assertEqual({}, exp.exception.headers)
 
-        self.assertListEqual(
-            [
-                (20, "Request TEST URL failed with 403: NOT GOOD"),
-                (30, "Failed to inspect response message"),
-            ],
-            [call[1] for call in log.mock_calls],
-        )
+            self.assertIsInstance(exp.exception.__cause__, RuntimeError)
+            self.assertEqual(("Failed to inspect response message", ), exp.exception.__cause__.args)
 
-        self.assertListEqual(
-            [{}, {"exc_info": "Unable to determine whether fp is closed."}],
-            [{k: str(v) for k, v in call[2].items()} for call in log.mock_calls],
-        )
+            self.assertIsInstance(exp.exception.__cause__.__cause__, ValueError)
+            self.assertEqual(("Unable to determine whether fp is closed.", ), exp.exception.__cause__.__cause__.args)
+
+        log.assert_called_once_with(logging.INFO, "Request TEST URL failed with 403: NOT GOOD")


### PR DESCRIPTION
Adds cause of retry failures to the exception instead of logging it. This improves identifying issues where no logging is available.