### PR TITLE
Allow SHAs when creating PR comments

### DIFF
--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -448,9 +448,7 @@ class PullRequest(CompletableGithubObject):
         headers, data = self._requester.requestJsonAndCheck("GET", self.issue_url)
         return github.Issue.Issue(self._requester, headers, data, completed=True)
 
-    def create_comment(
-        self, body: str, commit: github.Commit.Commit | str, path: str, position: int
-    ) -> PullRequestComment:
+    def create_comment(self, body: str, commit: github.Commit.Commit, path: str, position: int) -> PullRequestComment:
         """
         :calls: `POST /repos/{owner}/{repo}/pulls/{number}/comments <https://docs.github.com/en/rest/reference/pulls#review-comments>`_
         """
@@ -459,7 +457,34 @@ class PullRequest(CompletableGithubObject):
     def create_review_comment(
         self,
         body: str,
-        commit: github.Commit.Commit | str,
+        commit: github.Commit.Commit,
+        path: str,
+        # line replaces deprecated position argument, so we put it between path and side
+        line: Opt[int] = NotSet,
+        side: Opt[str] = NotSet,
+        start_line: Opt[int] = NotSet,
+        start_side: Opt[str] = NotSet,
+        in_reply_to: Opt[int] = NotSet,
+        subject_type: Opt[str] = NotSet,
+        as_suggestion: bool = False,
+    ) -> PullRequestComment:
+        return self.create_review_comment_with_primatives(
+            body=body,
+            commit=commit._identity,
+            path=path,
+            line=line,
+            side=side,
+            start_line=start_line,
+            start_side=start_side,
+            in_reply_to=in_reply_to,
+            subject_type=subject_type,
+            as_suggestion=as_suggestion,
+        )
+
+    def create_review_comment_with_primatives(
+        self,
+        body: str,
+        commit: str,
         path: str,
         # line replaces deprecated position argument, so we put it between path and side
         line: Opt[int] = NotSet,
@@ -474,7 +499,7 @@ class PullRequest(CompletableGithubObject):
         :calls: `POST /repos/{owner}/{repo}/pulls/{number}/comments <https://docs.github.com/en/rest/reference/pulls#review-comments>`_
         """
         assert isinstance(body, str), body
-        assert isinstance(commit, (github.Commit.Commit, str)), commit
+        assert isinstance(commit, str), commit
         assert isinstance(path, str), path
         assert is_optional(line, int), line
         assert is_undefined(side) or side in ["LEFT", "RIGHT"], side
@@ -496,7 +521,7 @@ class PullRequest(CompletableGithubObject):
         post_parameters = NotSet.remove_unset_items(
             {
                 "body": body,
-                "commit_id": commit._identity if isinstance(commit, github.Commit.Commit) else commit,
+                "commit_id": commit,
                 "path": path,
                 "line": line,
                 "side": side,

--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -448,7 +448,9 @@ class PullRequest(CompletableGithubObject):
         headers, data = self._requester.requestJsonAndCheck("GET", self.issue_url)
         return github.Issue.Issue(self._requester, headers, data, completed=True)
 
-    def create_comment(self, body: str, commit: github.Commit.Commit, path: str, position: int) -> PullRequestComment:
+    def create_comment(
+        self, body: str, commit: github.Commit.Commit | str, path: str, position: int
+    ) -> PullRequestComment:
         """
         :calls: `POST /repos/{owner}/{repo}/pulls/{number}/comments <https://docs.github.com/en/rest/reference/pulls#review-comments>`_
         """
@@ -457,7 +459,7 @@ class PullRequest(CompletableGithubObject):
     def create_review_comment(
         self,
         body: str,
-        commit: github.Commit.Commit,
+        commit: github.Commit.Commit | str,
         path: str,
         # line replaces deprecated position argument, so we put it between path and side
         line: Opt[int] = NotSet,
@@ -472,7 +474,7 @@ class PullRequest(CompletableGithubObject):
         :calls: `POST /repos/{owner}/{repo}/pulls/{number}/comments <https://docs.github.com/en/rest/reference/pulls#review-comments>`_
         """
         assert isinstance(body, str), body
-        assert isinstance(commit, github.Commit.Commit), commit
+        assert isinstance(commit, (github.Commit.Commit, str)), commit
         assert isinstance(path, str), path
         assert is_optional(line, int), line
         assert is_undefined(side) or side in ["LEFT", "RIGHT"], side
@@ -494,7 +496,7 @@ class PullRequest(CompletableGithubObject):
         post_parameters = NotSet.remove_unset_items(
             {
                 "body": body,
-                "commit_id": commit._identity,
+                "commit_id": commit._identity if isinstance(commit, github.Commit.Commit) else commit,
                 "path": path,
                 "line": line,
                 "side": side,


### PR DESCRIPTION
Existing code requires a `Commit` to be passed into `PullRequest.create_review_comment` even though it only uses the SHA. Given an existing `PullRequest`, to pass a `Commit`, one would need to make another round trip via `Repository.get_commit(sha=sha)` just to pass in the larger object. 

This may need additional tests / work, but I was hoping to gauge interest in the idea before completing the rest. Thanks :) 