### PR TITLE
Remove dependency on python-dateutil

### DIFF
--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -50,7 +50,6 @@ from decimal import Decimal
 from operator import itemgetter
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
-from dateutil import parser
 from typing_extensions import Protocol, TypeGuard
 
 from . import Consts
@@ -82,6 +81,20 @@ def _datetime_from_http_date(value: str) -> datetime:
         # RFC7231 states that UTC is assumed if no timezone info is present
         return dt.replace(tzinfo=timezone.utc)
     return dt
+
+
+def _datetime_from_github_isoformat(value: str) -> datetime:
+    """
+    Convert an GitHub API timestamps to a datetime object.
+    Raises ValueError for invalid timestamps.
+    """
+
+    # Github always returns YYYY-MM-DDTHH:MM:SSZ, so we can use the stdlib parser
+    # with some minor adjustments for Python < 3.11 which doesn't support "Z"
+    # https://docs.github.com/en/rest/overview/resources-in-the-rest-api#schema
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value)
 
 
 class _NotSetType:
@@ -258,7 +271,7 @@ class GithubObject:
 
     @staticmethod
     def _makeDatetimeAttribute(value: Optional[str]) -> Attribute[datetime]:
-        return GithubObject.__makeTransformedAttribute(value, str, parser.parse)  # type: ignore
+        return GithubObject.__makeTransformedAttribute(value, str, _datetime_from_github_isoformat)  # type: ignore
 
     @staticmethod
     def _makeHttpDatetimeAttribute(value: Optional[str]) -> Attribute[datetime]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pynacl >=1.4.0
-python-dateutil
 requests >=2.14.0
 pyjwt[crypto] >=2.4.0
 typing-extensions >=4.0.0

--- a/requirements/types.txt
+++ b/requirements/types.txt
@@ -1,5 +1,4 @@
 mypy >=1.0.0
 types-deprecated
 types-jwt
-types-python-dateutil
 types-requests

--- a/tests/BadAttributes.py
+++ b/tests/BadAttributes.py
@@ -26,8 +26,6 @@
 
 from datetime import datetime, timezone
 
-from dateutil.parser import ParserError
-
 import github
 
 from . import Framework
@@ -56,10 +54,10 @@ class BadAttributes(Framework.TestCase):
             user.created_at
         self.assertEqual(raisedexp.exception.actual_value, "foobar")
         self.assertEqual(raisedexp.exception.expected_type, str)
-        self.assertEqual(raisedexp.exception.transformation_exception.__class__, ParserError)
+        self.assertEqual(raisedexp.exception.transformation_exception.__class__, ValueError)
         self.assertEqual(
             raisedexp.exception.transformation_exception.args,
-            ("Unknown string format: %s", "foobar"),
+            ("Invalid isoformat string: 'foobar'",),
         )
 
     def testBadTransformedAttribute(self):

--- a/tests/GithubObject.py
+++ b/tests/GithubObject.py
@@ -77,15 +77,39 @@ class GithubObject(unittest.TestCase):
             (
                 "2021-01-23T12:34:56.000-06:00",
                 datetime(2021, 1, 23, 12, 34, 56, tzinfo=tzoffset(None, -21600)),
-            ),
-            (
-                "Mon, 11 Sep 2023 14:07:29 GMT",
-                datetime(2023, 9, 11, 14, 7, 29, tzinfo=tzutc()),
-            ),
+            )
         ]:
             actual = gho.GithubObject._makeDatetimeAttribute(value)
             self.assertEqual(gho._ValuedAttribute, type(actual), value)
             self.assertEqual(expected, actual.value, value)
+
+    def testMakeHttpDatetimeAttribute(self):
+        for value, expected in [
+            (None, None),
+            # https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1
+            (
+                "Mon, 11 Sep 2023 14:07:29 GMT",
+                datetime(2023, 9, 11, 14, 7, 29, tzinfo=timezone.utc),
+            ),
+            # obsolete formats:
+            (
+                "Monday, 11-Sep-23 14:07:29 GMT",
+                datetime(2023, 9, 11, 14, 7, 29, tzinfo=timezone.utc),
+            ),
+            (
+                "Mon Sep  11 14:07:29 2023",
+                datetime(2023, 9, 11, 14, 7, 29, tzinfo=timezone.utc),
+            ),
+        ]:
+            actual = gho.GithubObject._makeHttpDatetimeAttribute(value)
+            self.assertEqual(gho._ValuedAttribute, type(actual), value)
+            self.assertEqual(expected, actual.value, value)
+
+    def testMakeHttpDatetimeAttributeBadValues(self):
+        for value in ["not a timestamp", 1234]:
+            actual = gho.GithubObject._makeHttpDatetimeAttribute(value)
+            with self.assertRaises(Framework.github.BadAttributeException):
+                actual.value
 
     def testMakeDatetimeAttributeBadValues(self):
         for value in ["not a timestamp", 1234]:

--- a/tests/GithubObject.py
+++ b/tests/GithubObject.py
@@ -23,8 +23,6 @@
 import unittest
 from datetime import datetime, timedelta, timezone
 
-from dateutil.tz.tz import tzoffset, tzutc
-
 from . import Framework
 
 gho = Framework.github.GithubObject
@@ -36,14 +34,6 @@ class GithubObject(unittest.TestCase):
             (None, None),
             (
                 "2021-01-23T12:34:56Z",
-                datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc),
-            ),
-            (
-                "2021-01-23T12:34:56.000Z",
-                datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc),
-            ),
-            (
-                "2021-01-23T12:34:56.000Z",
                 datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc),
             ),
             (
@@ -66,18 +56,6 @@ class GithubObject(unittest.TestCase):
                     tzinfo=timezone(timedelta(hours=-6, minutes=-30)),
                 ),
             ),
-            (
-                "2021-01-23T12:34:56.000+00:00",
-                datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone.utc),
-            ),
-            (
-                "2021-01-23T12:34:56.000+01:00",
-                datetime(2021, 1, 23, 12, 34, 56, tzinfo=timezone(timedelta(hours=1))),
-            ),
-            (
-                "2021-01-23T12:34:56.000-06:00",
-                datetime(2021, 1, 23, 12, 34, 56, tzinfo=tzoffset(None, -21600)),
-            )
         ]:
             actual = gho.GithubObject._makeDatetimeAttribute(value)
             self.assertEqual(gho._ValuedAttribute, type(actual), value)

--- a/tests/Migration.py
+++ b/tests/Migration.py
@@ -45,9 +45,7 @@
 #                                                                              #
 ################################################################################
 
-from datetime import datetime
-
-from dateutil.tz.tz import tzoffset
+from datetime import datetime, timedelta, timezone
 
 import github
 
@@ -72,11 +70,11 @@ class Migration(Framework.TestCase):
         self.assertEqual(self.migration.url, "https://api.github.com/user/migrations/25320")
         self.assertEqual(
             self.migration.created_at,
-            datetime(2018, 9, 14, 1, 35, 35, tzinfo=tzoffset(None, 19800)),
+            datetime(2018, 9, 14, 1, 35, 35, tzinfo=timezone(timedelta(seconds=19800))),
         )
         self.assertEqual(
             self.migration.updated_at,
-            datetime(2018, 9, 14, 1, 35, 46, tzinfo=tzoffset(None, 19800)),
+            datetime(2018, 9, 14, 1, 35, 46, tzinfo=timezone(timedelta(seconds=19800))),
         )
         self.assertEqual(
             repr(self.migration),


### PR DESCRIPTION
According to https://docs.github.com/en/rest/overview/resources-in-the-rest-api#schema the GitHub API only returns timestamps in the format YYYY-MM-DDTHH:MM:SSZ which we can parse with the Python stdlib back to 3.7 if we handle the "Z" ourselves.

This removes the test cases using fractional seconds since the stdlib (< 3.11) can't parse them and according to the above GitHub doesn't return them anyway.