### PR TITLE
adding reinstate options to organization invitations

### DIFF
--- a/github/Organization.py
+++ b/github/Organization.py
@@ -1108,7 +1108,7 @@ class Organization(CompletableGithubObject):
         assert is_optional(email, str), email
         assert is_defined(email) != is_defined(user), "specify only one of email or user"
 
-        assert is_undefined(role) or role in ["admin", "direct_member", "billing_manager"], role
+        assert is_undefined(role) or role in ["admin", "direct_member", "billing_manager", "reinstate"], role
         assert is_optional_list(teams, github.Team.Team), teams
 
         parameters: dict[str, Any] = NotSet.remove_unset_items({"email": email, "role": role})


### PR DESCRIPTION
when you create an organization invitation there is a fourth role as "reinstate". It is used for an old member to join the organization with the existing teams, permissions etc.

https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#create-an-organization-invitation