### PR TITLE
Make `GitTag.verification` return `GitCommitVerification`

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -24,6 +24,20 @@ Breaking Changes
 
     gh.get_rate_limit().resources.core.remaining
 
+* Changes the return value of `GitTag.verification` from `dict` to ``GitCommitVerification``.
+
+  Code like
+
+  .. code-block:: python
+
+    tag.verification["reason"]
+
+  should be replaced with
+
+  .. code-block:: python
+
+    tag.verification.reason
+
 Version 2.6.0 (February 15, 2025)
 ---------------------------------
 
@@ -48,6 +62,22 @@ Breaking Changes
 
     repo.get_views_traffic().views.timestamp
     repo.get_clones_traffic().clones.timestamp
+
+* Add ``GitCommitVerification`` class (`#3028 <https://github.com/PyGithub/PyGithub/pull/3028>`_) (`822e6d71 <https://github.com/PyGithub/PyGithub/commit/822e6d71>`_):
+
+  Changes the return value of ``GitCommit.verification`` from ``dict`` to ``GitCommitVerification``.
+
+  Code like
+
+  .. code-block:: python
+
+    commit.verification["reason"]
+
+  should be replaced with
+
+  .. code-block:: python
+
+    commit.verification.reason
 
 * Fix typos (`#3086 <https://github.com/PyGithub/PyGithub/pull/3086>`_) (`a50ae51b <https://github.com/PyGithub/PyGithub/commit/a50ae51b>`_):
 

--- a/github/GitTag.py
+++ b/github/GitTag.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import github.GitAuthor
+import github.GitCommitVerification
 import github.GithubObject
 import github.GitObject
 import github.GitTreeElement
@@ -50,6 +51,7 @@ from github.GithubObject import Attribute, CompletableGithubObject, NotSet
 
 if TYPE_CHECKING:
     from github.GitAuthor import GitAuthor
+    from github.GitCommitVerification import GitCommitVerification
     from github.GitObject import GitObject
 
 
@@ -73,7 +75,7 @@ class GitTag(CompletableGithubObject):
         self._tag: Attribute[str] = NotSet
         self._tagger: Attribute[GitAuthor] = NotSet
         self._url: Attribute[str] = NotSet
-        self._verification: Attribute[dict[str, Any]] = NotSet
+        self._verification: Attribute[GitCommitVerification] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"sha": self._sha.value, "tag": self._tag.value})
@@ -114,7 +116,7 @@ class GitTag(CompletableGithubObject):
         return self._url.value
 
     @property
-    def verification(self) -> dict[str, Any]:
+    def verification(self) -> GitCommitVerification:
         self._completeIfNotSet(self._verification)
         return self._verification.value
 
@@ -134,4 +136,6 @@ class GitTag(CompletableGithubObject):
         if "url" in attributes:  # pragma no branch
             self._url = self._makeStringAttribute(attributes["url"])
         if "verification" in attributes:  # pragma no branch
-            self._verification = self._makeDictAttribute(attributes["verification"])
+            self._verification = self._makeClassAttribute(
+                github.GitCommitVerification.GitCommitVerification, attributes["verification"]
+            )

--- a/tests/GitTag.py
+++ b/tests/GitTag.py
@@ -65,7 +65,4 @@ class GitTag(Framework.TestCase):
             "https://api.github.com/repos/PyGithub/PyGithub/git/tags/f5f37322407b02a80de4526ad88d5f188977bc3c",
         )
         self.assertEqual(repr(self.tag), 'GitTag(tag="v0.6", sha="f5f37322407b02a80de4526ad88d5f188977bc3c")')
-        self.assertEqual(
-            self.tag.verification,
-            {"verified": False, "reason": "unsigned", "signature": None, "payload": None, "verified_at": None},
-        )
+        self.assertEqual(self.tag.verification.reason, "unsigned")


### PR DESCRIPTION
Turns the return value of `GitTag.verification` from `dict` into a proper class.

Follow-up on #3028.