### PR TITLE
Return more union classe like `NamedUser | Organization | Enterprise`

### DIFF
--- a/github/CommitComment.py
+++ b/github/CommitComment.py
@@ -157,7 +157,7 @@ class CommitComment(CompletableGithubObject):
         return self._url.value
 
     @property
-    def user(self) -> github.NamedUser.NamedUser | github.Organization.Organization:
+    def user(self) -> NamedUser | Organization:
         self._completeIfNotSet(self._user)
         return self._user.value
 

--- a/github/CommitComment.py
+++ b/github/CommitComment.py
@@ -55,6 +55,8 @@ from github.GithubObject import Attribute, CompletableGithubObject, NotSet
 from github.PaginatedList import PaginatedList
 
 if TYPE_CHECKING:
+    from github.NamedUser import NamedUser
+    from github.Organization import Organization
     from github.Reaction import Reaction
 
 
@@ -84,7 +86,7 @@ class CommitComment(CompletableGithubObject):
         self._reactions: Attribute[dict[str, Any]] = NotSet
         self._updated_at: Attribute[datetime] = NotSet
         self._url: Attribute[str] = NotSet
-        self._user: Attribute[github.NamedUser.NamedUser] = NotSet
+        self._user: Attribute[NamedUser | Organization] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"id": self._id.value, "user": self.user})
@@ -155,7 +157,7 @@ class CommitComment(CompletableGithubObject):
         return self._url.value
 
     @property
-    def user(self) -> github.NamedUser.NamedUser:
+    def user(self) -> github.NamedUser.NamedUser | github.Organization.Organization:
         self._completeIfNotSet(self._user)
         return self._user.value
 
@@ -251,4 +253,12 @@ class CommitComment(CompletableGithubObject):
         if "url" in attributes:  # pragma no branch
             self._url = self._makeStringAttribute(attributes["url"])
         if "user" in attributes:  # pragma no branch
-            self._user = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["user"])
+            self._user = self._makeUnionClassAttributeFromTypeKey(
+                github.NamedUser.NamedUser,
+                "User",
+                github.Organization.Organization,
+                "Organization",
+                "type",
+                "User",
+                attributes["user"],
+            )

--- a/github/CommitComment.py
+++ b/github/CommitComment.py
@@ -254,11 +254,9 @@ class CommitComment(CompletableGithubObject):
             self._url = self._makeStringAttribute(attributes["url"])
         if "user" in attributes:  # pragma no branch
             self._user = self._makeUnionClassAttributeFromTypeKey(
-                github.NamedUser.NamedUser,
-                "User",
-                github.Organization.Organization,
-                "Organization",
                 "type",
                 "User",
                 attributes["user"],
+                (github.NamedUser.NamedUser, "User"),
+                (github.Organization.Organization, "Organization"),
             )

--- a/github/CommitStatus.py
+++ b/github/CommitStatus.py
@@ -41,12 +41,16 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import github.GithubObject
 import github.NamedUser
 import github.Organization
 from github.GithubObject import Attribute, NonCompletableGithubObject, NotSet
+
+if TYPE_CHECKING:
+    from github.NamedUser import NamedUser
+    from github.Organization import Organization
 
 
 class CommitStatus(NonCompletableGithubObject):
@@ -62,7 +66,7 @@ class CommitStatus(NonCompletableGithubObject):
         self._avatar_url: Attribute[str] = NotSet
         self._context: Attribute[str] = NotSet
         self._created_at: Attribute[datetime] = NotSet
-        self._creator: Attribute[github.NamedUser.NamedUser] = NotSet
+        self._creator: Attribute[NamedUser | Organization] = NotSet
         self._description: Attribute[str] = NotSet
         self._id: Attribute[int] = NotSet
         self._node_id: Attribute[str] = NotSet
@@ -93,7 +97,7 @@ class CommitStatus(NonCompletableGithubObject):
         return self._created_at.value
 
     @property
-    def creator(self) -> github.NamedUser.NamedUser:
+    def creator(self) -> NamedUser | Organization:
         return self._creator.value
 
     @property
@@ -132,7 +136,15 @@ class CommitStatus(NonCompletableGithubObject):
         if "created_at" in attributes:  # pragma no branch
             self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
         if "creator" in attributes:  # pragma no branch
-            self._creator = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["creator"])
+            self._creator = self._makeUnionClassAttributeFromTypeKey(
+                github.NamedUser.NamedUser,
+                "User",
+                github.Organization.Organization,
+                "Organization",
+                "type",
+                "User",
+                attributes["creator"],
+            )
         if "description" in attributes:  # pragma no branch
             self._description = self._makeStringAttribute(attributes["description"])
         if "id" in attributes:  # pragma no branch

--- a/github/CommitStatus.py
+++ b/github/CommitStatus.py
@@ -137,13 +137,11 @@ class CommitStatus(NonCompletableGithubObject):
             self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
         if "creator" in attributes:  # pragma no branch
             self._creator = self._makeUnionClassAttributeFromTypeKey(
-                github.NamedUser.NamedUser,
-                "User",
-                github.Organization.Organization,
-                "Organization",
                 "type",
                 "User",
                 attributes["creator"],
+                (github.NamedUser.NamedUser, "User"),
+                (github.Organization.Organization, "Organization"),
             )
         if "description" in attributes:  # pragma no branch
             self._description = self._makeStringAttribute(attributes["description"])

--- a/github/DependabotAlert.py
+++ b/github/DependabotAlert.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from github.DependabotAlertDependency import DependabotAlertDependency
     from github.DependabotAlertVulnerability import DependabotAlertVulnerability
     from github.NamedUser import NamedUser
+    from github.Organization import Organization
 
 
 class DependabotAlert(NonCompletableGithubObject):
@@ -60,7 +61,7 @@ class DependabotAlert(NonCompletableGithubObject):
         self._created_at: Attribute[datetime] = NotSet
         self._dependency: Attribute[DependabotAlertDependency] = NotSet
         self._dismissed_at: Attribute[datetime | None] = NotSet
-        self._dismissed_by: Attribute[NamedUser | None] = NotSet
+        self._dismissed_by: Attribute[NamedUser | Organization | None] = NotSet
         self._dismissed_comment: Attribute[str | None] = NotSet
         self._dismissed_reason: Attribute[str | None] = NotSet
         self._fixed_at: Attribute[str] = NotSet
@@ -92,7 +93,7 @@ class DependabotAlert(NonCompletableGithubObject):
         return self._dismissed_at.value
 
     @property
-    def dismissed_by(self) -> NamedUser | None:
+    def dismissed_by(self) -> NamedUser | Organization | None:
         return self._dismissed_by.value
 
     @property
@@ -147,7 +148,15 @@ class DependabotAlert(NonCompletableGithubObject):
         if "dismissed_at" in attributes:
             self._dismissed_at = self._makeDatetimeAttribute(attributes["dismissed_at"])
         if "dismissed_by" in attributes:
-            self._dismissed_by = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["dismissed_by"])
+            self._dismissed_by = self._makeUnionClassAttributeFromTypeKey(
+                github.NamedUser.NamedUser,
+                "User",
+                github.Organization.Organization,
+                "Organization",
+                "type",
+                "User",
+                attributes["dismissed_by"],
+            )
         if "dismissed_comment" in attributes:
             self._dismissed_comment = self._makeStringAttribute(attributes["dismissed_comment"])
         if "dismissed_reason" in attributes:

--- a/github/DependabotAlert.py
+++ b/github/DependabotAlert.py
@@ -149,13 +149,11 @@ class DependabotAlert(NonCompletableGithubObject):
             self._dismissed_at = self._makeDatetimeAttribute(attributes["dismissed_at"])
         if "dismissed_by" in attributes:
             self._dismissed_by = self._makeUnionClassAttributeFromTypeKey(
-                github.NamedUser.NamedUser,
-                "User",
-                github.Organization.Organization,
-                "Organization",
                 "type",
                 "User",
                 attributes["dismissed_by"],
+                (github.NamedUser.NamedUser, "User"),
+                (github.Organization.Organization, "Organization"),
             )
         if "dismissed_comment" in attributes:
             self._dismissed_comment = self._makeStringAttribute(attributes["dismissed_comment"])

--- a/github/DependabotAlert.py
+++ b/github/DependabotAlert.py
@@ -154,7 +154,7 @@ class DependabotAlert(NonCompletableGithubObject):
                 attributes["dismissed_by"],
                 (github.NamedUser.NamedUser, "User"),
                 (github.Organization.Organization, "Organization"),
-            )
+            )  # type: ignore
         if "dismissed_comment" in attributes:
             self._dismissed_comment = self._makeStringAttribute(attributes["dismissed_comment"])
         if "dismissed_reason" in attributes:

--- a/github/Deployment.py
+++ b/github/Deployment.py
@@ -264,13 +264,11 @@ class Deployment(CompletableGithubObject):
             self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
         if "creator" in attributes:  # pragma no branch
             self._creator = self._makeUnionClassAttributeFromTypeKey(
-                github.NamedUser.NamedUser,
-                "User",
-                github.Organization.Organization,
-                "Organization",
                 "type",
                 "User",
                 attributes["creator"],
+                (github.NamedUser.NamedUser, "User"),
+                (github.Organization.Organization, "Organization"),
             )
         if "description" in attributes:  # pragma no branch
             self._description = self._makeStringAttribute(attributes["description"])

--- a/github/Deployment.py
+++ b/github/Deployment.py
@@ -59,6 +59,7 @@ from github.PaginatedList import PaginatedList
 if TYPE_CHECKING:
     from github.GithubApp import GithubApp
     from github.NamedUser import NamedUser
+    from github.Organization import Organization
 
 
 class Deployment(CompletableGithubObject):
@@ -76,7 +77,7 @@ class Deployment(CompletableGithubObject):
 
     def _initAttributes(self) -> None:
         self._created_at: Attribute[datetime] = NotSet
-        self._creator: Attribute[NamedUser] = NotSet
+        self._creator: Attribute[NamedUser | Organization] = NotSet
         self._description: Attribute[str] = NotSet
         self._environment: Attribute[str] = NotSet
         self._id: Attribute[int] = NotSet
@@ -103,7 +104,7 @@ class Deployment(CompletableGithubObject):
         return self._created_at.value
 
     @property
-    def creator(self) -> NamedUser:
+    def creator(self) -> NamedUser | Organization:
         self._completeIfNotSet(self._creator)
         return self._creator.value
 
@@ -262,7 +263,15 @@ class Deployment(CompletableGithubObject):
         if "created_at" in attributes:  # pragma no branch
             self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
         if "creator" in attributes:  # pragma no branch
-            self._creator = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["creator"])
+            self._creator = self._makeUnionClassAttributeFromTypeKey(
+                github.NamedUser.NamedUser,
+                "User",
+                github.Organization.Organization,
+                "Organization",
+                "type",
+                "User",
+                attributes["creator"],
+            )
         if "description" in attributes:  # pragma no branch
             self._description = self._makeStringAttribute(attributes["description"])
         if "environment" in attributes:  # pragma no branch

--- a/github/EnvironmentProtectionRuleReviewer.py
+++ b/github/EnvironmentProtectionRuleReviewer.py
@@ -74,11 +74,9 @@ class EnvironmentProtectionRuleReviewer(NonCompletableGithubObject):
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:
         if "reviewer" in attributes and "type" in attributes:  # pragma no branch
-            assert attributes["type"] in ("User", "Team")
-            if attributes["type"] == "User":
-                self._reviewer = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["reviewer"])
-            elif attributes["type"] == "Team":
-                self._reviewer = self._makeClassAttribute(github.Team.Team, attributes["reviewer"])
+            self._reviewer = self._makeUnionClassAttributeFromTypeName(
+                github.NamedUser.NamedUser, "User", github.Team.Team, "Team", attributes["type"], attributes["reviewer"]
+            )
         if "type" in attributes:  # pragma no branch
             self._type = self._makeStringAttribute(attributes["type"])
 

--- a/github/EnvironmentProtectionRuleReviewer.py
+++ b/github/EnvironmentProtectionRuleReviewer.py
@@ -73,9 +73,9 @@ class EnvironmentProtectionRuleReviewer(NonCompletableGithubObject):
         return self._type.value
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:
-        if "reviewer" in attributes and "type" in attributes:  # pragma no branch
-            self._reviewer = self._makeUnionClassAttributeFromTypeKey(
-                "type", None, attributes["reviewer"], (github.NamedUser.NamedUser, "User"), (github.Team.Team, "Team")
+        if "reviewer" in attributes:  # pragma no branch
+            self._reviewer = self._makeUnionClassAttributeFromTypeKeyAndValueKey(
+                "type", "reviewer", None, attributes, (github.NamedUser.NamedUser, "User"), (github.Team.Team, "Team")
             )
         if "type" in attributes:  # pragma no branch
             self._type = self._makeStringAttribute(attributes["type"])

--- a/github/EnvironmentProtectionRuleReviewer.py
+++ b/github/EnvironmentProtectionRuleReviewer.py
@@ -41,11 +41,15 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import github.NamedUser
 import github.Team
 from github.GithubObject import Attribute, NonCompletableGithubObject, NotSet
+
+if TYPE_CHECKING:
+    from github.NamedUser import NamedUser
+    from github.Team import Team
 
 
 class EnvironmentProtectionRuleReviewer(NonCompletableGithubObject):
@@ -65,7 +69,7 @@ class EnvironmentProtectionRuleReviewer(NonCompletableGithubObject):
         return self.get__repr__({"type": self._type.value})
 
     @property
-    def reviewer(self) -> github.NamedUser.NamedUser | github.Team.Team:
+    def reviewer(self) -> NamedUser | Team:
         return self._reviewer.value
 
     @property

--- a/github/EnvironmentProtectionRuleReviewer.py
+++ b/github/EnvironmentProtectionRuleReviewer.py
@@ -74,8 +74,8 @@ class EnvironmentProtectionRuleReviewer(NonCompletableGithubObject):
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:
         if "reviewer" in attributes and "type" in attributes:  # pragma no branch
-            self._reviewer = self._makeUnionClassAttributeFromTypeName(
-                github.NamedUser.NamedUser, "User", github.Team.Team, "Team", attributes["type"], attributes["reviewer"]
+            self._reviewer = self._makeUnionClassAttributeFromTypeKey(
+                "type", None, attributes["reviewer"], (github.NamedUser.NamedUser, "User"), (github.Team.Team, "Team")
             )
         if "type" in attributes:  # pragma no branch
             self._type = self._makeStringAttribute(attributes["type"])

--- a/github/GithubApp.py
+++ b/github/GithubApp.py
@@ -45,17 +45,23 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+import github.Enterprise
 import github.GithubObject
 import github.NamedUser
 import github.Organization
 from github.GithubObject import Attribute, CompletableGithubObject, NotSet
 
+if TYPE_CHECKING:
+    from github.Enterprise import Enterprise
+    from github.NamedUser import NamedUser
+    from github.Organization import Organization
+
 
 class GithubApp(CompletableGithubObject):
     """
-    This class represents github apps.
+    This class represents GitHub apps.
 
     The reference can be found here
     https://docs.github.com/en/rest/reference/apps
@@ -78,7 +84,7 @@ class GithubApp(CompletableGithubObject):
         self._installations_count: Attribute[int] = NotSet
         self._name: Attribute[str] = NotSet
         self._node_id: Attribute[str] = NotSet
-        self._owner: Attribute[github.NamedUser.NamedUser] = NotSet
+        self._owner: Attribute[NamedUser | Organization | Enterprise] = NotSet
         self._pem: Attribute[str] = NotSet
         self._permissions: Attribute[dict[str, str]] = NotSet
         self._slug: Attribute[str] = NotSet
@@ -145,7 +151,7 @@ class GithubApp(CompletableGithubObject):
         return self._node_id.value
 
     @property
-    def owner(self) -> github.NamedUser.NamedUser:
+    def owner(self) -> NamedUser | Organization | Enterprise:
         self._completeIfNotSet(self._owner)
         return self._owner.value
 
@@ -202,7 +208,14 @@ class GithubApp(CompletableGithubObject):
         if "node_id" in attributes:  # pragma no branch
             self._node_id = self._makeStringAttribute(attributes["node_id"])
         if "owner" in attributes:  # pragma no branch
-            self._owner = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["owner"])
+            self._owner = self._makeUnionClassAttributeFromTypeKey(
+                "type",
+                "Enterprise",
+                attributes["owner"],
+                (github.NamedUser.NamedUser, "User"),
+                (github.Organization.Organization, "Organization"),
+                (github.Enterprise.Enterprise, "Enterprise"),
+            )
         if "pem" in attributes:  # pragma no branch
             self._pem = self._makeStringAttribute(attributes["pem"])
         if "permissions" in attributes:  # pragma no branch

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -391,6 +391,20 @@ class GithubObject(ABC):
             return _ValuedAttribute(None)  # type: ignore
         return self._makeUnionClassAttributeFromTypeName(value.get(type_key, default_type), value, *class_and_names)
 
+    def _makeUnionClassAttributeFromTypeKeyAndValueKey(
+        self,
+        type_key: str,
+        value_key: str,
+        default_type: str | None,
+        value: Any,
+        *class_and_names: (type[T_gh], str),
+    ) -> Attribute[T_gh | T_gh2]:
+        if value is None or not isinstance(value, dict):
+            return _ValuedAttribute(None)  # type: ignore
+        return self._makeUnionClassAttributeFromTypeName(
+            value.get(type_key, default_type), value.get(value_key), *class_and_names
+        )
+
     @staticmethod
     def _makeListOfStringsAttribute(value: list[list[str]] | list[str] | list[str | int]) -> Attribute:
         return GithubObject.__makeSimpleListAttribute(value, str)

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -72,7 +72,6 @@ T = typing.TypeVar("T")
 K = typing.TypeVar("K")
 T_co = typing.TypeVar("T_co", covariant=True)
 T_gh = typing.TypeVar("T_gh", bound="GithubObject")
-T_gh2 = typing.TypeVar("T_gh2", bound="GithubObject")
 
 
 class Attribute(Protocol[T_co]):
@@ -371,8 +370,8 @@ class GithubObject(ABC):
         )
 
     def _makeUnionClassAttributeFromTypeName(
-        self, type_name: str | None, value: Any, *class_and_names: (type[T_gh], str)
-    ) -> Attribute[T_gh | T_gh2]:
+        self, type_name: str | None, value: Any, *class_and_names: tuple[type[T_gh], str]
+    ) -> Attribute[T_gh]:
         if value is None or type_name is None:
             return _ValuedAttribute(None)  # type: ignore
         for klass, name in class_and_names:
@@ -385,8 +384,8 @@ class GithubObject(ABC):
         type_key: str,
         default_type: str | None,
         value: Any,
-        *class_and_names: (type[T_gh], str),
-    ) -> Attribute[T_gh | T_gh2]:
+        *class_and_names: tuple[type[T_gh], str],
+    ) -> Attribute[T_gh]:
         if value is None or not isinstance(value, dict):
             return _ValuedAttribute(None)  # type: ignore
         return self._makeUnionClassAttributeFromTypeName(value.get(type_key, default_type), value, *class_and_names)
@@ -397,8 +396,8 @@ class GithubObject(ABC):
         value_key: str,
         default_type: str | None,
         value: Any,
-        *class_and_names: (type[T_gh], str),
-    ) -> Attribute[T_gh | T_gh2]:
+        *class_and_names: tuple[type[T_gh], str],
+    ) -> Attribute[T_gh]:
         if value is None or not isinstance(value, dict):
             return _ValuedAttribute(None)  # type: ignore
         return self._makeUnionClassAttributeFromTypeName(

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -371,31 +371,25 @@ class GithubObject(ABC):
         )
 
     def _makeUnionClassAttributeFromTypeName(
-        self, klass: type[T_gh], name: str, klass2: type[T_gh2], name2: str, type_name: str, value: Any
+        self, type_name: str | None, value: Any, *class_and_names: (type[T_gh], str)
     ) -> Attribute[T_gh | T_gh2]:
         if value is None or type_name is None:
             return _ValuedAttribute(None)  # type: ignore
-        if type_name == name:
-            return self._makeClassAttribute(klass, value)
-        if type_name == name2:
-            return self._makeClassAttribute(klass2, value)
+        for klass, name in class_and_names:
+            if type_name == name:
+                return self._makeClassAttribute(klass, value)
         return _BadAttribute(value, type)  # type: ignore
 
     def _makeUnionClassAttributeFromTypeKey(
         self,
-        klass: type[T_gh],
-        name: str,
-        klass2: type[T_gh2],
-        name2: str,
         type_key: str,
-        default_type: str,
+        default_type: str | None,
         value: Any,
+        *class_and_names: (type[T_gh], str),
     ) -> Attribute[T_gh | T_gh2]:
         if value is None or not isinstance(value, dict):
             return _ValuedAttribute(None)  # type: ignore
-        return self._makeUnionClassAttributeFromTypeName(
-            klass, name, klass2, name2, value.get(type_key, default_type), value
-        )
+        return self._makeUnionClassAttributeFromTypeName(value.get(type_key, default_type), value, *class_and_names)
 
     @staticmethod
     def _makeListOfStringsAttribute(value: list[list[str]] | list[str] | list[str | int]) -> Attribute:

--- a/github/Installation.py
+++ b/github/Installation.py
@@ -237,13 +237,12 @@ class Installation(NonCompletableGithubObject):
         if "access_tokens_url" in attributes:  # pragma no branch
             self._access_tokens_url = self._makeStringAttribute(attributes["access_tokens_url"])
         if "account" in attributes and "target_type" in attributes:  # pragma no branch
-            self._account = self._makeUnionClassAttributeFromTypeName(
-                github.NamedUser.NamedUser,
-                "User",
-                github.Organization.Organization,
-                "Organization",
-                attributes["target_type"],
+            self._account = self._makeUnionClassAttributeFromTypeKey(
+                "target_type",
+                None,
                 attributes["account"],
+                (github.NamedUser.NamedUser, "User"),
+                (github.Organization.Organization, "Organization"),
             )
         if "app_id" in attributes:  # pragma no branch
             self._app_id = self._makeIntAttribute(attributes["app_id"])

--- a/github/Installation.py
+++ b/github/Installation.py
@@ -236,11 +236,12 @@ class Installation(NonCompletableGithubObject):
     def _useAttributes(self, attributes: dict[str, Any]) -> None:
         if "access_tokens_url" in attributes:  # pragma no branch
             self._access_tokens_url = self._makeStringAttribute(attributes["access_tokens_url"])
-        if "account" in attributes and "target_type" in attributes:  # pragma no branch
-            self._account = self._makeUnionClassAttributeFromTypeKey(
+        if "account" in attributes:  # pragma no branch
+            self._account = self._makeUnionClassAttributeFromTypeKeyAndValueKey(
                 "target_type",
+                "account",
                 None,
-                attributes["account"],
+                attributes,
                 (github.NamedUser.NamedUser, "User"),
                 (github.Organization.Organization, "Organization"),
             )

--- a/github/Installation.py
+++ b/github/Installation.py
@@ -237,11 +237,14 @@ class Installation(NonCompletableGithubObject):
         if "access_tokens_url" in attributes:  # pragma no branch
             self._access_tokens_url = self._makeStringAttribute(attributes["access_tokens_url"])
         if "account" in attributes and "target_type" in attributes:  # pragma no branch
-            target_type = attributes["target_type"]
-            if target_type == "User":
-                self._account = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["account"])
-            if target_type == "Organization":
-                self._account = self._makeClassAttribute(github.Organization.Organization, attributes["account"])
+            self._account = self._makeUnionClassAttributeFromTypeName(
+                github.NamedUser.NamedUser,
+                "User",
+                github.Organization.Organization,
+                "Organization",
+                attributes["target_type"],
+                attributes["account"],
+            )
         if "app_id" in attributes:  # pragma no branch
             self._app_id = self._makeIntAttribute(attributes["app_id"])
         if "app_slug" in attributes:  # pragma no branch

--- a/github/Invitation.py
+++ b/github/Invitation.py
@@ -52,6 +52,7 @@ from github.GithubObject import Attribute, CompletableGithubObject, NotSet
 
 if TYPE_CHECKING:
     from github.NamedUser import NamedUser
+    from github.Organization import Organization
     from github.Repository import Repository
 
 
@@ -72,8 +73,8 @@ class Invitation(CompletableGithubObject):
         self._expired: Attribute[bool] = NotSet
         self._html_url: Attribute[str] = NotSet
         self._id: Attribute[int] = NotSet
-        self._invitee: Attribute[NamedUser] = NotSet
-        self._inviter: Attribute[NamedUser] = NotSet
+        self._invitee: Attribute[NamedUser | Organization] = NotSet
+        self._inviter: Attribute[NamedUser | Organization] = NotSet
         self._node_id: Attribute[str] = NotSet
         self._permissions: Attribute[str] = NotSet
         self._repository: Attribute[Repository] = NotSet
@@ -103,12 +104,12 @@ class Invitation(CompletableGithubObject):
         return self._id.value
 
     @property
-    def invitee(self) -> NamedUser:
+    def invitee(self) -> NamedUser | Organization:
         self._completeIfNotSet(self._invitee)
         return self._invitee.value
 
     @property
-    def inviter(self) -> NamedUser:
+    def inviter(self) -> NamedUser | Organization:
         self._completeIfNotSet(self._inviter)
         return self._inviter.value
 
@@ -142,9 +143,25 @@ class Invitation(CompletableGithubObject):
         if "id" in attributes:  # pragma no branch
             self._id = self._makeIntAttribute(attributes["id"])
         if "invitee" in attributes:  # pragma no branch
-            self._invitee = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["invitee"])
+            self._invitee = self._makeUnionClassAttributeFromTypeKey(
+                github.NamedUser.NamedUser,
+                "User",
+                github.Organization.Organization,
+                "Organization",
+                "type",
+                "User",
+                attributes["invitee"],
+            )
         if "inviter" in attributes:  # pragma no branch
-            self._inviter = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["inviter"])
+            self._inviter = self._makeUnionClassAttributeFromTypeKey(
+                github.NamedUser.NamedUser,
+                "User",
+                github.Organization.Organization,
+                "Organization",
+                "type",
+                "User",
+                attributes["inviter"],
+            )
         if "node_id" in attributes:  # pragma no branch
             self._node_id = self._makeStringAttribute(attributes["node_id"])
 

--- a/github/Invitation.py
+++ b/github/Invitation.py
@@ -144,23 +144,19 @@ class Invitation(CompletableGithubObject):
             self._id = self._makeIntAttribute(attributes["id"])
         if "invitee" in attributes:  # pragma no branch
             self._invitee = self._makeUnionClassAttributeFromTypeKey(
-                github.NamedUser.NamedUser,
-                "User",
-                github.Organization.Organization,
-                "Organization",
                 "type",
                 "User",
                 attributes["invitee"],
+                (github.NamedUser.NamedUser, "User"),
+                (github.Organization.Organization, "Organization"),
             )
         if "inviter" in attributes:  # pragma no branch
             self._inviter = self._makeUnionClassAttributeFromTypeKey(
-                github.NamedUser.NamedUser,
-                "User",
-                github.Organization.Organization,
-                "Organization",
                 "type",
                 "User",
                 attributes["inviter"],
+                (github.NamedUser.NamedUser, "User"),
+                (github.Organization.Organization, "Organization"),
             )
         if "node_id" in attributes:  # pragma no branch
             self._node_id = self._makeStringAttribute(attributes["node_id"])

--- a/github/IssueComment.py
+++ b/github/IssueComment.py
@@ -61,6 +61,7 @@ from github.PaginatedList import PaginatedList
 if TYPE_CHECKING:
     from github.GithubApp import GithubApp
     from github.NamedUser import NamedUser
+    from github.Organization import Organization
     from github.Reaction import Reaction
 
 
@@ -90,7 +91,7 @@ class IssueComment(CompletableGithubObject):
         self._reactions: Attribute[dict] = NotSet
         self._updated_at: Attribute[datetime] = NotSet
         self._url: Attribute[str] = NotSet
-        self._user: Attribute[NamedUser] = NotSet
+        self._user: Attribute[NamedUser | Organization] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"id": self._id.value, "user": self._user.value})
@@ -161,7 +162,7 @@ class IssueComment(CompletableGithubObject):
         return self._url.value
 
     @property
-    def user(self) -> NamedUser:
+    def user(self) -> NamedUser | Organization:
         self._completeIfNotSet(self._user)
         return self._user.value
 
@@ -287,4 +288,12 @@ class IssueComment(CompletableGithubObject):
         if "url" in attributes:  # pragma no branch
             self._url = self._makeStringAttribute(attributes["url"])
         if "user" in attributes:  # pragma no branch
-            self._user = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["user"])
+            self._user = self._makeUnionClassAttributeFromTypeKey(
+                github.NamedUser.NamedUser,
+                "User",
+                github.Organization.Organization,
+                "Organization",
+                "type",
+                "User",
+                attributes["user"],
+            )

--- a/github/IssueComment.py
+++ b/github/IssueComment.py
@@ -289,11 +289,9 @@ class IssueComment(CompletableGithubObject):
             self._url = self._makeStringAttribute(attributes["url"])
         if "user" in attributes:  # pragma no branch
             self._user = self._makeUnionClassAttributeFromTypeKey(
-                github.NamedUser.NamedUser,
-                "User",
-                github.Organization.Organization,
-                "Organization",
                 "type",
                 "User",
                 attributes["user"],
+                (github.NamedUser.NamedUser, "User"),
+                (github.Organization.Organization, "Organization"),
             )

--- a/github/IssueEvent.py
+++ b/github/IssueEvent.py
@@ -61,6 +61,7 @@ if TYPE_CHECKING:
     from github.Label import Label
     from github.Milestone import Milestone
     from github.NamedUser import NamedUser
+    from github.Organization import Organization
     from github.Team import Team
 
 
@@ -78,9 +79,9 @@ class IssueEvent(CompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._actor: Attribute[NamedUser] = NotSet
-        self._assignee: Attribute[NamedUser] = NotSet
-        self._assigner: Attribute[NamedUser] = NotSet
+        self._actor: Attribute[NamedUser | Organization] = NotSet
+        self._assignee: Attribute[NamedUser | Organization] = NotSet
+        self._assigner: Attribute[NamedUser | Organization] = NotSet
         self._author_association: Attribute[dict[str, Any]] = NotSet
         self._commit_id: Attribute[str] = NotSet
         self._commit_url: Attribute[str] = NotSet
@@ -96,26 +97,26 @@ class IssueEvent(CompletableGithubObject):
         self._performed_via_github_app: Attribute[GithubApp] = NotSet
         self._project_card: Attribute[dict[str, Any]] = NotSet
         self._rename: Attribute[dict] = NotSet
-        self._requested_reviewer: Attribute[NamedUser] = NotSet
+        self._requested_reviewer: Attribute[NamedUser | Organization] = NotSet
         self._requested_team: Attribute[Team] = NotSet
-        self._review_requester: Attribute[NamedUser] = NotSet
+        self._review_requester: Attribute[NamedUser | Organization] = NotSet
         self._url: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"id": self._id.value})
 
     @property
-    def actor(self) -> NamedUser:
+    def actor(self) -> NamedUser | Organization:
         self._completeIfNotSet(self._actor)
         return self._actor.value
 
     @property
-    def assignee(self) -> NamedUser:
+    def assignee(self) -> NamedUser | Organization:
         self._completeIfNotSet(self._assignee)
         return self._assignee.value
 
     @property
-    def assigner(self) -> NamedUser:
+    def assigner(self) -> NamedUser | Organization:
         self._completeIfNotSet(self._assigner)
         return self._assigner.value
 
@@ -195,7 +196,7 @@ class IssueEvent(CompletableGithubObject):
         return self._rename.value
 
     @property
-    def requested_reviewer(self) -> NamedUser:
+    def requested_reviewer(self) -> NamedUser | Organization:
         self._completeIfNotSet(self._requested_reviewer)
         return self._requested_reviewer.value
 
@@ -205,7 +206,7 @@ class IssueEvent(CompletableGithubObject):
         return self._requested_team.value
 
     @property
-    def review_requester(self) -> NamedUser:
+    def review_requester(self) -> NamedUser | Organization:
         self._completeIfNotSet(self._review_requester)
         return self._review_requester.value
 
@@ -216,11 +217,35 @@ class IssueEvent(CompletableGithubObject):
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:
         if "actor" in attributes:  # pragma no branch
-            self._actor = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["actor"])
+            self._actor = self._makeUnionClassAttributeFromTypeKey(
+                github.NamedUser.NamedUser,
+                "User",
+                github.Organization.Organization,
+                "Organization",
+                "type",
+                "User",
+                attributes["actor"],
+            )
         if "assignee" in attributes:  # pragma no branch
-            self._assignee = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["assignee"])
+            self._assignee = self._makeUnionClassAttributeFromTypeKey(
+                github.NamedUser.NamedUser,
+                "User",
+                github.Organization.Organization,
+                "Organization",
+                "type",
+                "User",
+                attributes["assignee"],
+            )
         if "assigner" in attributes:  # pragma no branch
-            self._assigner = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["assigner"])
+            self._assigner = self._makeUnionClassAttributeFromTypeKey(
+                github.NamedUser.NamedUser,
+                "User",
+                github.Organization.Organization,
+                "Organization",
+                "type",
+                "User",
+                attributes["assigner"],
+            )
         if "author_association" in attributes:  # pragma no branch
             self._author_association = self._makeDictAttribute(attributes["author_association"])
         if "commit_id" in attributes:  # pragma no branch
@@ -254,14 +279,26 @@ class IssueEvent(CompletableGithubObject):
         if "rename" in attributes:  # pragma no branch
             self._rename = self._makeDictAttribute(attributes["rename"])
         if "requested_reviewer" in attributes:  # pragma no branch
-            self._requested_reviewer = self._makeClassAttribute(
-                github.NamedUser.NamedUser, attributes["requested_reviewer"]
+            self._requested_reviewer = self._makeUnionClassAttributeFromTypeKey(
+                github.NamedUser.NamedUser,
+                "User",
+                github.Organization.Organization,
+                "Organization",
+                "type",
+                "User",
+                attributes["requested_reviewer"],
             )
         if "requested_team" in attributes:  # pragma no branch
             self._requested_team = self._makeClassAttribute(github.Team.Team, attributes["requested_team"])
         if "review_requester" in attributes:  # pragma no branch
-            self._review_requester = self._makeClassAttribute(
-                github.NamedUser.NamedUser, attributes["review_requester"]
+            self._review_requester = self._makeUnionClassAttributeFromTypeKey(
+                github.NamedUser.NamedUser,
+                "User",
+                github.Organization.Organization,
+                "Organization",
+                "type",
+                "User",
+                attributes["review_requester"],
             )
         if "url" in attributes:  # pragma no branch
             self._url = self._makeStringAttribute(attributes["url"])

--- a/github/IssueEvent.py
+++ b/github/IssueEvent.py
@@ -218,33 +218,27 @@ class IssueEvent(CompletableGithubObject):
     def _useAttributes(self, attributes: dict[str, Any]) -> None:
         if "actor" in attributes:  # pragma no branch
             self._actor = self._makeUnionClassAttributeFromTypeKey(
-                github.NamedUser.NamedUser,
-                "User",
-                github.Organization.Organization,
-                "Organization",
                 "type",
                 "User",
                 attributes["actor"],
+                (github.NamedUser.NamedUser, "User"),
+                (github.Organization.Organization, "Organization"),
             )
         if "assignee" in attributes:  # pragma no branch
             self._assignee = self._makeUnionClassAttributeFromTypeKey(
-                github.NamedUser.NamedUser,
-                "User",
-                github.Organization.Organization,
-                "Organization",
                 "type",
                 "User",
                 attributes["assignee"],
+                (github.NamedUser.NamedUser, "User"),
+                (github.Organization.Organization, "Organization"),
             )
         if "assigner" in attributes:  # pragma no branch
             self._assigner = self._makeUnionClassAttributeFromTypeKey(
-                github.NamedUser.NamedUser,
-                "User",
-                github.Organization.Organization,
-                "Organization",
                 "type",
                 "User",
                 attributes["assigner"],
+                (github.NamedUser.NamedUser, "User"),
+                (github.Organization.Organization, "Organization"),
             )
         if "author_association" in attributes:  # pragma no branch
             self._author_association = self._makeDictAttribute(attributes["author_association"])
@@ -280,25 +274,21 @@ class IssueEvent(CompletableGithubObject):
             self._rename = self._makeDictAttribute(attributes["rename"])
         if "requested_reviewer" in attributes:  # pragma no branch
             self._requested_reviewer = self._makeUnionClassAttributeFromTypeKey(
-                github.NamedUser.NamedUser,
-                "User",
-                github.Organization.Organization,
-                "Organization",
                 "type",
                 "User",
                 attributes["requested_reviewer"],
+                (github.NamedUser.NamedUser, "User"),
+                (github.Organization.Organization, "Organization"),
             )
         if "requested_team" in attributes:  # pragma no branch
             self._requested_team = self._makeClassAttribute(github.Team.Team, attributes["requested_team"])
         if "review_requester" in attributes:  # pragma no branch
             self._review_requester = self._makeUnionClassAttributeFromTypeKey(
-                github.NamedUser.NamedUser,
-                "User",
-                github.Organization.Organization,
-                "Organization",
                 "type",
                 "User",
                 attributes["review_requester"],
+                (github.NamedUser.NamedUser, "User"),
+                (github.Organization.Organization, "Organization"),
             )
         if "url" in attributes:  # pragma no branch
             self._url = self._makeStringAttribute(attributes["url"])

--- a/github/Migration.py
+++ b/github/Migration.py
@@ -260,13 +260,11 @@ class Migration(CompletableGithubObject):
             self._org_metadata_only = self._makeBoolAttribute(attributes["org_metadata_only"])
         if "owner" in attributes:
             self._owner = self._makeUnionClassAttributeFromTypeKey(
-                github.NamedUser.NamedUser,
-                "User",
-                github.Organization.Organization,
-                "Organization",
                 "type",
                 "User",
                 attributes["owner"],
+                (github.NamedUser.NamedUser, "User"),
+                (github.Organization.Organization, "Organization"),
             )
         if "repositories" in attributes:
             self._repositories = self._makeListOfClassesAttribute(

--- a/github/Project.py
+++ b/github/Project.py
@@ -48,7 +48,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import github.GithubObject
 import github.NamedUser
@@ -57,6 +57,10 @@ import github.ProjectColumn
 from github import Consts
 from github.GithubObject import Attribute, CompletableGithubObject, NotSet, Opt
 from github.PaginatedList import PaginatedList
+
+if TYPE_CHECKING:
+    from github.NamedUser import NamedUser
+    from github.Organization import Organization
 
 
 class Project(CompletableGithubObject):
@@ -75,7 +79,7 @@ class Project(CompletableGithubObject):
         self._body: Attribute[str] = NotSet
         self._columns_url: Attribute[str] = NotSet
         self._created_at: Attribute[datetime] = NotSet
-        self._creator: Attribute[github.NamedUser.NamedUser] = NotSet
+        self._creator: Attribute[NamedUser | Organization] = NotSet
         self._html_url: Attribute[str] = NotSet
         self._id: Attribute[int] = NotSet
         self._name: Attribute[str] = NotSet
@@ -107,7 +111,7 @@ class Project(CompletableGithubObject):
         return self._created_at.value
 
     @property
-    def creator(self) -> github.NamedUser.NamedUser:
+    def creator(self) -> NamedUser | Organization:
         self._completeIfNotSet(self._creator)
         return self._creator.value
 
@@ -241,7 +245,15 @@ class Project(CompletableGithubObject):
         if "created_at" in attributes:  # pragma no branch
             self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
         if "creator" in attributes:  # pragma no branch
-            self._creator = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["creator"])
+            self._creator = self._makeUnionClassAttributeFromTypeKey(
+                github.NamedUser.NamedUser,
+                "User",
+                github.Organization.Organization,
+                "Organization",
+                "type",
+                "User",
+                attributes["creator"],
+            )
         if "html_url" in attributes:  # pragma no branch
             self._html_url = self._makeStringAttribute(attributes["html_url"])
         if "id" in attributes:  # pragma no branch

--- a/github/Project.py
+++ b/github/Project.py
@@ -246,13 +246,11 @@ class Project(CompletableGithubObject):
             self._created_at = self._makeDatetimeAttribute(attributes["created_at"])
         if "creator" in attributes:  # pragma no branch
             self._creator = self._makeUnionClassAttributeFromTypeKey(
-                github.NamedUser.NamedUser,
-                "User",
-                github.Organization.Organization,
-                "Organization",
                 "type",
                 "User",
                 attributes["creator"],
+                (github.NamedUser.NamedUser, "User"),
+                (github.Organization.Organization, "Organization"),
             )
         if "html_url" in attributes:  # pragma no branch
             self._html_url = self._makeStringAttribute(attributes["html_url"])

--- a/github/StatsContributor.py
+++ b/github/StatsContributor.py
@@ -123,13 +123,11 @@ class StatsContributor(NonCompletableGithubObject):
     def _useAttributes(self, attributes: dict[str, Any]) -> None:
         if "author" in attributes:  # pragma no branch
             self._author = self._makeUnionClassAttributeFromTypeKey(
-                github.NamedUser.NamedUser,
-                "User",
-                github.Organization.Organization,
-                "Organization",
                 "type",
                 "User",
                 attributes["author"],
+                (github.NamedUser.NamedUser, "User"),
+                (github.Organization.Organization, "Organization"),
             )
         if "total" in attributes:  # pragma no branch
             self._total = self._makeIntAttribute(attributes["total"])

--- a/github/StatsContributor.py
+++ b/github/StatsContributor.py
@@ -38,12 +38,16 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import github.GithubObject
 import github.NamedUser
 import github.Organization
 from github.GithubObject import Attribute, NonCompletableGithubObject, NotSet
+
+if TYPE_CHECKING:
+    from github.NamedUser import NamedUser
+    from github.Organization import Organization
 
 
 class StatsContributor(NonCompletableGithubObject):
@@ -100,12 +104,12 @@ class StatsContributor(NonCompletableGithubObject):
                 self._w = self._makeTimestampAttribute(attributes["w"])
 
     def _initAttributes(self) -> None:
-        self._author: Attribute[github.NamedUser.NamedUser] = NotSet
+        self._author: Attribute[NamedUser | Organization] = NotSet
         self._total: Attribute[int] = NotSet
         self._weeks: Attribute[list[StatsContributor.Week]] = NotSet
 
     @property
-    def author(self) -> github.NamedUser.NamedUser:
+    def author(self) -> NamedUser | Organization:
         return self._author.value
 
     @property
@@ -118,7 +122,15 @@ class StatsContributor(NonCompletableGithubObject):
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:
         if "author" in attributes:  # pragma no branch
-            self._author = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["author"])
+            self._author = self._makeUnionClassAttributeFromTypeKey(
+                github.NamedUser.NamedUser,
+                "User",
+                github.Organization.Organization,
+                "Organization",
+                "type",
+                "User",
+                attributes["author"],
+            )
         if "total" in attributes:  # pragma no branch
             self._total = self._makeIntAttribute(attributes["total"])
         if "weeks" in attributes:  # pragma no branch

--- a/tests/GithubApp.py
+++ b/tests/GithubApp.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 import github
+import github.Organization
 
 from . import Framework
 from .GithubIntegration import APP_ID, PRIVATE_KEY
@@ -93,6 +94,7 @@ class GithubApp(Framework.TestCase):
         self.assertIsNone(app.installations_count)
         self.assertEqual(app.name, "GitHub Actions")
         self.assertEqual(app.node_id, "MDM6QXBwMTUzNjg=")
+        self.assertIsInstance(app.owner, github.Organization.Organization)
         self.assertEqual(app.owner.login, "github")
         self.assertIsNone(app.pem)
         self.assertDictEqual(


### PR DESCRIPTION
More attributes return a `Union` of PyGithub classes:
- `CommitComment.user` returns `NamedUser | Organization`
- `CommitStatus.creator` returns `NamedUser | Organization`
- `DependabotAlert.dismissed_by` returns `NamedUser | Organization | None`
- `Deployment.creator` returns `NamedUser | Organization`
- `GithubApp.owner` returns `NamedUser | Organization | Enterprise`
- `Invitation.invitee` and `Invitation.inviter` return `NamedUser | Organization`
- `IssueComment.user` returns `NamedUser | Organization`
- `IssueEvent.actor`, `IssueEvent.assignee`, `IssueEvent.assigner`, `IssueEvent.requested_reviewer` and `IssueEvent.review_requester` return `NamedUser | Organization`
- `Migration.owner` returns `NamedUser | Organization`
- `Project.creator` returns `NamedUser | Organization`
- `StatsContributor.author` returns `NamedUser | Organization`