### PR TITLE
Requester: fix type annotation for requestBlobAndCheck

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -564,7 +564,7 @@ class Requester:
         headers: Optional[Dict[str, str]] = None,
         input: Optional[str] = None,
         cnx: Optional[Union[HTTPRequestsConnectionClass, HTTPSRequestsConnectionClass]] = None,
-    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    ) -> Tuple[Dict[str, Any], str]:
         return self.__check(*self.requestBlob(verb, url, parameters, headers, input, self.__customConnection(url)))
 
     def graphql_query(self, query: str, variables: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:


### PR DESCRIPTION
requestBlob returns `tuple[int, dict[str, Any], str]`, so requestBlobAndCheck should return `tuple[dict[str, Any], str]`.