### PR TITLE
Add rerun-failed-jobs for WorkflowRun

### DIFF
--- a/github/WorkflowRun.py
+++ b/github/WorkflowRun.py
@@ -86,6 +86,7 @@ class WorkflowRun(CompletableGithubObject):
         self._check_suite_url: Attribute[str] = NotSet
         self._cancel_url: Attribute[str] = NotSet
         self._rerun_url: Attribute[str] = NotSet
+        self._rerun_failed_jobs_url: Attribute[str] = NotSet
         self._artifacts_url: Attribute[str] = NotSet
         self._workflow_url: Attribute[str] = NotSet
         self._head_commit: Attribute[GitCommit] = NotSet
@@ -225,6 +226,11 @@ class WorkflowRun(CompletableGithubObject):
         return self._rerun_url.value
 
     @property
+    def rerun_failed_jobs_url(self) -> str:
+        self._completeIfNotSet(self._rerun_failed_jobs_url)
+        return self._rerun_failed_jobs_url.value
+
+    @property
     def workflow_url(self) -> str:
         self._completeIfNotSet(self._workflow_url)
         return self._workflow_url.value
@@ -256,6 +262,13 @@ class WorkflowRun(CompletableGithubObject):
         :calls: `POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun <https://docs.github.com/en/rest/reference/actions#workflow-runs>`_
         """
         status, _, _ = self._requester.requestJson("POST", self.rerun_url)
+        return status == 201
+
+    def rerun_failed_jobs(self) -> bool:
+        """
+        :calls: `POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs <https://docs.github.com/en/rest/reference/actions#workflow-runs>`_
+        """
+        status, _, _ = self._requester.requestJson("POST", self.rerun_failed_jobs_url)
         return status == 201
 
     def timing(self) -> TimingData:
@@ -343,6 +356,8 @@ class WorkflowRun(CompletableGithubObject):
             self._cancel_url = self._makeStringAttribute(attributes["cancel_url"])
         if "rerun_url" in attributes:  # pragma no branch
             self._rerun_url = self._makeStringAttribute(attributes["rerun_url"])
+        if "rerun_failed_jobs_url" in attributes:  # pragma no branch
+            self._rerun_failed_jobs_url = self._makeStringAttribute(attributes["rerun_failed_jobs_url"])
         if "workflow_url" in attributes:  # pragma no branch
             self._workflow_url = self._makeStringAttribute(attributes["workflow_url"])
         if "head_commit" in attributes:  # pragma no branch

--- a/github/WorkflowRun.py
+++ b/github/WorkflowRun.py
@@ -70,6 +70,7 @@ class WorkflowRun(CompletableGithubObject):
         self._path: Attribute[str] = NotSet
         self._head_branch: Attribute[str] = NotSet
         self._head_sha: Attribute[str] = NotSet
+        self._rerun_failed_jobs_url: Attribute[str] = NotSet
         self._run_attempt: Attribute[int] = NotSet
         self._run_number: Attribute[int] = NotSet
         self._created_at: Attribute[datetime] = NotSet
@@ -86,7 +87,6 @@ class WorkflowRun(CompletableGithubObject):
         self._check_suite_url: Attribute[str] = NotSet
         self._cancel_url: Attribute[str] = NotSet
         self._rerun_url: Attribute[str] = NotSet
-        self._rerun_failed_jobs_url: Attribute[str] = NotSet
         self._artifacts_url: Attribute[str] = NotSet
         self._workflow_url: Attribute[str] = NotSet
         self._head_commit: Attribute[GitCommit] = NotSet
@@ -125,6 +125,11 @@ class WorkflowRun(CompletableGithubObject):
     def path(self) -> str:
         self._completeIfNotSet(self._path)
         return self._path.value
+
+    @property
+    def rerun_failed_jobs_url(self) -> str:
+        self._completeIfNotSet(self._rerun_failed_jobs_url)
+        return self._rerun_failed_jobs_url.value
 
     @property
     def run_attempt(self) -> int:
@@ -226,11 +231,6 @@ class WorkflowRun(CompletableGithubObject):
         return self._rerun_url.value
 
     @property
-    def rerun_failed_jobs_url(self) -> str:
-        self._completeIfNotSet(self._rerun_failed_jobs_url)
-        return self._rerun_failed_jobs_url.value
-
-    @property
     def workflow_url(self) -> str:
         self._completeIfNotSet(self._workflow_url)
         return self._workflow_url.value
@@ -315,6 +315,8 @@ class WorkflowRun(CompletableGithubObject):
             self._display_title = self._makeStringAttribute(attributes["display_title"])
         if "path" in attributes:  # pragma no branch
             self._path = self._makeStringAttribute(attributes["path"])
+        if "rerun_failed_jobs_url" in attributes:  # pragma no branch
+            self._rerun_failed_jobs_url = self._makeStringAttribute(attributes["rerun_failed_jobs_url"])
         if "run_attempt" in attributes:  # pragma no branch
             self._run_attempt = self._makeIntAttribute(attributes["run_attempt"])
         if "run_number" in attributes:  # pragma no branch
@@ -356,8 +358,6 @@ class WorkflowRun(CompletableGithubObject):
             self._cancel_url = self._makeStringAttribute(attributes["cancel_url"])
         if "rerun_url" in attributes:  # pragma no branch
             self._rerun_url = self._makeStringAttribute(attributes["rerun_url"])
-        if "rerun_failed_jobs_url" in attributes:  # pragma no branch
-            self._rerun_failed_jobs_url = self._makeStringAttribute(attributes["rerun_failed_jobs_url"])
         if "workflow_url" in attributes:  # pragma no branch
             self._workflow_url = self._makeStringAttribute(attributes["workflow_url"])
         if "head_commit" in attributes:  # pragma no branch

--- a/tests/ReplayData/WorkflowRun.test_rerun_failed_jobs.txt
+++ b/tests/ReplayData/WorkflowRun.test_rerun_failed_jobs.txt
@@ -1,0 +1,10 @@
+https
+POST
+api.github.com
+None
+/repos/PyGithub/PyGithub/actions/runs/3910280793/rerun-failed-jobs
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+None
+201
+[('Server', 'GitHub.com'), ('Date', 'Fri, 13 Jan 2023 13:19:55 GMT'), ('Content-Type', 'application/json; charset=utf-8'), ('Transfer-Encoding', 'chunked'), ('X-GitHub-Media-Type', 'github.v3; format=json'), ('x-github-api-version-selected', '2022-11-28'), ('X-RateLimit-Limit', '60'), ('X-RateLimit-Remaining', '25'), ('X-RateLimit-Reset', '1673619381'), ('X-RateLimit-Used', '35'), ('X-RateLimit-Resource', 'core'), ('Access-Control-Expose-Headers', 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset'), ('Access-Control-Allow-Origin', '*'), ('Strict-Transport-Security', 'max-age=31536000; includeSubdomains; preload'), ('X-Frame-Options', 'deny'), ('X-Content-Type-Options', 'nosniff'), ('X-XSS-Protection', '0'), ('Referrer-Policy', 'origin-when-cross-origin, strict-origin-when-cross-origin'), ('Content-Security-Policy', "default-src 'none'"), ('Vary', 'Accept-Encoding, Accept, X-Requested-With'), ('Content-Encoding', 'gzip'), ('X-GitHub-Request-Id', 'CBBF:42BA:0E45:5D33:63C15A7B')]
+{ }

--- a/tests/WorkflowRun.py
+++ b/tests/WorkflowRun.py
@@ -96,10 +96,6 @@ class WorkflowRun(Framework.TestCase):
             "https://api.github.com/repos/PyGithub/PyGithub/actions/runs/3881497935/rerun",
         )
         self.assertEqual(
-            self.workflow_run.rerun_failed_jobs_url,
-            "https://api.github.com/repos/PyGithub/PyGithub/actions/runs/3910280793/rerun-failed-jobs",
-        )
-        self.assertEqual(
             self.workflow_run.workflow_url,
             "https://api.github.com/repos/PyGithub/PyGithub/actions/workflows/1903133",
         )
@@ -134,10 +130,6 @@ class WorkflowRun(Framework.TestCase):
     def test_rerun_with_successful_run(self):
         wr = self.repo.get_workflow_run(3881497935)
         self.assertFalse(wr.rerun())
-
-    def test_rerun_failed_jobs(self):
-        wr = self.repo.get_workflow_run(3910280793)
-        self.assertFalse(wr.rerun_failed_jobs())
 
     def test_cancel(self):
         wr = self.repo.get_workflow_run(3911660493)

--- a/tests/WorkflowRun.py
+++ b/tests/WorkflowRun.py
@@ -96,6 +96,10 @@ class WorkflowRun(Framework.TestCase):
             "https://api.github.com/repos/PyGithub/PyGithub/actions/runs/3881497935/rerun",
         )
         self.assertEqual(
+            self.workflow_run.rerun_failed_jobs_url,
+            "https://api.github.com/repos/PyGithub/PyGithub/actions/runs/3910280793/rerun-failed-jobs",
+        )
+        self.assertEqual(
             self.workflow_run.workflow_url,
             "https://api.github.com/repos/PyGithub/PyGithub/actions/workflows/1903133",
         )

--- a/tests/WorkflowRun.py
+++ b/tests/WorkflowRun.py
@@ -96,6 +96,10 @@ class WorkflowRun(Framework.TestCase):
             "https://api.github.com/repos/PyGithub/PyGithub/actions/runs/3881497935/rerun",
         )
         self.assertEqual(
+            self.workflow_run.rerun_failed_jobs_url,
+            "https://api.github.com/repos/PyGithub/PyGithub/actions/runs/3881497935/rerun-failed-jobs",
+        )
+        self.assertEqual(
             self.workflow_run.workflow_url,
             "https://api.github.com/repos/PyGithub/PyGithub/actions/workflows/1903133",
         )
@@ -130,6 +134,10 @@ class WorkflowRun(Framework.TestCase):
     def test_rerun_with_successful_run(self):
         wr = self.repo.get_workflow_run(3881497935)
         self.assertFalse(wr.rerun())
+
+    def test_rerun_failed_jobs(self):
+        wr = self.repo.get_workflow_run(3910280793)
+        self.assertFalse(wr.rerun_failed_jobs())
 
     def test_cancel(self):
         wr = self.repo.get_workflow_run(3911660493)

--- a/tests/WorkflowRun.py
+++ b/tests/WorkflowRun.py
@@ -96,10 +96,6 @@ class WorkflowRun(Framework.TestCase):
             "https://api.github.com/repos/PyGithub/PyGithub/actions/runs/3881497935/rerun",
         )
         self.assertEqual(
-            self.workflow_run.rerun_failed_jobs_url,
-            "https://api.github.com/repos/PyGithub/PyGithub/actions/runs/3881497935/rerun-failed-jobs",
-        )
-        self.assertEqual(
             self.workflow_run.workflow_url,
             "https://api.github.com/repos/PyGithub/PyGithub/actions/workflows/1903133",
         )


### PR DESCRIPTION
GitHub API provides an ability to rerun only failed jobs in a workflow: https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#re-run-failed-jobs-from-a-workflow-run

PR adds `rerun_failed_jobs` attribute. I also tried to add tests but it seems I need some help with them or a hint how can I fix them.