### PR TITLE
Use message of response in GithubException

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -815,21 +815,26 @@ class Requester:
         headers: Dict[str, Any],
         output: Dict[str, Any],
     ) -> GithubException.GithubException:
-        message = output.get("message", "").lower() if output is not None else ""
+        message = output.get("message") if output else None
+        lc_message = message.lower() if message else ""
 
+        msg = None
         exc = GithubException.GithubException
-        if status == 401 and message == "bad credentials":
+        if status == 401 and lc_message == "bad credentials":
             exc = GithubException.BadCredentialsException
         elif status == 401 and Consts.headerOTP in headers and re.match(r".*required.*", headers[Consts.headerOTP]):
             exc = GithubException.TwoFactorException
-        elif status == 403 and message.startswith("missing or invalid user agent string"):
+        elif status == 403 and lc_message.startswith("missing or invalid user agent string"):
             exc = GithubException.BadUserAgentException
-        elif status == 403 and cls.isRateLimitError(message):
+        elif status == 403 and cls.isRateLimitError(lc_message):
             exc = GithubException.RateLimitExceededException
-        elif status == 404 and (message == "not found" or "no object found" in message):
+        elif status == 404 and (lc_message == "not found" or "no object found" in lc_message):
             exc = GithubException.UnknownObjectException
+        else:
+            # for general GithubException, provide the actual message
+            msg = message
 
-        return exc(status, output, headers)
+        return exc(status, output, headers, msg)
 
     @classmethod
     def isRateLimitError(cls, message: str) -> bool:

--- a/tests/ApplicationOAuth.py
+++ b/tests/ApplicationOAuth.py
@@ -183,6 +183,7 @@ class ApplicationOAuth(Framework.TestCase):
     def testGetAccessTokenBadCode(self):
         with self.assertRaises(github.BadCredentialsException) as exc:
             self.app.get_access_token("oauth_code_removed", state="state_removed")
+        self.assertIsNone(exc.exception.message)
         self.assertEqual(exc.exception.status, 200)
         self.assertIn("error", exc.exception.data)
         self.assertEqual(exc.exception.data["error"], "bad_verification_code")
@@ -190,6 +191,7 @@ class ApplicationOAuth(Framework.TestCase):
     def testGetAccessTokenUnknownError(self):
         with self.assertRaises(github.GithubException) as exc:
             self.app.get_access_token("oauth_code_removed", state="state_removed")
+        self.assertIsNone(exc.exception.message)
         self.assertEqual(exc.exception.status, 200)
         self.assertIn("error", exc.exception.data)
         self.assertEqual(exc.exception.data["error"], "some_unknown_error")
@@ -197,6 +199,7 @@ class ApplicationOAuth(Framework.TestCase):
     def testRefreshAccessTokenBadCode(self):
         with self.assertRaises(github.BadCredentialsException) as exc:
             self.app.refresh_access_token("oauth_code_removed")
+        self.assertIsNone(exc.exception.message)
         self.assertEqual(exc.exception.status, 200)
         self.assertIn("error", exc.exception.data)
         self.assertEqual(exc.exception.data["error"], "bad_verification_code")
@@ -204,6 +207,7 @@ class ApplicationOAuth(Framework.TestCase):
     def testRefreshAccessTokenUnknownError(self):
         with self.assertRaises(github.GithubException) as exc:
             self.app.refresh_access_token("oauth_code_removed")
+        self.assertIsNone(exc.exception.message)
         self.assertEqual(exc.exception.status, 200)
         self.assertIn("error", exc.exception.data)
         self.assertEqual(exc.exception.data["error"], "some_unknown_error")
@@ -222,12 +226,14 @@ class ApplicationOAuth(Framework.TestCase):
 
         with self.assertRaises(github.BadCredentialsException) as exc:
             aoa._checkError({}, {"error": "bad_verification_code"})
+        self.assertIsNone(exc.exception.message)
         self.assertEqual(exc.exception.status, 200)
         self.assertIn("error", exc.exception.data)
         self.assertEqual(exc.exception.data["error"], "bad_verification_code")
 
         with self.assertRaises(github.GithubException) as exc:
             aoa._checkError({}, {"error": "other"})
+        self.assertIsNone(exc.exception.message)
         self.assertEqual(exc.exception.status, 200)
         self.assertIn("error", exc.exception.data)
         self.assertEqual(exc.exception.data["error"], "other")

--- a/tests/Branch.py
+++ b/tests/Branch.py
@@ -217,7 +217,10 @@ class Branch(Framework.TestCase):
     def testEditRequiredPullRequestReviewsWithUserBranchAndDismissalUsers(self):
         with self.assertRaises(github.GithubException) as raisedexp:
             self.protected_branch.edit_required_pull_request_reviews(dismissal_users=["jacquev6"])
-        self.assertEqual(raisedexp.exception.message, "Dismissal restrictions are supported only for repositories owned by an organization.")
+        self.assertEqual(
+            raisedexp.exception.message,
+            "Dismissal restrictions are supported only for repositories owned by an organization.",
+        )
         self.assertEqual(raisedexp.exception.status, 422)
         self.assertEqual(
             raisedexp.exception.data,

--- a/tests/Branch.py
+++ b/tests/Branch.py
@@ -99,6 +99,7 @@ class Branch(Framework.TestCase):
     def testEditProtectionDismissalUsersWithUserOwnedBranch(self):
         with self.assertRaises(github.GithubException) as raisedexp:
             self.protected_branch.edit_protection(dismissal_users=["jacquev6"])
+        self.assertEqual(raisedexp.exception.message, "Validation Failed")
         self.assertEqual(raisedexp.exception.status, 422)
         self.assertEqual(
             raisedexp.exception.data,
@@ -112,6 +113,7 @@ class Branch(Framework.TestCase):
     def testEditProtectionPushRestrictionsWithUserOwnedBranch(self):
         with self.assertRaises(github.GithubException) as raisedexp:
             self.protected_branch.edit_protection(user_push_restrictions=["jacquev6"], team_push_restrictions=[])
+        self.assertEqual(raisedexp.exception.message, "Validation Failed")
         self.assertEqual(raisedexp.exception.status, 422)
         self.assertEqual(
             raisedexp.exception.data,
@@ -149,6 +151,7 @@ class Branch(Framework.TestCase):
         self.assertFalse(protected_branch.protected)
         with self.assertRaises(github.GithubException) as raisedexp:
             protected_branch.get_protection()
+        self.assertEqual(raisedexp.exception.message, "Branch not protected")
         self.assertEqual(raisedexp.exception.status, 404)
         self.assertEqual(
             raisedexp.exception.data,
@@ -178,6 +181,7 @@ class Branch(Framework.TestCase):
         self.protected_branch.remove_required_status_checks()
         with self.assertRaises(github.GithubException) as raisedexp:
             self.protected_branch.get_required_status_checks()
+        self.assertEqual(raisedexp.exception.message, "Required status checks not enabled")
         self.assertEqual(raisedexp.exception.status, 404)
         self.assertEqual(
             raisedexp.exception.data,
@@ -200,6 +204,7 @@ class Branch(Framework.TestCase):
     def testEditRequiredPullRequestReviewsWithTooLargeApprovingReviewCount(self):
         with self.assertRaises(github.GithubException) as raisedexp:
             self.protected_branch.edit_required_pull_request_reviews(required_approving_review_count=9)
+        self.assertEqual(raisedexp.exception.message, "Invalid request.\n\n9 must be less than or equal to 6.")
         self.assertEqual(raisedexp.exception.status, 422)
         self.assertEqual(
             raisedexp.exception.data,
@@ -212,6 +217,7 @@ class Branch(Framework.TestCase):
     def testEditRequiredPullRequestReviewsWithUserBranchAndDismissalUsers(self):
         with self.assertRaises(github.GithubException) as raisedexp:
             self.protected_branch.edit_required_pull_request_reviews(dismissal_users=["jacquev6"])
+        self.assertEqual(raisedexp.exception.message, "Dismissal restrictions are supported only for repositories owned by an organization.")
         self.assertEqual(raisedexp.exception.status, 422)
         self.assertEqual(
             raisedexp.exception.data,
@@ -303,6 +309,7 @@ class Branch(Framework.TestCase):
         self.organization_branch.remove_push_restrictions()
         with self.assertRaises(github.GithubException) as raisedexp:
             list(self.organization_branch.get_user_push_restrictions())
+        self.assertEqual(raisedexp.exception.message, "Push restrictions not enabled")
         self.assertEqual(raisedexp.exception.status, 404)
         self.assertEqual(
             raisedexp.exception.data,

--- a/tests/Exceptions.py
+++ b/tests/Exceptions.py
@@ -50,6 +50,8 @@ class Exceptions(Framework.TestCase):
     def testInvalidInput(self):
         with self.assertRaises(github.GithubException) as raisedexp:
             self.g.get_user().create_key("Bad key", "xxx")
+        self.assertIsInstance(raisedexp.exception, github.GithubException)
+        self.assertEqual(raisedexp.exception.message, "Validation Failed")
         self.assertEqual(raisedexp.exception.status, 422)
         self.assertEqual(
             raisedexp.exception.data,
@@ -71,6 +73,8 @@ class Exceptions(Framework.TestCase):
         with self.assertRaises(github.GithubException) as raisedexp:
             # 503 would be retried, disable retries
             self.get_github(retry=None, pool_size=self.pool_size).get_user("jacquev6")
+        self.assertIsInstance(raisedexp.exception, github.GithubException)
+        self.assertIsNone(raisedexp.exception.message)
         self.assertEqual(raisedexp.exception.status, 503)
         self.assertEqual(
             raisedexp.exception.data,
@@ -82,6 +86,8 @@ class Exceptions(Framework.TestCase):
     def testUnknownObject(self):
         with self.assertRaises(github.GithubException) as raisedexp:
             self.g.get_user().get_repo("Xxx")
+        self.assertIsInstance(raisedexp.exception, github.UnknownObjectException)
+        self.assertIsNone(raisedexp.exception.message)
         self.assertEqual(raisedexp.exception.status, 404)
         self.assertEqual(raisedexp.exception.data, {"message": "Not Found"})
         self.assertEqual(str(raisedexp.exception), '404 {"message": "Not Found"}')
@@ -89,6 +95,8 @@ class Exceptions(Framework.TestCase):
     def testUnknownUser(self):
         with self.assertRaises(github.GithubException) as raisedexp:
             self.g.get_user("ThisUserShouldReallyNotExist")
+        self.assertIsInstance(raisedexp.exception, github.UnknownObjectException)
+        self.assertIsNone(raisedexp.exception.message)
         self.assertEqual(raisedexp.exception.status, 404)
         self.assertEqual(raisedexp.exception.data, {"message": "Not Found"})
         self.assertEqual(str(raisedexp.exception), '404 {"message": "Not Found"}')
@@ -96,6 +104,8 @@ class Exceptions(Framework.TestCase):
     def testBadAuthentication(self):
         with self.assertRaises(github.GithubException) as raisedexp:
             github.Github(auth=github.Auth.Login("BadUser", "BadPassword")).get_user().login
+        self.assertIsInstance(raisedexp.exception, github.BadCredentialsException)
+        self.assertIsNone(raisedexp.exception.message)
         self.assertEqual(raisedexp.exception.status, 401)
         self.assertEqual(raisedexp.exception.data, {"message": "Bad credentials"})
         self.assertEqual(str(raisedexp.exception), '401 {"message": "Bad credentials"}')

--- a/tests/GithubIntegration.py
+++ b/tests/GithubIntegration.py
@@ -255,7 +255,7 @@ class GithubIntegration(Framework.BasicTestCase):
         github_integration = github.GithubIntegration(auth=auth)
         with self.assertRaises(github.GithubException) as raisedexp:
             github_integration.get_org_installation(org="GithubApp-Test-Org")
-
+        self.assertEqual(raisedexp.exception.message, "'Expiration time' claim ('exp') must be a numeric value representing the future time at which the assertion expires")
         self.assertEqual(raisedexp.exception.status, 401)
 
     def testGetAccessTokenWithExpiredJWT(self):
@@ -263,7 +263,7 @@ class GithubIntegration(Framework.BasicTestCase):
         github_integration = github.GithubIntegration(auth=auth)
         with self.assertRaises(github.GithubException) as raisedexp:
             github_integration.get_access_token(self.repo_installation_id)
-
+        self.assertEqual(raisedexp.exception.message, "'Expiration time' claim ('exp') must be a numeric value representing the future time at which the assertion expires")
         self.assertEqual(raisedexp.exception.status, 401)
 
     def testGetAccessTokenForNoInstallation(self):
@@ -279,7 +279,7 @@ class GithubIntegration(Framework.BasicTestCase):
         github_integration = github.GithubIntegration(auth=auth)
         with self.assertRaises(github.GithubException) as raisedexp:
             github_integration.get_access_token(self.repo_installation_id, permissions={"test-permissions": "read"})
-
+        self.assertEqual(raisedexp.exception.message, "The permissions requested are not granted to this installation.")
         self.assertEqual(raisedexp.exception.status, 422)
 
     def testGetAccessTokenWithInvalidData(self):
@@ -287,7 +287,7 @@ class GithubIntegration(Framework.BasicTestCase):
         github_integration = github.GithubIntegration(auth=auth)
         with self.assertRaises(github.GithubException) as raisedexp:
             github_integration.get_access_token(self.repo_installation_id, permissions="invalid_data")
-
+        self.assertIsNone(raisedexp.exception.message)
         self.assertEqual(raisedexp.exception.status, 400)
 
     def testGetApp(self):

--- a/tests/GithubIntegration.py
+++ b/tests/GithubIntegration.py
@@ -255,7 +255,10 @@ class GithubIntegration(Framework.BasicTestCase):
         github_integration = github.GithubIntegration(auth=auth)
         with self.assertRaises(github.GithubException) as raisedexp:
             github_integration.get_org_installation(org="GithubApp-Test-Org")
-        self.assertEqual(raisedexp.exception.message, "'Expiration time' claim ('exp') must be a numeric value representing the future time at which the assertion expires")
+        self.assertEqual(
+            raisedexp.exception.message,
+            "'Expiration time' claim ('exp') must be a numeric value representing the future time at which the assertion expires",
+        )
         self.assertEqual(raisedexp.exception.status, 401)
 
     def testGetAccessTokenWithExpiredJWT(self):
@@ -263,7 +266,10 @@ class GithubIntegration(Framework.BasicTestCase):
         github_integration = github.GithubIntegration(auth=auth)
         with self.assertRaises(github.GithubException) as raisedexp:
             github_integration.get_access_token(self.repo_installation_id)
-        self.assertEqual(raisedexp.exception.message, "'Expiration time' claim ('exp') must be a numeric value representing the future time at which the assertion expires")
+        self.assertEqual(
+            raisedexp.exception.message,
+            "'Expiration time' claim ('exp') must be a numeric value representing the future time at which the assertion expires",
+        )
         self.assertEqual(raisedexp.exception.status, 401)
 
     def testGetAccessTokenForNoInstallation(self):

--- a/tests/GithubRetry.py
+++ b/tests/GithubRetry.py
@@ -390,6 +390,7 @@ class GithubRetry(unittest.TestCase):
         with mock.patch.object(retry, "_GithubRetry__log") as log:
             with self.assertRaises(github.GithubException) as exp:
                 retry.increment("TEST", "URL", response)
+            self.assertIsNone(exp.exception.message)
             self.assertEqual(403, exp.exception.status)
             self.assertEqual("NOT GOOD", exp.exception.data)
             self.assertEqual({}, exp.exception.headers)

--- a/tests/GraphQl.py
+++ b/tests/GraphQl.py
@@ -109,9 +109,9 @@ class GraphQl(Framework.TestCase):
         # wrong type should throw an exception
         with self.assertRaises(github.GithubException) as e:
             requester.graphql_node("D_kwDOADYVqs4ATJZD", "login", "User")
+        self.assertEqual(e.exception.message, "Retrieved User object is of different type: Discussion")
         self.assertEqual(e.exception.status, 400)
         self.assertEqual(e.exception.data, {"data": {"node": {"__typename": "Discussion"}}})
-        self.assertEqual(e.exception.message, "Retrieved User object is of different type: Discussion")
 
     def testNodeClass(self):
         requester = self.g._Github__requester
@@ -147,9 +147,9 @@ class GraphQl(Framework.TestCase):
             requester.graphql_node_class(
                 "D_kwDOADYVqs4ATJZD", "login", github.RepositoryDiscussion.RepositoryDiscussion, "User"
             )
+        self.assertEqual(e.exception.message, "Retrieved User object is of different type: Discussion")
         self.assertEqual(e.exception.status, 400)
         self.assertEqual(e.exception.data, {"data": {"node": {"__typename": "Discussion"}}})
-        self.assertEqual(e.exception.message, "Retrieved User object is of different type: Discussion")
 
     def testQuery(self):
         requester = self.g._Github__requester

--- a/tests/Issue134.py
+++ b/tests/Issue134.py
@@ -43,6 +43,7 @@ class Issue134(Framework.BasicTestCase):  # https://github.com/jacquev6/PyGithub
         g = github.Github(auth=self.oauth_token)
         with self.assertRaises(github.GithubException) as raisedexp:
             list(g.get_user().get_authorizations())
+        self.assertIsNone(raisedexp.exception.message)
         self.assertEqual(raisedexp.exception.status, 404)
 
     def testGetAuthorizationsSucceedsWhenAutenticatedThroughLoginPassword(self):

--- a/tests/Organization.py
+++ b/tests/Organization.py
@@ -64,7 +64,6 @@
 
 from __future__ import annotations
 
-from audioop import error
 from datetime import datetime, timezone
 from unittest import mock
 
@@ -555,7 +554,9 @@ class Organization(Framework.TestCase):
     def testInviteUserAsNonOwner(self):
         with self.assertRaises(github.GithubException) as raisedexp:
             self.org.invite_user(email="bar@example.com")
-        self.assertEqual(raisedexp.exception.message, "You must be an admin to create an invitation to an organization.")
+        self.assertEqual(
+            raisedexp.exception.message, "You must be an admin to create an invitation to an organization."
+        )
         self.assertEqual(raisedexp.exception.status, 403)
         self.assertEqual(
             raisedexp.exception.data,

--- a/tests/Organization.py
+++ b/tests/Organization.py
@@ -64,6 +64,7 @@
 
 from __future__ import annotations
 
+from audioop import error
 from datetime import datetime, timezone
 from unittest import mock
 
@@ -554,6 +555,7 @@ class Organization(Framework.TestCase):
     def testInviteUserAsNonOwner(self):
         with self.assertRaises(github.GithubException) as raisedexp:
             self.org.invite_user(email="bar@example.com")
+        self.assertEqual(raisedexp.exception.message, "You must be an admin to create an invitation to an organization.")
         self.assertEqual(raisedexp.exception.status, 403)
         self.assertEqual(
             raisedexp.exception.data,

--- a/tests/PullRequest.py
+++ b/tests/PullRequest.py
@@ -508,6 +508,7 @@ class PullRequest(Framework.TestCase):
         self.assertTrue(self.delete_restore_pull.is_merged())
         with self.assertRaises(github.GithubException) as raisedexp:
             self.delete_restore_repo.get_branch(self.delete_restore_pull.head.ref)
+        self.assertEqual(raisedexp.exception.message, "Branch not found")
         self.assertEqual(
             raisedexp.exception.data,
             {
@@ -519,6 +520,7 @@ class PullRequest(Framework.TestCase):
     def testRestoreBranch(self):
         with self.assertRaises(github.GithubException) as raisedexp:
             self.delete_restore_repo.get_branch(self.delete_restore_pull.head.ref)
+        self.assertEqual(raisedexp.exception.message, "Branch not found")
         self.assertEqual(raisedexp.exception.status, 404)
         self.assertEqual(
             raisedexp.exception.data,
@@ -535,6 +537,7 @@ class PullRequest(Framework.TestCase):
         self.delete_restore_pull.delete_branch(force=False)
         with self.assertRaises(github.GithubException) as raisedexp:
             self.delete_restore_repo.get_branch(self.delete_restore_pull.head.ref)
+        self.assertEqual(raisedexp.exception.message, "Branch not found")
         self.assertEqual(raisedexp.exception.status, 404)
         self.assertEqual(
             raisedexp.exception.data,
@@ -549,6 +552,7 @@ class PullRequest(Framework.TestCase):
         self.assertEqual(self.delete_restore_pull.delete_branch(force=True), None)
         with self.assertRaises(github.GithubException) as raisedexp:
             self.delete_restore_repo.get_branch(self.delete_restore_pull.head.ref)
+        self.assertEqual(raisedexp.exception.message, "Branch not found")
         self.assertEqual(raisedexp.exception.status, 404)
         self.assertEqual(
             raisedexp.exception.data,
@@ -592,7 +596,7 @@ class PullRequest(Framework.TestCase):
         # To reproduce this, the PR repository need to have the "Allow auto-merge" option disabled
         with pytest.raises(github.GithubException) as error:
             self.pull.enable_automerge()
-
+        assert error.value.message is None
         assert error.value.status == 400
         assert error.value.data == {
             "data": {"enablePullRequestAutoMerge": None},

--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -751,6 +751,7 @@ class Repository(Framework.TestCase):
     def testCollaboratorPermissionNoPushAccess(self):
         with self.assertRaises(github.GithubException) as raisedexp:
             self.repo.get_collaborator_permission("lyloa")
+        self.assertEqual(raisedexp.exception.message, "Must have push access to view collaborator permission.")
         self.assertEqual(raisedexp.exception.status, 403)
         self.assertEqual(
             raisedexp.exception.data,
@@ -1746,6 +1747,7 @@ class Repository(Framework.TestCase):
     def testMergeWithConflict(self):
         with self.assertRaises(github.GithubException) as raisedexp:
             self.repo.merge("branchForBase", "branchForHead")
+        self.assertEqual(raisedexp.exception.message, "Merge conflict")
         self.assertEqual(raisedexp.exception.status, 409)
         self.assertEqual(raisedexp.exception.data, {"message": "Merge conflict"})
 
@@ -1908,6 +1910,7 @@ class Repository(Framework.TestCase):
     def testBadSubscribePubSubHubbub(self):
         with self.assertRaises(github.GithubException) as raisedexp:
             self.repo.subscribe_to_hub("non-existing-event", "http://requestb.in/1bc1sc61")
+        self.assertEqual(raisedexp.exception.message, 'Invalid event: "non-existing-event"')
         self.assertEqual(raisedexp.exception.status, 422)
         self.assertEqual(raisedexp.exception.data, {"message": 'Invalid event: "non-existing-event"'})
 

--- a/tests/Requester.py
+++ b/tests/Requester.py
@@ -291,8 +291,12 @@ class Requester(Framework.TestCase):
         for message in self.OtherErrors + self.PrimaryRateLimitErrors:
             self.assertFalse(github.Requester.Requester.isSecondaryRateLimitError(message), message)
 
-    def assertException(self, exception, exception_type, status, data, headers, string):
+    def assertException(self, exception, exception_type, message, status, data, headers, string):
         self.assertIsInstance(exception, exception_type)
+        if message is None:
+            self.assertIsNone(exception.message)
+        else:
+            self.assertEqual(exception.message, message)
         self.assertEqual(exception.status, status)
         if data is None:
             self.assertIsNone(exception.data)
@@ -306,6 +310,7 @@ class Requester(Framework.TestCase):
         self.assertException(
             exc,
             github.BadCredentialsException,
+            None,
             401,
             {"message": "Bad credentials"},
             {"header": "value"},
@@ -324,6 +329,7 @@ class Requester(Framework.TestCase):
         self.assertException(
             exc,
             github.TwoFactorException,
+            None,
             401,
             {
                 "message": "Must specify two-factor authentication OTP code.",
@@ -342,6 +348,7 @@ class Requester(Framework.TestCase):
         self.assertException(
             exc,
             github.BadUserAgentException,
+            None,
             403,
             {"message": "Missing or invalid User Agent string"},
             {"header": "value"},
@@ -355,6 +362,7 @@ class Requester(Framework.TestCase):
                 self.assertException(
                     exc,
                     github.RateLimitExceededException,
+                    None,
                     403,
                     {"message": message},
                     {"header": "value"},
@@ -366,6 +374,7 @@ class Requester(Framework.TestCase):
         self.assertException(
             exc,
             github.UnknownObjectException,
+            None,
             404,
             {"message": "Not Found"},
             {"header": "value"},
@@ -379,6 +388,7 @@ class Requester(Framework.TestCase):
         self.assertException(
             exc,
             github.UnknownObjectException,
+            None,
             404,
             {"message": "No object found for the path some-nonexistent-file"},
             {"header": "value"},
@@ -394,23 +404,24 @@ class Requester(Framework.TestCase):
                 self.assertException(
                     exc,
                     github.GithubException,
+                    "Something unknown",
                     status,
                     {"message": "Something unknown"},
                     {"header": "value"},
-                    f'{status} {{"message": "Something unknown"}}',
+                    f'Something unknown: {status} {{"message": "Something unknown"}}',
                 )
 
     def testShouldCreateExceptionWithoutMessage(self):
         for status in range(400, 600):
             with self.subTest(status=status):
                 exc = self.g._Github__requester.createException(status, {}, {})
-                self.assertException(exc, github.GithubException, status, {}, {}, f"{status} {{}}")
+                self.assertException(exc, github.GithubException, None, status, {}, {}, f"{status} {{}}")
 
     def testShouldCreateExceptionWithoutOutput(self):
         for status in range(400, 600):
             with self.subTest(status=status):
                 exc = self.g._Github__requester.createException(status, {}, None)
-                self.assertException(exc, github.GithubException, status, None, {}, f"{status}")
+                self.assertException(exc, github.GithubException, None, status, None, {}, f"{status}")
 
 
 class RequesterThrottleTestCase(Framework.TestCase):


### PR DESCRIPTION
The `message` extracted from response data could easily be used for the `message` parameter of the `GithubException`.