### PR TITLE
Add state and submitted_at attributes to TimelineEvent

### DIFF
--- a/github/TimelineEvent.py
+++ b/github/TimelineEvent.py
@@ -140,9 +140,6 @@ class TimelineEvent(NonCompletableGithubObject):
         if "state" in attributes:  # pragma no branch
             self._state = self._makeStringAttribute(attributes["state"])
         if "submitted_at" in attributes:  # pragma no branch
-            assert attributes["submitted_at"] is None or isinstance(attributes["submitted_at"], str), attributes[
-                "submitted_at"
-            ]
             self._submitted_at = self._makeDatetimeAttribute(attributes["submitted_at"])
         if "url" in attributes:  # pragma no branch
             self._url = self._makeStringAttribute(attributes["url"])

--- a/github/TimelineEvent.py
+++ b/github/TimelineEvent.py
@@ -27,7 +27,7 @@ from typing import Any
 import github.GithubObject
 import github.NamedUser
 import github.TimelineEventSource
-from github.GithubObject import Attribute, NonCompletableGithubObject, NotSet
+from github.GithubObject import Attribute, NonCompletableGithubObject, NotSet, is_defined
 
 
 class TimelineEvent(NonCompletableGithubObject):
@@ -88,25 +88,25 @@ class TimelineEvent(NonCompletableGithubObject):
 
     @property
     def body(self) -> str | None:
-        if self.event == "commented" and self._body is not NotSet:
+        if is_defined(self._body):
             return self._body.value
         return None
 
     @property
     def author_association(self) -> str | None:
-        if self.event == "commented" and self._author_association is not NotSet:
+        if is_defined(self._author_association):
             return self._author_association.value
         return None
 
     @property
     def state(self) -> str | None:
-        if self.event == "review_requested" and self._submitted_at is not NotSet:
+        if is_defined(self._state):
             return self._state.value
         return None
 
     @property
     def submitted_at(self) -> datetime | None:
-        if self.event == "review_requested" and self._submitted_at is not NotSet:
+        if is_defined(self._submitted_at):
             return self._submitted_at.value
         return None
 

--- a/github/TimelineEvent.py
+++ b/github/TimelineEvent.py
@@ -45,6 +45,8 @@ class TimelineEvent(NonCompletableGithubObject):
         self._commit_url: Attribute[str] = NotSet
         self._source: Attribute[github.TimelineEventSource.TimelineEventSource] = NotSet
         self._url: Attribute[str] = NotSet
+        self._state: Attribute[str] = NotSet
+        self._submitted_at: Attribute[datetime] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"id": self._id.value})
@@ -97,6 +99,18 @@ class TimelineEvent(NonCompletableGithubObject):
         return None
 
     @property
+    def state(self) -> str | None:
+        if self.event == "review_requested" and self._submitted_at is not NotSet:
+            return self._state.value
+        return None
+
+    @property
+    def submitted_at(self) -> datetime | None:
+        if self.event == "review_requested" and self._submitted_at is not NotSet:
+            return self._submitted_at.value
+        return None
+
+    @property
     def url(self) -> str:
         return self._url.value
 
@@ -123,5 +137,12 @@ class TimelineEvent(NonCompletableGithubObject):
             self._body = self._makeStringAttribute(attributes["body"])
         if "author_association" in attributes:  # pragma no branch
             self._author_association = self._makeStringAttribute(attributes["author_association"])
+        if "state" in attributes:  # pragma no branch
+            self._state = self._makeStringAttribute(attributes["state"])
+        if "submitted_at" in attributes:  # pragma no branch
+            assert attributes["submitted_at"] is None or isinstance(attributes["submitted_at"], str), attributes[
+                "submitted_at"
+            ]
+            self._submitted_at = self._makeDatetimeAttribute(attributes["submitted_at"])
         if "url" in attributes:  # pragma no branch
             self._url = self._makeStringAttribute(attributes["url"])


### PR DESCRIPTION
This PR add two new attributes for event type `reviewed`:

- `state`: The state of the submitted review. Can be one of: `commented`, `changes_requested`, `approved` or `dismissed`.
- `submitted_at`: The timestamp indicating when the review was submitted.

Doc: https://docs.github.com/en/rest/overview/issue-event-types?apiVersion=2022-11-28#properties-for-reviewed
