### PR TITLE
remove COMMENT as default event for create_review

### DIFF
--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -491,7 +491,6 @@ class PullRequest(CompletableGithubObject):
         assert is_optional(event, str), event
         assert is_optional_list(comments, dict), comments
         post_parameters: dict[str, Any] = NotSet.remove_unset_items({"body": body})
-        post_parameters["event"] = "COMMENT" if is_undefined(event) else event
         if is_defined(commit):
             post_parameters["commit_id"] = commit.sha
         if is_defined(comments):


### PR DESCRIPTION
Fixes a discrepancy between PyGithub for creating a pull request review, compared to the Github API. When using the REST API, not specifying an `event` defaults to using `PENDING` mode, which creates a review and automatically adds the user as a reviewer. In the current PyGithub implementation, if no `event` parameter is given, it defaults to `COMMENT`, which does not add the user as a reviewer. It is not possible to use `event="PENDING"` via the API, it's just the default Github creates when `event` is sent empty.

https://docs.github.com/en/rest/pulls/reviews?apiVersion=2022-11-28#create-a-review-for-a-pull-request