### PR TITLE
Add signature field for commits

### DIFF
--- a/github/Commit.py
+++ b/github/Commit.py
@@ -90,6 +90,7 @@ class Commit(CompletableGithubObject):
         self._html_url: Attribute[str] = NotSet
         self._parents: Attribute[list[Commit]] = NotSet
         self._sha: Attribute[str] = NotSet
+        self._signature: Attribute[str] = NotSet
         self._stats: Attribute[CommitStats] = NotSet
         self._url: Attribute[str] = NotSet
 
@@ -146,6 +147,11 @@ class Commit(CompletableGithubObject):
     def sha(self) -> str:
         self._completeIfNotSet(self._sha)
         return self._sha.value
+
+    @property
+    def signature(self) -> str:
+        self._completeIfNotSet(self._signature)
+        return self._signature.value
 
     @property
     def stats(self) -> CommitStats:
@@ -307,6 +313,8 @@ class Commit(CompletableGithubObject):
             self._parents = self._makeListOfClassesAttribute(Commit, attributes["parents"])
         if "sha" in attributes:  # pragma no branch
             self._sha = self._makeStringAttribute(attributes["sha"])
+        if "signature" in attributes:  # pragma no branch
+            self._signature = self._makeStringAttribute(attributes["signature"])
         if "stats" in attributes:  # pragma no branch
             self._stats = self._makeClassAttribute(github.CommitStats.CommitStats, attributes["stats"])
         if "url" in attributes:  # pragma no branch

--- a/github/GitCommit.py
+++ b/github/GitCommit.py
@@ -63,6 +63,7 @@ class GitCommit(CompletableGithubObject):
         self._message: Attribute[str] = NotSet
         self._parents: Attribute[list[GitCommit]] = NotSet
         self._sha: Attribute[str] = NotSet
+        self._signature: Attribute[str] = NotSet
         self._tree: Attribute[github.GitTree.GitTree] = NotSet
         self._url: Attribute[str] = NotSet
 
@@ -100,6 +101,11 @@ class GitCommit(CompletableGithubObject):
         return self._sha.value
 
     @property
+    def signature(self) -> str:
+        self._completeIfNotSet(self._signature)
+        return self._signature.value
+
+    @property
     def tree(self) -> github.GitTree.GitTree:
         self._completeIfNotSet(self._tree)
         return self._tree.value
@@ -126,6 +132,8 @@ class GitCommit(CompletableGithubObject):
             self._parents = self._makeListOfClassesAttribute(GitCommit, attributes["parents"])
         if "sha" in attributes:  # pragma no branch
             self._sha = self._makeStringAttribute(attributes["sha"])
+        if "signature" in attributes:  # pragma no branch
+            self._signature = self._makeStringAttribute(attributes["signature"])
         if "tree" in attributes:  # pragma no branch
             self._tree = self._makeClassAttribute(github.GitTree.GitTree, attributes["tree"])
         if "url" in attributes:  # pragma no branch


### PR DESCRIPTION
The REST API documentation includes the signature field: https://docs.github.com/en/rest/git/commits?apiVersion=2022-11-28#create-a-commit

This PR adds the optional field.