### PR TITLE
Docs: Fix parameter order according to Version 2.1.0

### DIFF
--- a/doc/examples/PullRequest.rst
+++ b/doc/examples/PullRequest.rst
@@ -15,7 +15,7 @@ Create a new Pull Request
     >>>   - [x] Send 'GET' request
     >>>   - [x] Send 'POST' request with/without body
     >>> '''
-    >>> pr = repo.create_pull(title="Use 'requests' instead of 'httplib'", body=body, head="develop", base="master")
+    >>> pr = repo.create_pull(base="master", head="develop", title="Use 'requests' instead of 'httplib'", body=body)
     >>> pr
     PullRequest(title="Use 'requests' instead of 'httplib'", number=664)
 


### PR DESCRIPTION
Version 2.1.0 introduced a breaking change to the `Repository.create_pull` method. This PR updates the example provided in the docs: https://pygithub.readthedocs.io/en/latest/examples/PullRequest.html#create-a-new-pull-request