### PR TITLE
Fix the Pip install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This library enables you to manage [GitHub] resources such as repositories, user
 ## Install
 
 ```bash
-$ pip install PyGithub
+pip install PyGithub
 ```
 
 ## Simple Demo


### PR DESCRIPTION
On the front page of the [README Install](https://github.com/PyGithub/PyGithub#install) Instructions there is a button to copy  `$ pip install PyGithub` command to the clipboard
Due to the leading `$` this command fails when pasted into a terminal
Removing the leading `$` from the command so it can be copy pasted