### PR TITLE
Add runner attributes to WorkflowJob

### DIFF
--- a/github/WorkflowJob.py
+++ b/github/WorkflowJob.py
@@ -53,6 +53,10 @@ class WorkflowJob(CompletableGithubObject):
         self._status: Attribute[str] = NotSet
         self._steps: Attribute[list[github.WorkflowStep.WorkflowStep]] = NotSet
         self._url: Attribute[str] = NotSet
+        self._runner_id: Attribute[int] = NotSet
+        self._runner_name: Attribute[str] = NotSet
+        self._runner_group_id: Attribute[int] = NotSet
+        self._runner_group_name: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"id": self._id.value, "url": self._url.value})
@@ -127,6 +131,26 @@ class WorkflowJob(CompletableGithubObject):
         self._completeIfNotSet(self._url)
         return self._url.value
 
+    @property
+    def runner_id(self) -> int:
+        self._completeIfNotSet(self._runner_id)
+        return self._runner_id.value
+
+    @property
+    def runner_name(self) -> str:
+        self._completeIfNotSet(self._runner_name)
+        return self._runner_name.value
+
+    @property
+    def runner_group_id(self) -> int:
+        self._completeIfNotSet(self._runner_group_id)
+        return self._runner_group_id.value
+
+    @property
+    def runner_group_name(self) -> str:
+        self._completeIfNotSet(self._runner_group_name)
+        return self._runner_group_name.value
+
     def logs_url(self) -> str:
         headers, _ = self._requester.requestBlobAndCheck("GET", f"{self.url}/logs")
         return headers["location"]
@@ -160,3 +184,11 @@ class WorkflowJob(CompletableGithubObject):
             self._steps = self._makeListOfClassesAttribute(github.WorkflowStep.WorkflowStep, attributes["steps"])
         if "url" in attributes:  # pragma no branch
             self._url = self._makeStringAttribute(attributes["url"])
+        if "runner_id" in attributes:  # pragma no branch
+            self._runner_id = self._makeIntAttribute(attributes["runner_id"])
+        if "runner_name" in attributes:  # pragma no branch
+            self._runner_name = self._makeStringAttribute(attributes["runner_name"])
+        if "runner_group_id" in attributes:  # pragma no branch
+            self._runner_group_id = self._makeIntAttribute(attributes["runner_group_id"])
+        if "runner_group_name" in attributes:  # pragma no branch
+            self._runner_group_name = self._makeStringAttribute(attributes["runner_group_name"])

--- a/tests/WorkflowJob.py
+++ b/tests/WorkflowJob.py
@@ -79,3 +79,7 @@ class WorkflowJob(Framework.TestCase):
             self.job.logs_url(),
             "https://pipelines.actions.githubusercontent.com/serviceHosts/d560a817-28d4-4544-a539-eb35c2a56899/_apis/pipelines/1/runs/5/signedlogcontent/5?urlExpires=2023-03-15T17%3A02%3A58.1305046Z&urlSigningMethod=HMACV1&urlSignature=abcdefghijklmn",
         )
+        self.assertEqual(self.job.runner_id, 2)
+        self.assertEqual(self.job.runner_name, "GitHub Actions 2")
+        self.assertEqual(self.job.runner_group_id, 2)
+        self.assertEqual(self.job.runner_group_name, "GitHub Actions")


### PR DESCRIPTION
This patch adds the runner attributes to the WorkflowJob class. The four attributes, runner_id, runner_name, runner_group_id, and runner_group_name are always sent along with the job information, but before this patch, are not represented in PyGtithub. This patch adds the attributes and test coverage.