### PR TITLE
Add .swp fils to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@
 venv
 .tox/
 .mypy_cache/
+*.swp


### PR DESCRIPTION
Vim creates .swp files while editing files. These should be included in the gitignore to ensure that they don't accidentally get committed and to make it easier for users who wish to utilize commands like git add --all.