### PR TITLE
PullRequest.delete_branch: fix the remaining pull requests check

### DIFF
--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -777,7 +777,7 @@ class PullRequest(CompletableGithubObject):
         Convenience function that calls :meth:`GitRef.delete` :rtype: bool.
         """
         if not force:
-            remaining_pulls = self.head.repo.get_pulls(head=self.head.ref)
+            remaining_pulls = self.head.repo.get_pulls(head=f"{self.head.repo.owner.name}:{self.head.ref}")
             if remaining_pulls.totalCount > 0:
                 raise RuntimeError(
                     "This branch is referenced by open pull requests, set force=True to delete this branch."

--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -777,7 +777,7 @@ class PullRequest(CompletableGithubObject):
         Convenience function that calls :meth:`GitRef.delete` :rtype: bool.
         """
         if not force:
-            remaining_pulls = self.head.repo.get_pulls(head=f"{self.head.repo.owner.name}:{self.head.ref}")
+            remaining_pulls = self.head.repo.get_pulls(head=f"{self.head.repo.owner.login}:{self.head.ref}")
             if remaining_pulls.totalCount > 0:
                 raise RuntimeError(
                     "This branch is referenced by open pull requests, set force=True to delete this branch."

--- a/tests/ReplayData/PullRequest.testDeleteBranch.txt
+++ b/tests/ReplayData/PullRequest.testDeleteBranch.txt
@@ -13,7 +13,7 @@ https
 GET
 api.github.com
 None
-/repos/austinsasko/PyGithub/pulls?head=revert-20-revert-19-revert-18-revert-16-revert-15-revert-14-revert-13-revert-12-revert-11-revert-10-revert-9-revert-8-revert-7-revert-6-revert-5-revert-4-revert-3-revert-2-revert-1-testing&per_page=1
+/repos/austinsasko/PyGithub/pulls?head=austinsasko%3Arevert-20-revert-19-revert-18-revert-16-revert-15-revert-14-revert-13-revert-12-revert-11-revert-10-revert-9-revert-8-revert-7-revert-6-revert-5-revert-4-revert-3-revert-2-revert-1-testing&per_page=1
 {'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 None
 200

--- a/tests/ReplayData/PullRequest.testDeleteOnMerge.txt
+++ b/tests/ReplayData/PullRequest.testDeleteOnMerge.txt
@@ -35,7 +35,7 @@ https
 GET
 api.github.com
 None
-/repos/austinsasko/PyGithub/pulls?head=revert-20-revert-19-revert-18-revert-16-revert-15-revert-14-revert-13-revert-12-revert-11-revert-10-revert-9-revert-8-revert-7-revert-6-revert-5-revert-4-revert-3-revert-2-revert-1-testing&per_page=1
+/repos/austinsasko/PyGithub/pulls?austinsasko%3Arevert-20-revert-19-revert-18-revert-16-revert-15-revert-14-revert-13-revert-12-revert-11-revert-10-revert-9-revert-8-revert-7-revert-6-revert-5-revert-4-revert-3-revert-2-revert-1-testing&per_page=1
 {'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 None
 200

--- a/tests/ReplayData/PullRequest.testDeleteOnMerge.txt
+++ b/tests/ReplayData/PullRequest.testDeleteOnMerge.txt
@@ -35,7 +35,7 @@ https
 GET
 api.github.com
 None
-/repos/austinsasko/PyGithub/pulls?austinsasko%3Arevert-20-revert-19-revert-18-revert-16-revert-15-revert-14-revert-13-revert-12-revert-11-revert-10-revert-9-revert-8-revert-7-revert-6-revert-5-revert-4-revert-3-revert-2-revert-1-testing&per_page=1
+/repos/austinsasko/PyGithub/pulls?head=austinsasko%3Arevert-20-revert-19-revert-18-revert-16-revert-15-revert-14-revert-13-revert-12-revert-11-revert-10-revert-9-revert-8-revert-7-revert-6-revert-5-revert-4-revert-3-revert-2-revert-1-testing&per_page=1
 {'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
 None
 200


### PR DESCRIPTION
### Problem
`delete_branch(force=False)` raises a `RuntimeError` if the repository has any open pull requests because the current check used for remaining open pull requests returns all open pull requests for the repository instead of only the open pull requests associated with the pull request's branch.

### Fix
Updating this to use the format of `user:ref-name` or `organization:ref-name` appropriately gets open pull requests for the pull request's branch.

```
remaining_pulls = self.head.repo.get_pulls(head=f"{self.head.repo.owner.login}:{self.head.ref}")
```

> [!NOTE]
> See: https://github.com/PyGithub/PyGithub/issues/3031
> From docs: https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests
![Screenshot 2024-10-17 at 3 13 20 PM](https://github.com/user-attachments/assets/d0fbe8e9-09f3-42cc-8dd9-716418de2387)
