### PR TITLE
fixes a temporary directory in source tree to crash building PyGithub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ integrations = []
 
 [tool.setuptools_scm]
 
+[tool.setuptools]
+packages = ["github"]
+
 [tool.setuptools.package-data]
 github = ["py.typed", '*.pyi']
 


### PR DESCRIPTION
- closes #2887
- explicitly name the modules that should be build in pyproject.toml to tell the build system which modules it should build
- works when creating a empty dir with name `temp` in root of PyGithub
- for reference see https://setuptools.pypa.io/en/latest/userguide/package_discovery.html