### PR TITLE
Remove redundant types from docstrings

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,8 +40,6 @@ import os
 import re
 import sys
 import typing
-# make annotations visible to Sphinx
-typing.TYPE_CHECKING = True
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -152,6 +152,7 @@ from __future__ import annotations
 
 import collections
 import urllib.parse
+import sys
 from base64 import b64encode
 from collections.abc import Iterable
 from datetime import date, datetime, timezone
@@ -242,7 +243,7 @@ from github.GithubObject import (
 )
 from github.PaginatedList import PaginatedList
 
-if TYPE_CHECKING:
+if TYPE_CHECKING or 'sphinx' in sys.modules:
     from github.Artifact import Artifact
     from github.AuthenticatedUser import AuthenticatedUser
     from github.Autolink import Autolink


### PR DESCRIPTION
surely sphinx can get that from the actual types?