### PR TITLE
Remove unusable commit input from `Workflow.create_dispatch`

### DIFF
--- a/github/Workflow.py
+++ b/github/Workflow.py
@@ -25,7 +25,6 @@ from datetime import datetime
 from typing import Any
 
 import github.Branch
-import github.Commit
 import github.GithubObject
 import github.NamedUser
 import github.Tag


### PR DESCRIPTION
`Workflow.create_dispatch` currently allows `ref` to be a `github.Commit.Commit` type. 

It appears that this option was added when workflow dispatch support was introduced https://github.com/PyGithub/PyGithub/pull/1625#issuecomment-664364599 but [the GitHub API did not end up supporting it](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event):

>The git reference for the workflow. The reference can be a branch or tag name.

I've tested this behavior with PyGithub and manually invoking the API, both showing the dispatch creation fails when a commit is provided. The Github CLI gives a more verbose response confirming that their definition of ref does not support commits:

```shell
$ gh workflow --ref "<a commit that exists in the repo>" run build.yml
could not create workflow dispatch event: HTTP 422: No ref found for: <a commit that exists in the repo> (https://api.github.com/repos/<redacted>/<redacted>/actions/workflows/<redacted>/dispatches)
```