### PR TITLE
Introducing PyGitHub Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Open Source Helpers](https://www.codetriage.com/pygithub/pygithub/badges/users.svg)](https://www.codetriage.com/pygithub/pygithub)
 [![codecov](https://codecov.io/gh/PyGithub/PyGithub/branch/master/graph/badge.svg)](https://codecov.io/gh/PyGithub/PyGithub)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20PyGitHub%20Guru-006BFF)](https://gurubase.io/g/pygithub)
 
 PyGitHub is a Python library to access the [GitHub REST API].
 This library enables you to manage [GitHub] resources such as repositories, user profiles, and organizations in your Python applications.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [PyGitHub Guru](https://gurubase.io/g/pygithub) to Gurubase. PyGitHub Guru uses the data from this repo and data from the [docs](https://pygithub.readthedocs.io/en/stable/) to answer questions by leveraging the LLM.

In this PR, I showcased the "PyGitHub Guru", which highlights that PyGitHub now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable PyGitHub Guru in Gurubase, just let me know that's totally fine.
