### PR TITLE
Fix API break when contents not found

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -815,7 +815,7 @@ class Requester:
             exc = GithubException.BadUserAgentException
         elif status == 403 and cls.isRateLimitError(message):
             exc = GithubException.RateLimitExceededException
-        elif status == 404 and message == "not found":
+        elif status == 404 and (message == "not found" or "no object found" in message):
             exc = GithubException.UnknownObjectException
 
         return exc(status, output, headers)

--- a/tests/Requester.py
+++ b/tests/Requester.py
@@ -372,6 +372,17 @@ class Requester(Framework.TestCase):
             '404 {"message": "Not Found"}',
         )
 
+    def testShouldCreateUnknownObjectException2(self):
+        exc = self.g._Github__requester.createException(404, {"header": "value"}, {"message": "No object found for the path some-nonexistent-file"})
+        self.assertException(
+            exc,
+            github.UnknownObjectException,
+            404,
+            {"message": "No object found for the path some-nonexistent-file"},
+            {"header": "value"},
+            '404 {"message": "No object found for the path some-nonexistent-file"}',
+        )
+
     def testShouldCreateGithubException(self):
         for status in range(400, 600):
             with self.subTest(status=status):

--- a/tests/Requester.py
+++ b/tests/Requester.py
@@ -373,7 +373,9 @@ class Requester(Framework.TestCase):
         )
 
     def testShouldCreateUnknownObjectException2(self):
-        exc = self.g._Github__requester.createException(404, {"header": "value"}, {"message": "No object found for the path some-nonexistent-file"})
+        exc = self.g._Github__requester.createException(
+            404, {"header": "value"}, {"message": "No object found for the path some-nonexistent-file"}
+        )
         self.assertException(
             exc,
             github.UnknownObjectException,


### PR DESCRIPTION
Alternative to https://github.com/PyGithub/PyGithub/pull/3180 that fixes https://github.com/PyGithub/PyGithub/issues/3179, but tries to preserve existing behavior.

UnknownObjectException is raised for all kinds of calls that may return a 404, for example [get_repo](https://pygithub.readthedocs.io/en/stable/github_objects/Organization.html#github.Organization.Organization.get_repo). Those API calls still return a "Not Found" message:

```python
>>> from github import Github
>>> from os import environ
>>> Github(environ['GITHUB_TOKEN']).get_organization('asdfqwertyjkl')
Traceback (most recent call last):
  File "<python-input-3>", line 1, in <module>
    Github(environ['GITHUB_TOKEN']).get_organization('asdfqwertyjkl')
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File ".../venv/lib/python3.13/site-packages/github/MainClass.py", line 408, in get_organization
    headers, data = self.__requester.requestJsonAndCheck("GET", f"/orgs/{login}")
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../venv/lib/python3.13/site-packages/github/Requester.py", line 586, in requestJsonAndCheck
    return self.__check(*self.requestJson(verb, url, parameters, headers, input, self.__customConnection(url)))
           ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../venv/lib/python3.13/site-packages/github/Requester.py", line 744, in __check
    raise self.createException(status, responseHeaders, data)
github.GithubException.UnknownObjectException: 404 {"message": "Not Found", "documentation_url": "https://docs.github.com/rest/orgs/orgs#get-an-organization", "status": "404"}
```

So, in this PR we honor both kinds of messages, but still no _other_ kinds of messages.

Tests are updated to reflect the new case.