### PR TITLE
avoid pre-commit action in order to pin pre-commit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,17 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.x"
-      - uses: pre-commit/action@v3.0.0
+      # FIXME: pin pre-commit<4 pending PyCQA/docformatter#287
+      - name: install pre-commit
+        run: python -m pip install 'pre-commit<4'
+      - name: show environment
+        run: python -m pip freeze --local
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: run pre-commit
+        run: pre-commit run --show-diff-on-failure --color=always --all-files
 
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
mainly to pin pre-commit for now

pre-commit action doesn't save much, and relinquishes some control

fixes #3058 