### PR TITLE
Improve ruff DX

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,6 @@ repos:
           - --quiet-level=2
 
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.3.0
     hooks:
       - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,19 +7,6 @@ repos:
       - id: mixed-line-ending
         args: [ --fix=lf ]
 
-  - repo: https://github.com/psf/black
-    rev: 22.10.0
-    hooks:
-      - id: black
-
-  - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.1
-    hooks:
-      - id: codespell
-        exclude: tests/
-        args:
-          - --ignore-words-list="bloaded,nto,pullrequest,pullrequests,thi,tim,wan,Wan,chang,Chang"
-          - --quiet-level=2
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.1.0
     hooks:
@@ -31,4 +18,18 @@ repos:
     rev: 'v0.0.278'
     hooks:
       - id: ruff
-        args: ["--fix"]
+        args: [ "--fix", "--fixable=ALL", "--exit-non-zero-on-fix" ]
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.1
+    hooks:
+      - id: codespell
+        exclude: tests/
+        args:
+          - --ignore-words-list="bloaded,nto,pullrequest,pullrequests,thi,tim,wan,Wan,chang,Chang"
+          - --quiet-level=2
+
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+      - id: black

--- a/tests/Framework.py
+++ b/tests/Framework.py
@@ -330,7 +330,7 @@ class BasicTestCase(unittest.TestCase):
             yield
 
     def __openFile(self, mode):
-        for (_, _, functionName, _) in traceback.extract_stack():
+        for _, _, functionName, _ in traceback.extract_stack():
             if functionName.startswith("test") or functionName == "setUp" or functionName == "tearDown":
                 if functionName != "test":  # because in class Hook(Framework.TestCase), method testTest calls Hook.test
                     fileName = os.path.join(


### PR DESCRIPTION
1. make ruff in pre-commit hook fix all fixable error
2. put ruff before black, so black can format the code generated by `ruff --fix`
3. upgrade black to latest version what still support python3.7