### PR TITLE
Add `download_asset` to `GitReleaseAsset`

### DIFF
--- a/github/GitReleaseAsset.py
+++ b/github/GitReleaseAsset.py
@@ -149,6 +149,12 @@ class GitReleaseAsset(github.GithubObject.CompletableGithubObject):
         headers, data = self._requester.requestJsonAndCheck("PATCH", self.url, input=post_parameters)
         return GitReleaseAsset(self._requester, headers, data, completed=True)
 
+    def download_asset(self, io):
+        """
+        Download the asset.
+        """
+        self._requester.download(self.browser_download_url, file_like=io)
+
     def _initAttributes(self):
         self._url = github.GithubObject.NotSet
         self._id = github.GithubObject.NotSet

--- a/github/GitReleaseAsset.pyi
+++ b/github/GitReleaseAsset.pyi
@@ -1,5 +1,6 @@
 from datetime import datetime
-from typing import Any, Dict, Union
+from typing import Any, Dict
+from io import IOBase
 
 from github.GithubObject import CompletableGithubObject
 from github.NamedUser import NamedUser
@@ -15,6 +16,7 @@ class GitReleaseAsset(CompletableGithubObject):
     @property
     def created_at(self) -> datetime: ...
     def delete_asset(self) -> bool: ...
+    def download_asset(self, io: IOBase) -> None: ...
     @property
     def download_count(self) -> int: ...
     @property

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -648,6 +648,19 @@ class Requester:
         response = self.__requestEncode(cnx, verb, url, parameters, headers, file_like, encode)
         return self.__check(response.status, response.headers, response.text)
 
+    def download(
+        self,
+        public_url: str,
+        file_like: IOBase,
+        cnx: Optional[Union[HTTPRequestsConnectionClass, HTTPSRequestsConnectionClass]] = None,
+    ) -> None:
+        response = self.__requestEncode(
+            cnx, "GET", public_url, None, None, None, None, follow_redirects=True, stream=True
+        )
+        response.underlying.raise_for_status()
+        for chunk in response.underlying.iter_content(chunk_size=128):
+            file_like.write(chunk)
+
     def __requestEncode(
         self,
         cnx: Optional[Union[HTTPRequestsConnectionClass, HTTPSRequestsConnectionClass]],

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -687,6 +687,7 @@ class Requester:
 
         encoded_input = None
         if input is not None:
+            assert encode is not None
             requestHeaders["Content-Type"], encoded_input = encode(input)
 
         self.NEW_DEBUG_FRAME(requestHeaders)

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -89,15 +89,15 @@ class RequestsResponse:
     def __init__(self, r: requests.Response):
         self.underlying = r
         # Cached properties
-        self._headers = None
-        self._text = None
+        self._headers: Optional[Dict[str, Any]] = None
+        self._text: Optional[str] = None
 
     @property
     def status(self) -> int:
         return self.underlying.status_code
 
     @property
-    def headers(self) -> Dict[str, str]:
+    def headers(self) -> Dict[str, Any]:
         if self._headers is None:
             self._headers = {k.lower(): v for k, v in self.underlying.headers.items()}
         return self._headers


### PR DESCRIPTION
This change adds `download_asset` to `GitReleaseAsset` to close the gap on missing functionality.

Unfortunately, the current code isn't designed to handle this use-case so some refactoring was necessary. The changes should only be to private methods/attributes. Ideally, the `RequestsResponse` object was handed around more freely, but I didn't want to break any public-facing APIs.

Fixes https://github.com/PyGithub/PyGithub/issues/2445

