### PR TITLE
Add marking notification as done method

### DIFF
--- a/github/Notification.py
+++ b/github/Notification.py
@@ -129,6 +129,15 @@ class Notification(CompletableGithubObject):
             self.url,
         )
 
+    def mark_as_done(self) -> None:
+        """
+        :calls: `DELETE /notifications/threads/{id} <https://docs.github.com/en/rest/reference/activity#notifications>`_
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url,
+        )
+
     def get_pull_request(self) -> github.PullRequest.PullRequest:
         headers, data = self._requester.requestJsonAndCheck("GET", self.subject.url)
         return github.PullRequest.PullRequest(self._requester, headers, data, completed=True)

--- a/tests/Notification.py
+++ b/tests/Notification.py
@@ -41,3 +41,6 @@ class Notification(Framework.TestCase):
 
     def testMarkAsRead(self):
         self.notification.mark_as_read()
+
+    def testMarkAsDone(self):
+        self.notification.mark_as_done()

--- a/tests/ReplayData/Notification.testMarkAsDone.txt
+++ b/tests/ReplayData/Notification.testMarkAsDone.txt
@@ -1,0 +1,9 @@
+https
+DELETE
+api.github.com
+None
+/notifications/threads/10073016181
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+None
+204
+[('Server', 'GitHub.com'), ('Date', 'Tue, 21 May 2024 22:12:05 GMT'), ('X-OAuth-Scopes', 'admin:enterprise, admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook, admin:ssh_signing_key, audit_log, codespace, copilot, delete:packages, delete_repo, gist, notifications, project, repo, user, workflow, write:discussion, write:packages'), ('X-Accepted-OAuth-Scopes', 'notifications, repo'), ('github-authentication-token-expiration', '2024-05-28 22:05:37 UTC'), ('X-GitHub-Media-Type', 'github.v3; format=json'), ('x-github-api-version-selected', '2022-11-28'), ('X-RateLimit-Limit', '5000'), ('X-RateLimit-Remaining', '4975'), ('X-RateLimit-Reset', '1716332268'), ('X-RateLimit-Used', '25'), ('X-RateLimit-Resource', 'core'), ('Access-Control-Expose-Headers', 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset'), ('Access-Control-Allow-Origin', '*'), ('Strict-Transport-Security', 'max-age=31536000; includeSubdomains; preload'), ('X-Frame-Options', 'deny'), ('X-Content-Type-Options', 'nosniff'), ('X-XSS-Protection', '0'), ('Referrer-Policy', 'origin-when-cross-origin, strict-origin-when-cross-origin'), ('Content-Security-Policy', "default-src 'none'"), ('Vary', 'Accept-Encoding, Accept, X-Requested-With'), ('X-GitHub-Request-Id', 'E7D9:314FA9:9BFAE50:9CC86C7:664D1C35')]


### PR DESCRIPTION
This PR adds the ability to mark a notification as done, following the already implemented mark as read by https://github.com/PyGithub/PyGithub/pull/932

Closes https://github.com/PyGithub/PyGithub/issues/2947
