### PR TITLE
fix: allow app installation to use custom certificate authority file

### DIFF
--- a/github/Auth.py
+++ b/github/Auth.py
@@ -256,6 +256,7 @@ class AppInstallationAuth(Auth, WithRequester["AppInstallationAuth"]):
         self.__integration = GithubIntegration(
             auth=self._app_auth,
             base_url=requester.base_url,
+            verify=self._WithRequester__requester._Requester__verify,
         )
 
         return self


### PR DESCRIPTION
Pass the `verify` value from the requester, or it will default to `True`.

<details>
<summary>Minimal code example and explanation</summary>

Assume I have a `ca.pem` for my company, and it won't be able to verify `api.github.com`

```python
auth = Auth.AppAuth(
    app_id,
    private_key,
).get_installation_auth(installation_id)

Github(auth=auth, verify="ca.pem")

# expect a blow up
print(auth.token)
```

It does not blow up, because at the time of evaluation, `verify=True`, and the default CA (which can validate `api.github.com`) is used instead. Why?

It turns out that `verify` was not being passed into the `GithubIntegration` (a couple of layers down in the call stack).
</details>