### PR TITLE
Removing use of .netrc from default behaviour. 

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -141,6 +141,16 @@ class Github:
         assert seconds_between_writes is None or seconds_between_writes >= 0
         assert auth is None or isinstance(auth, Auth.Auth), auth
 
+        # The 'requests' package can attempt to use a .netrc or other method to log in to github.
+        # This check minimizes user error where no login credentials are provided.
+        assert (
+            login_or_token is not None
+            or password is not None
+            or jwt is not None
+            or app_auth is not None
+            or auth is not None
+        ), "At least one authorization method is required."
+
         if password is not None:
             warnings.warn(
                 "Arguments login_or_token and password are deprecated, please use "


### PR DESCRIPTION
While attempting to use PyGitHub, I noticed that it would ignore the given credentials and always used my machine's .netrc credentials.

This PR adds an assert to ensure that at least one login method is provided, and ensures that the provided login method is used (via the method proposed in PR #910).

If using a .netrc file is desired as a fallback, the assert could be removed. If that is the case, a flag could be added to the constructor or the documentation updated to explain this.

## Expected Behaviour:

```
User@Computer:~$ python3
Python 3.11
>>> from github import Auth, Github
>>> gh = Github()
>>> print("Using user account {}".format(gh.get_user().login))
Traceback (most recent call last):
    (...)
  File "/home/user/.local/lib/python3.11/site-packages/github/Requester.py", line 487, in __check
    raise self.__createException(status, responseHeaders, data)
github.GithubException.GithubException: 401 {"message": "Requires authentication", "documentation_url": "https://docs.github.com/rest/users/users#get-the-authenticated-user"}
>>>
```

## Actual Behaviour:

```
User@Computer:~$ python3
Python 3.11
>>> from github import Auth, Github
>>> gh = Github()
>>> print("Using user account {}".format(gh.get_user().login))
Using user account DanielNaaykens
>>>
```

## New Behaviour:

```
User@Computer:~$ python3
Python 3.11
>>> from github import Auth, Github
>>> gh = Github()
>>> print("Using user account {}".format(gh.get_user().login))
Traceback (most recent call last):
    (...)
  File "/home/user/.local/lib/python3.11/site-packages/github/MainClass.py", line 139, in __init__
    assert (
AssertionError: At least one authorization method is required.
>>>
```