### PR TITLE
Add a requester method to explicitly validate status codes

### DIFF
--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -724,7 +724,7 @@ class PullRequest(CompletableGithubObject):
         """
         :calls: `GET /repos/{owner}/{repo}/pulls/{number}/merge <https://docs.github.com/en/rest/reference/pulls>`_
         """
-        status, headers, data = self._requester.requestJson("GET", f"{self.url}/merge")
+        status, _, _ = self._requester.requestJsonAndValidateStatus("GET", f"{self.url}/merge", valid_codes={204, 404})
         return status == 204
 
     def merge(

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -75,6 +75,7 @@ from typing import (
     ItemsView,
     List,
     Optional,
+    Set,
     Tuple,
     Type,
     TypeVar,
@@ -613,6 +614,22 @@ class Requester:
                 if data.startswith("{") or data.startswith("["):
                     raise
                 return {"data": data}
+
+    def requestJsonAndValidateStatus(
+        self,
+        verb: str,
+        url: str,
+        parameters: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, Any]] = None,
+        input: Optional[Any] = None,
+        cnx: Optional[Union[HTTPRequestsConnectionClass, HTTPSRequestsConnectionClass]] = None,
+        valid_codes: Optional[Set[int]] = None,
+    ) -> Tuple[int, Dict[str, Any], str]:
+        status, responseHeaders, output = self.requestJson(verb, url, parameters, headers, input, cnx=cnx)
+        if valid_codes and status not in valid_codes:
+            data = self.__structuredFromJson(output)
+            raise self.createException(status, responseHeaders, data)
+        return status, responseHeaders, output
 
     def requestJson(
         self,


### PR DESCRIPTION
# Problem

Described a specific scenario in detail here: https://github.com/PyGithub/PyGithub/issues/2760

The general problem is when `requestJson` is used to get a status code and then comparing that to an expected
status code via `status == <expected status>`. This pattern does not handle codes that would be returned due to errors like Authentication errors ( 401, 403) , Validation errors (422), Not found (404), etc. Instead of an appropriate error being raised to the user so they can act on it, the error is swallowed and the call returns False.

# Evaluation

From my understanding of the code, the `is_merged` method uses `requestJson` instead of `requestJsonAndCheck` since the latter would raise an `UnknownObjectException` when a pull request is not merged. This is due to the APIs use of 404 to signify a pull request has not been merged. See [here](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#check-if-a-pull-request-has-been-merged) for details.

The other issue is that `requestJsonAndCheck` does not return the `status` so a comparison on that with an expected code is currently not possible. 

This seems to me like a generic approach is needed that returns `status` and raises exceptions but can ignore certain expected 400+ codes.

# Proposed Solution

I see two possible solutions:
1. Modify `requestJsonAndCheck` to return `status` and ignore certain codes like 404 in the is_merged case.
2. Create a new method that returns `status` and validates it's within the expected codes if not it raises an exception.

I opted not to pursue Solution 1 since it is a breaking change and every call to `requestJsonAndCheck` would need to handle the new `status` returned.

Opted for Solution 2 since it can be implemented in a rolling basis in the scenarios that require it and `requestJsonAndCheck` could remain as is.

**NOTE**: I am new to the code base so if there's a better way of solving this issue that I have missed let me know.