### PR TITLE
Safely coerce responseHeaders to int

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -670,6 +670,7 @@ class Requester:
                 int(float(responseHeaders[Consts.headerRateLimit])),
             )
         if Consts.headerRateReset in responseHeaders:
+            # ints expected but sometimes floats returned: https://github.com/PyGithub/PyGithub/pull/2697
             self.rate_limiting_resettime = int(float(responseHeaders[Consts.headerRateReset]))
 
         if Consts.headerOAuthScopes in responseHeaders:


### PR DESCRIPTION
Today for the first time I got the following traceback in my CI build. I'm not sure what changed, but casting these headers as float prior to int seems innocent enough.

```
Traceback (most recent call last):
  File "/home/circleci/project/.circleci/update_badge.py", line 23, in <module>
    cov_badge.edit(files={"coverage.svg": InputFileContent(coverage_badge)})
  File "/home/circleci/.pyenv/versions/3.10.12/lib/python3.10/site-packages/github/Gist.py", line 258, in edit
    headers, data = self._requester.requestJsonAndCheck(
  File "/home/circleci/.pyenv/versions/3.10.12/lib/python3.10/site-packages/github/Requester.py", line 399, in requestJsonAndCheck
    *self.requestJson(
  File "/home/circleci/.pyenv/versions/3.10.12/lib/python3.10/site-packages/github/Requester.py", line 499, in requestJson
    return self.__requestEncode(cnx, verb, url, parameters, headers, input, encode)
  File "/home/circleci/.pyenv/versions/3.10.12/lib/python3.10/site-packages/github/Requester.py", line 582, in __requestEncode
    int(responseHeaders[Consts.headerRateRemaining]),
ValueError: invalid literal for int() with base 10: '2499.0'
```