### PR TITLE
CI: Fix mypy error by ignoring override

### DIFF
--- a/github/GithubRetry.py
+++ b/github/GithubRetry.py
@@ -76,13 +76,13 @@ class GithubRetry(Retry):
 
     def new(self, **kw: Any) -> Self:
         kw.update(dict(secondary_rate_wait=self.secondary_rate_wait))
-        return super().new(**kw)
+        return super().new(**kw)  # type: ignore
 
     def increment(
         self,
         method: Optional[str] = None,
         url: Optional[str] = None,
-        response: Optional[HTTPResponse] = None,
+        response: Optional[HTTPResponse] = None,  # type: ignore[override]
         error: Optional[Exception] = None,
         _pool: Optional[ConnectionPool] = None,
         _stacktrace: Optional[TracebackType] = None,
@@ -197,7 +197,7 @@ class GithubRetry(Retry):
         return super().increment(method, url, response, error, _pool, _stacktrace)
 
     @staticmethod
-    def get_content(resp: HTTPResponse, url: str) -> bytes:
+    def get_content(resp: HTTPResponse, url: str) -> bytes:  # type: ignore[override]
         # logic taken from HTTPAdapter.build_response (requests.adapters)
         response = Response()
 


### PR DESCRIPTION
MyPy complains:

```
Error: github/GithubRetry.py:79:16: error: Incompatible return value type (got "Retry", expected "Self")  [return-value]
Error: github/GithubRetry.py:85:9: error: Argument 3 of "increment" is incompatible with supertype "Retry"; supertype defines the argument type as "Optional[BaseHTTPResponse]"  [override]
github/GithubRetry.py:85:9: note: This violates the Liskov substitution principle
github/GithubRetry.py:85:9: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
Found 2 errors in 1 file (checked 265 source files)
```
https://github.com/PyGithub/PyGithub/actions/runs/6371928134/job/17294295599?pr=2779

Urllib3 release 2.0.0a1 introduces `BaseHTTPResponse`.