### PR TITLE
Fix attrName extraction to keep attribute order in initAttributes

### DIFF
--- a/scripts/add_attribute.py
+++ b/scripts/add_attribute.py
@@ -143,7 +143,12 @@ def add_to_initAttributes(lines: list[str]) -> list[str]:
         if inInit:
             if not line or line.endswith(" = github.GithubObject.NotSet") or line.endswith(" = NotSet"):
                 if line:
-                    attrName = line[14:-29]
+                    if line.endswith(" = github.GithubObject.NotSet"):
+                        attrName = line[14:-29]
+                    else:  # line.endswith(" = NotSet")
+                        attrName = line[14:-9]
+                    if ":" in attrName:
+                        attrName = attrName[0:attrName.find(":")].strip()
                 if not line or attrName > attributeName:
                     newLines.append(f"        self._{attributeName}: Attribute[{attributeClassType}] = NotSet")
                     added = True


### PR DESCRIPTION
The `add_attribute.py` script does not maintain attribute order of attributes in `_initAttributes` that follow new coding style (e.g. `self._key: Attribute[str] = NotSet`).

Tested with:

    python scripts/add_attribute.py Commit test string

Was:

```patch
@@ -75,6 +75,7 @@ class Commit(CompletableGithubObject):
         self._sha: Attribute[str] = NotSet
         self._stats: Attribute[CommitStats] = NotSet
         self._url: Attribute[str] = NotSet
+        self._test: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"sha": self._sha.value})
```

Now:

```patch
@@ -74,6 +74,7 @@ class Commit(CompletableGithubObject):
         self._parents: Attribute[list[Commit]] = NotSet
         self._sha: Attribute[str] = NotSet
         self._stats: Attribute[CommitStats] = NotSet
+        self._test: Attribute[str] = NotSet
         self._url: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
```