### PR TITLE
Feature: transfer a repository ownership

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -4096,7 +4096,7 @@ class Repository(CompletableGithubObject):
         assert isinstance(new_owner, str), new_owner
         assert is_optional(new_name, str), new_name
         assert is_optional(team_ids, list), team_ids
-        status, _, _ = self._requester.requestJsonAndCheck(
+        status, _, _ = self._requester.requestJson(
             "POST",
             f"{self.url}/transfer",
             input=NotSet.remove_unset_items({"new_owner": new_owner, "new_name": new_name, "team_ids": team_ids}),

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -4085,6 +4085,24 @@ class Repository(CompletableGithubObject):
         )
         return github.DependabotAlert.DependabotAlert(self._requester, headers, data, completed=True)
 
+    def edit_ownersip(self, new_owner: str, new_name: str = NotSet, team_ids: list[int] = NotSet) -> bool:
+        """
+        :calls: `POST /repos/{owner}/{repo}/transfer <https://docs.github.com/en/rest/repos/repos#transfer-a-repository>`_
+        :param new_owner: string
+        :param new_name: Optional string
+        :param team_ids: Optional list of int
+        :rtype: bool
+        """
+        assert isinstance(new_owner, str), new_owner
+        assert is_optional(new_name, str), new_name
+        assert is_optional(team_ids, list), team_ids
+        status, _, _ = self._requester.requestJsonAndCheck(
+            "POST",
+            f"{self.url}/transfer",
+            input=NotSet.remove_unset_items({"new_owner": new_owner, "new_name": new_name, "team_ids": team_ids}),
+        )
+        return status == 202
+
     def _initAttributes(self) -> None:
         self._allow_auto_merge: Attribute[bool] = NotSet
         self._allow_forking: Attribute[bool] = NotSet


### PR DESCRIPTION
[https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#transfer-a-repository](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#transfer-a-repository )
This feature is not implemented, so I implemented it. 

Note: In our testing, we found that this feature only works with login authentication.