### PR TITLE
lock mypy version

### DIFF
--- a/requirements/types.txt
+++ b/requirements/types.txt
@@ -1,4 +1,4 @@
-mypy >=1.0.0
+mypy ==1.5.1
 types-deprecated
 types-jwt
 types-python-dateutil


### PR DESCRIPTION
mypy release a new verion and failed current ci.

So lock it's version to 1.5.1 until we update the code.