### PR TITLE
Add node_id attribute to IssueComment class

### DIFF
--- a/github/IssueComment.py
+++ b/github/IssueComment.py
@@ -71,6 +71,7 @@ class IssueComment(CompletableGithubObject):
         self._created_at: Attribute[datetime] = NotSet
         self._id: Attribute[int] = NotSet
         self._issue_url: Attribute[str] = NotSet
+        self._node_id: Attribute[str] = NotSet
         self._updated_at: Attribute[datetime] = NotSet
         self._url: Attribute[str] = NotSet
         self._html_url: Attribute[str] = NotSet
@@ -99,6 +100,11 @@ class IssueComment(CompletableGithubObject):
     def issue_url(self) -> str:
         self._completeIfNotSet(self._issue_url)
         return self._issue_url.value
+
+    @property
+    def node_id(self) -> str:
+        self._completeIfNotSet(self._node_id)
+        return self._node_id.value
 
     @property
     def updated_at(self) -> datetime:
@@ -194,6 +200,8 @@ class IssueComment(CompletableGithubObject):
             self._id = self._makeIntAttribute(attributes["id"])
         if "issue_url" in attributes:  # pragma no branch
             self._issue_url = self._makeStringAttribute(attributes["issue_url"])
+        if "node_id" in attributes:  # pragma no branch
+            self._node_id = self._makeStringAttribute(attributes["node_id"])
         if "updated_at" in attributes:  # pragma no branch
             self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
         if "url" in attributes:  # pragma no branch


### PR DESCRIPTION
Fix #3003.
I am adding it simply by running `python scripts/add_attribute.py IssueComment node_id string`.