### PR TITLE
Include bypass allowances in RequiredPullRequestReviews

### DIFF
--- a/github/RequiredPullRequestReviews.py
+++ b/github/RequiredPullRequestReviews.py
@@ -44,6 +44,7 @@ from typing import TYPE_CHECKING, Any
 
 import github.NamedUser
 import github.Team
+import github.GithubApp
 from github.GithubObject import Attribute, CompletableGithubObject, NotSet
 
 if TYPE_CHECKING:
@@ -60,8 +61,8 @@ class RequiredPullRequestReviews(CompletableGithubObject):
         self._dismiss_stale_reviews: Attribute[bool] = NotSet
         self._require_code_owner_reviews: Attribute[bool] = NotSet
         self._required_approving_review_count: Attribute[int] = NotSet
-        self._users: Attribute[list[NamedUser]] = NotSet
-        self._teams: Attribute[list[Team]] = NotSet
+        self._dismissal_users: Attribute[list[NamedUser]] = NotSet
+        self._dismissal_teams: Attribute[list[Team]] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__(
@@ -94,23 +95,38 @@ class RequiredPullRequestReviews(CompletableGithubObject):
 
     @property
     def dismissal_users(self) -> list[NamedUser]:
-        self._completeIfNotSet(self._users)
-        return self._users.value
+        self._completeIfNotSet(self._dismissal_users)
+        return self._dismissal_users.value
 
     @property
     def dismissal_teams(self) -> list[Team]:
-        self._completeIfNotSet(self._teams)
-        return self._teams.value
+        self._completeIfNotSet(self._dismissal_teams)
+        return self._dismissal_teams.value
+    
+    @property
+    def bypass_pull_request_allowances_users(self) -> list[NamedUser]:
+        self._completeIfNotSet(self._bypass_pull_request_allowances_users)
+        return self._bypass_pull_request_allowances_users.value
+    
+    @property
+    def bypass_pull_request_allowances_teams(self) -> list[Team]:
+        self._completeIfNotSet(self._bypass_pull_request_allowances_teams)
+        return self._bypass_pull_request_allowances_teams.value
+    
+    @property
+    def bypass_pull_request_allowances_apps(self) -> list[github.GitHubApp.GitHubApp]:
+        self._completeIfNotSet(self._bypass_pull_request_allowances_apps)
+        return self._bypass_pull_request_allowances_apps.value
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:
         if "dismissal_restrictions" in attributes:  # pragma no branch
             if "users" in attributes["dismissal_restrictions"]:
-                self._users = self._makeListOfClassesAttribute(
+                self._dismissal_users = self._makeListOfClassesAttribute(
                     github.NamedUser.NamedUser,
                     attributes["dismissal_restrictions"]["users"],
                 )
             if "teams" in attributes["dismissal_restrictions"]:  # pragma no branch
-                self._teams = self._makeListOfClassesAttribute(
+                self._dismissal_teams = self._makeListOfClassesAttribute(
                     github.Team.Team, attributes["dismissal_restrictions"]["teams"]
                 )
         if "dismiss_stale_reviews" in attributes:  # pragma no branch
@@ -123,3 +139,20 @@ class RequiredPullRequestReviews(CompletableGithubObject):
             )
         if "url" in attributes:  # pragma no branch
             self._url = self._makeStringAttribute(attributes["url"])
+        if "bypass_pull_request_allowances" in attributes:
+            if "users" in attributes["bypass_pull_request_allowances"]:
+                self._bypass_pull_request_allowances_users = self._makeListOfClassesAttribute(
+                    github.NamedUser.NamedUser,
+                    attributes["bypass_pull_request_allowances"]["users"],
+                )
+            if "teams" in attributes["bypass_pull_request_allowances"]:
+                self._bypass_pull_request_allowances_teams = self._makeListOfClassesAttribute(
+                    github.Team.Team,
+                    attributes["bypass_pull_request_allowances"]["teams"],
+                )
+            if "apps" in attributes["bypass_pull_request_allowances"]:
+                self._bypass_pull_request_allowances_apps = self._makeListOfClassesAttribute(
+                    github.GitHubApp.GitHubApp,
+                    attributes["bypass_pull_request_allowances"]["apps"],
+                )
+            


### PR DESCRIPTION
Retrieving a `BranchProtection` doesn't currently include attributes about bypass allowances. This PR adds these new fields to `RequiredPullRequestReviews`, which is a class attribute of `BranchProtection`.