### PR TITLE
Fix docstring formatting in `create_file` and `update_file`

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -2387,8 +2387,7 @@ class Repository(CompletableGithubObject):
         """
         Create a file in this repository.
 
-        :calls: `PUT /repos/{owner}/{repo}/contents/{path} <https://docs.github.com/en/rest/reference/repos#create-or-
-            update-file-contents>`_
+        :calls: `PUT /repos/{owner}/{repo}/contents/{path} <https://docs.github.com/en/rest/reference/repos#create-or-update-file-contents>`_
         :param path: string, (required), path of the file in the repository
         :param message: string, (required), commit message
         :param content: string, (required), the actual data in the file
@@ -2469,8 +2468,7 @@ class Repository(CompletableGithubObject):
         """
         This method updates a file in a repository.
 
-        :calls: `PUT /repos/{owner}/{repo}/contents/{path} <https://docs.github.com/en/rest/reference/repos#create-or-
-            update-file-contents>`_
+        :calls: `PUT /repos/{owner}/{repo}/contents/{path} <https://docs.github.com/en/rest/reference/repos#create-or-update-file-contents>`_
         :param path: string, Required. The content path.
         :param message: string, Required. The commit message.
         :param content: string, Required. The updated file content, either base64 encoded, or ready to be encoded.
@@ -2528,8 +2526,7 @@ class Repository(CompletableGithubObject):
         """
         This method deletes a file in a repository.
 
-        :calls: `DELETE /repos/{owner}/{repo}/contents/{path} <https://docs.github.com/en/rest/reference/repos#delete-a-
-        file>`_
+        :calls: `DELETE /repos/{owner}/{repo}/contents/{path} <https://docs.github.com/en/rest/reference/repos#delete-a-file>`_
         :param path: string, Required. The content path.
         :param message: string, Required. The commit message.
         :param sha: string, Required. The blob SHA of the file being replaced.


### PR DESCRIPTION
Formatting is currently broken as can be seen on [the published documentation](https://pygithub.readthedocs.io/en/v2.3.0/github_objects/Repository.html#github.Repository.Repository.create_file): line-breaking to the first column makes rST thing the info list has ended and go back to regular content, making a hash of the rest of the commit until reaching the next indented section which is interpreted as a quote, following which the new info fields are seen again.