### PR TITLE
Resolve login when repr-ing AuthenticatedUser

### DIFF
--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -177,7 +177,7 @@ class AuthenticatedUser(CompletableGithubObject):
         self._two_factor_authentication: Attribute[bool] = NotSet
 
     def __repr__(self) -> str:
-        return self.get__repr__({"login": self._login.value or "<UNKNOWN>"})
+        return self.get__repr__({"login": self._login.value or "(UNKNOWN)"})
 
     @property
     def avatar_url(self) -> str:


### PR DESCRIPTION
It's extremely confusing to dump an `AuthenticatedUser` and get `AuthenticatedUser(login=None)` even though the `AuthenticatedUser` is correctly set up, and necessarily has a login.

This risks incurring additional requests, but I think in the contexts where it would be used (mostly at the shell or when debugging services) it's more helpful to actually show the information.