### PR TITLE
Update the class name for NetrcAuth in the examples

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -110,7 +110,7 @@ Improvements
 * Add ``license`` attribute to ``Repository`` (#2721) (26d353e7)
 * Add missing attributes to ``Repository``  (#2742) (65cfeb1b)
 * Add ``is_alphanumeric`` attribute to ``Autolink`` and ``Repository.create_autolink`` (#2630) (b6a28a26)
-* Suppress ``requests`` fallback to netrc, provide ``github.Auth.Netrc`` (#2739) (ac36f6a9)
+* Suppress ``requests`` fallback to netrc, provide ``github.Auth.NetrcAuth`` (#2739) (ac36f6a9)
 * Pass Requester arguments to ``AppInstallationAuth.__integration`` (#2695) (8bf542ae)
 * Adding feature for enterprise consumed license (#2626) (a7bfdf2d)
 * Search Workflows by Name (#2711) (eadc241e)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -69,11 +69,11 @@ Add a timezone information to your ``datetime`` instances before comparison:
 
 A Netrc file (e.g. ``~/.netrc``) does not override PyGithub authentication, anymore.
 If you require authentication through Netrc, then this is a breaking change.
-Use a ``github.Auth.Netrc`` instance to use Netrc credentials:
+Use a ``github.Auth.NetrcAuth`` instance to use Netrc credentials:
 
 .. code-block:: python
 
-    >>> auth = Auth.Netrc()
+    >>> auth = Auth.NetrcAuth()
     >>> g = Github(auth=auth)
     >>> g.get_user().login
     'login'

--- a/doc/examples/Authentication.rst
+++ b/doc/examples/Authentication.rst
@@ -47,11 +47,11 @@ Write your credentials into a ``.netrc`` file:
 
 You might need to create the environment variable ``NETRC`` with the path to this file.
 
-Then, use a ``github.Auth.Netrc`` instance to access these information:
+Then, use a ``github.Auth.NetrcAuth`` instance to access these information:
 
 .. code-block:: python
 
-    >>> auth = Auth.Netrc()
+    >>> auth = Auth.NetrcAuth()
     >>> g = Github(auth=auth)
     >>> g.get_user().login
     'login'


### PR DESCRIPTION
The examples state that to use netrc auth, the class `Auth.Netrc` should be used. But it is actually `Auth.NetrcAuth`.

The release notes for 2.1.0 are also wrong, but I wasn't sure if that should be immutable.