### PR TITLE
Add missing attributes to `PullRequest` and `Repository`

### DIFF
--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -94,7 +94,7 @@ class PullRequest(CompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._active_lock_reason: Attribute[str] = NotSet
+        self._active_lock_reason: Attribute[str | None] = NotSet
         self._additions: Attribute[int] = NotSet
         self._assignee: Attribute[github.NamedUser.NamedUser] = NotSet
         self._assignees: Attribute[list[NamedUser]] = NotSet

--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -94,6 +94,7 @@ class PullRequest(CompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
+        self._active_lock_reason: Attribute[str] = NotSet
         self._additions: Attribute[int] = NotSet
         self._assignee: Attribute[github.NamedUser.NamedUser] = NotSet
         self._assignees: Attribute[list[NamedUser]] = NotSet
@@ -114,6 +115,7 @@ class PullRequest(CompletableGithubObject):
         self._id: Attribute[int] = NotSet
         self._issue_url: Attribute[str] = NotSet
         self._labels: Attribute[list[github.Label.Label]] = NotSet
+        self._locked: Attribute[bool] = NotSet
         self._merge_commit_sha: Attribute[str] = NotSet
         self._mergeable: Attribute[bool] = NotSet
         self._mergeable_state: Attribute[str] = NotSet
@@ -137,6 +139,11 @@ class PullRequest(CompletableGithubObject):
 
     def __repr__(self) -> str:
         return self.get__repr__({"number": self._number.value, "title": self._title.value})
+
+    @property
+    def active_lock_reason(self) -> str | None:
+        self._completeIfNotSet(self._active_lock_reason)
+        return self._active_lock_reason.value
 
     @property
     def additions(self) -> int:
@@ -237,6 +244,11 @@ class PullRequest(CompletableGithubObject):
     def labels(self) -> list[github.Label.Label]:
         self._completeIfNotSet(self._labels)
         return self._labels.value
+
+    @property
+    def locked(self) -> bool:
+        self._completeIfNotSet(self._locked)
+        return self._locked.value
 
     @property
     def merge_commit_sha(self) -> str:
@@ -796,6 +808,8 @@ class PullRequest(CompletableGithubObject):
         return status == 202
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:
+        if "active_lock_reason" in attributes:  # pragma no branch
+            self._active_lock_reason = self._makeStringAttribute(attributes["active_lock_reason"])
         if "additions" in attributes:  # pragma no branch
             self._additions = self._makeIntAttribute(attributes["additions"])
         if "assignee" in attributes:  # pragma no branch
@@ -841,6 +855,8 @@ class PullRequest(CompletableGithubObject):
             self._issue_url = self._makeStringAttribute(attributes["issue_url"])
         if "labels" in attributes:  # pragma no branch
             self._labels = self._makeListOfClassesAttribute(github.Label.Label, attributes["labels"])
+        if "locked" in attributes:  # pragma no branch
+            self._locked = self._makeBoolAttribute(attributes["locked"])
         if "maintainer_can_modify" in attributes:  # pragma no branch
             self._maintainer_can_modify = self._makeBoolAttribute(attributes["maintainer_can_modify"])
         if "merge_commit_sha" in attributes:  # pragma no branch

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -468,6 +468,14 @@ class Repository(CompletableGithubObject):
         return self._description.value
 
     @property
+    def disabled(self) -> bool:
+        """
+        :type: bool
+        """
+        self._completeIfNotSet(self._disabled)
+        return self._disabled.value
+
+    @property
     def downloads_url(self) -> str:
         """
         :type: string
@@ -3964,6 +3972,7 @@ class Repository(CompletableGithubObject):
         self._delete_branch_on_merge: Attribute[bool] = NotSet
         self._deployments_url: Attribute[str] = NotSet
         self._description: Attribute[str] = NotSet
+        self._disabled: Attribute[bool] = NotSet
         self._downloads_url: Attribute[str] = NotSet
         self._events_url: Attribute[str] = NotSet
         self._fork: Attribute[bool] = NotSet
@@ -4083,6 +4092,8 @@ class Repository(CompletableGithubObject):
             self._deployments_url = self._makeStringAttribute(attributes["deployments_url"])
         if "description" in attributes:  # pragma no branch
             self._description = self._makeStringAttribute(attributes["description"])
+        if "disabled" in attributes:  # pragma no branch
+            self._disabled = self._makeBoolAttribute(attributes["disabled"])
         if "downloads_url" in attributes:  # pragma no branch
             self._downloads_url = self._makeStringAttribute(attributes["downloads_url"])
         if "events_url" in attributes:  # pragma no branch

--- a/tests/PullRequest.py
+++ b/tests/PullRequest.py
@@ -82,6 +82,7 @@ class PullRequest(Framework.TestCase):
         self.assertEqual(self.pullIssue256Uncached.mergeable_state, "unknown")
 
     def testAttributes(self):
+        self.assertEqual(self.pull.active_lock_reason, None)
         self.assertEqual(self.pull.additions, 511)
         self.assertEqual(self.pull.assignee.login, "jacquev6")
         self.assertListKeyEqual(self.pull.assignees, lambda a: a.login, ["jacquev6"])
@@ -112,6 +113,7 @@ class PullRequest(Framework.TestCase):
             "https://api.github.com/repos/PyGithub/PyGithub/issues/31",
         )
         self.assertListKeyEqual(self.pull.labels, lambda a: a.name, [])
+        self.assertFalse(self.pull.locked)
         self.assertFalse(self.pull.mergeable)
         self.assertFalse(self.pull.rebaseable)
         self.assertTrue(self.pull.merged)

--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -70,6 +70,7 @@ class Repository(Framework.TestCase):
             datetime(2012, 2, 25, 12, 53, 47, tzinfo=timezone.utc),
         )
         self.assertEqual(self.repo.description, "Python library implementing the full Github API v3")
+        self.assertFalse(self.repo.disabled)
         self.assertFalse(self.repo.fork)
         self.assertEqual(self.repo.forks, 3)
         self.assertEqual(self.repo.full_name, "jacquev6/PyGithub")


### PR DESCRIPTION
This PR adds the following attributes which are returned in github API responses but were missing from PyGithub:

- `PullRequest` ([sample JSON response](https://api.github.com/repos/PyGithub/PyGithub/pulls/2793))
  - `active_lock_reason`: str | None
  - `locked`: bool
- `Repository` ([sample JSON response](https://api.github.com/repos/PyGithub/PyGIthub))
  - `disabled`: bool

Happy to address any feedback, and thanks very much for putting together this useful library!
