### PR TITLE
implement method to obtain logs download link from workflow run

### DIFF
--- a/github/WorkflowRun.py
+++ b/github/WorkflowRun.py
@@ -191,6 +191,10 @@ class WorkflowRun(CompletableGithubObject):
         return self._logs_url.value
 
     @property
+    def run_attempt_logs_url(self) -> str:
+        return self.logs_url[:-4] + f"attempts/{self.run_attempt}/logs"
+
+    @property
     def check_suite_url(self) -> str:
         self._completeIfNotSet(self._check_suite_url)
         return self._check_suite_url.value
@@ -283,6 +287,38 @@ class WorkflowRun(CompletableGithubObject):
             url_parameters,
             list_item="jobs",
         )
+
+    def get_logs_download_link_for_this_attempt(self) -> str:
+        """
+        :calls "`GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt}/logs <https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#download-workflow-run-attempt-logs>`_
+        """
+        return self._get_logs_download_link(self.run_attempt_logs_url)
+
+    def get_logs_download_link_for_latest_attempt(self) -> str:
+        """
+        :calls "`GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs <https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#download-workflow-run-logs>`_
+        """
+        return self._get_logs_download_link(self.logs_url)
+
+    def _get_logs_download_link(self, url: str) -> str:
+        """
+        A download link will be returned. Here's one way of extracting its content in-memory:
+
+            from io import BytesIO
+            from zipfile import ZipFile
+
+            download_link = workflow_run.get_logs_for_this_run_attempt_download_link()
+            response = requests.get(download_link, allow_redirects=True)
+            assert response.headers['content-type'] == 'application/zip'
+            zip_file = ZipFile(BytesIO(response.content))
+            return {
+                PurePosixPath(zip_info.filename): zip_file.read(zip_info.filename).decode()
+                for zip_info in zip_file.filelist
+            }
+        """
+        headers, _ = self._requester.requestJsonAndCheck("GET", url)
+        assert "location" in headers
+        return headers["location"]
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:
         if "id" in attributes:  # pragma no branch

--- a/tests/WorkflowRun.py
+++ b/tests/WorkflowRun.py
@@ -80,6 +80,10 @@ class WorkflowRun(Framework.TestCase):
             "https://api.github.com/repos/PyGithub/PyGithub/actions/runs/3881497935/logs",
         )
         self.assertEqual(
+            self.workflow_run.run_attempt_logs_url,
+            "https://api.github.com/repos/PyGithub/PyGithub/actions/runs/3881497935/attempt/1/logs",
+        )
+        self.assertEqual(
             self.workflow_run.check_suite_url,
             "https://api.github.com/repos/PyGithub/PyGithub/check-suites/10279069747",
         )
@@ -145,3 +149,13 @@ class WorkflowRun(Framework.TestCase):
             lambda j: j.id,
             [10545727758, 10545727888, 10545728039, 10545728190, 10545728356],
         )
+
+    def test_logs_download_link_for_this_attempt(self):
+        download_link = self.workflow_run.get_logs_download_link_for_this_attempt()
+        self.assertIsInstance(download_link, str)
+        self.assertTrue(download_link, "download link was empty")
+
+    def test_logs_download_link_for_latest_attempt(self):
+        download_link = self.workflow_run.get_logs_download_link_for_latest_attempt()
+        self.assertIsInstance(download_link, str)
+        self.assertTrue(download_link, "download link was empty")


### PR DESCRIPTION
This implements 2 new endpoints:

- Get download link for workflow run (latest attempt)
- Get download link for workflow run (WorkflowRun instance's attempt)

I also supplied a quick example of how to consume this download link, but I'm open to include this as a separate "courtesy" function (e.g.: `def get_logs_for_this_attempt() -> Dict[PurePath, str]: ...`).

I wasn't able to record the tests because I need admin access to the repository. Can an admin do that for me? 🥺 