### PR TITLE
remove commit reference

### DIFF
--- a/github/Workflow.py
+++ b/github/Workflow.py
@@ -138,8 +138,6 @@ class Workflow(CompletableGithubObject):
         assert inputs is NotSet or isinstance(inputs, dict), inputs
         if isinstance(ref, github.Branch.Branch):
             ref = ref.name
-        elif isinstance(ref, github.Commit.Commit):
-            ref = ref.sha
         elif isinstance(ref, github.Tag.Tag):
             ref = ref.name
         if inputs is NotSet:


### PR DESCRIPTION
The Github API doesn't support commit SHAs
as it is limited to branches and tags.

closes:https://github.com/PyGithub/PyGithub/issues/2881