### PR TITLE
Add possibility to mark a thread/notification as done

### DIFF
--- a/github/Notification.py
+++ b/github/Notification.py
@@ -129,6 +129,15 @@ class Notification(CompletableGithubObject):
             self.url,
         )
 
+    def mark_as_done(self) -> None:
+        """
+        :calls: `DELETE /notifications/threads/{id} <https://docs.github.com/en/rest/reference/activity#notifications>`_
+        """
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            self.url,
+        )
+
     def get_pull_request(self) -> github.PullRequest.PullRequest:
         headers, data = self._requester.requestJsonAndCheck("GET", self.subject.url)
         return github.PullRequest.PullRequest(self._requester, headers, data, completed=True)

--- a/tests/Notification.py
+++ b/tests/Notification.py
@@ -41,3 +41,6 @@ class Notification(Framework.TestCase):
 
     def testMarkAsRead(self):
         self.notification.mark_as_read()
+
+    def testMarkAsDone(self):
+        self.notification.mark_as_done()

--- a/tests/ReplayData/Notification.testMarkAsDone.txt
+++ b/tests/ReplayData/Notification.testMarkAsDone.txt
@@ -1,0 +1,9 @@
+https
+DELETE
+api.github.com
+None
+/notifications/threads/397777914
+{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+None
+204
+[('Server', 'GitHub.com'), ('Date', 'Thu, 18 Oct 2018 18:46:59 GMT'), ('Content-Type', 'text/plain;charset=utf-8'), ('Content-Length', '0'), ('Status', '204 No Content'), ('X-RateLimit-Limit', '5000'), ('X-RateLimit-Remaining', '4983'), ('X-RateLimit-Reset', '1539890344'), ('X-OAuth-Scopes', 'admin:gpg_key, admin:public_key, admin:repo_hook, gist, notifications, repo, user, write:discussion'), ('X-Accepted-OAuth-Scopes', 'notifications, repo'), ('X-GitHub-Media-Type', 'github.v3; format=json'), ('Access-Control-Expose-Headers', 'ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval'), ('Access-Control-Allow-Origin', '*'), ('Strict-Transport-Security', 'max-age=31536000; includeSubdomains; preload'), ('X-Frame-Options', 'deny'), ('X-Content-Type-Options', 'nosniff'), ('X-XSS-Protection', '1; mode=block'), ('Referrer-Policy', 'origin-when-cross-origin, strict-origin-when-cross-origin'), ('Content-Security-Policy', "default-src 'none'"), ('X-GitHub-Request-Id', 'B14A:4C25:2AC483C:58CB194:5BC8D523')]


### PR DESCRIPTION
This PR adds the ability to mark a notification as done, following the already implemented `mark_as_read` by #932. Duplicated by #2976.

Fixes #2947

Co-authored-by: Hodei Navarro <hodei.navarro@outlook.com>