### PR TITLE
Allow datetime authorship dates when creating commits

### DIFF
--- a/github/InputGitAuthor.py
+++ b/github/InputGitAuthor.py
@@ -37,7 +37,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Union
+from typing import Any
 
 from github.GithubObject import NotSet, Opt, is_defined, is_optional
 


### PR DESCRIPTION
Apparently github will take any timezone offset when specifying authorship, it just adjusts internally (I have not checked if it does that on input or output, but it's not really relevant to pygithub).