### PR TITLE
Use warnings.deprecated() decorator with Python 3.13+

### DIFF
--- a/github/AppAuthentication.py
+++ b/github/AppAuthentication.py
@@ -34,12 +34,11 @@
 ################################################################################
 from __future__ import annotations
 
-import deprecated
-
 from github.Auth import AppAuth, AppInstallationAuth
+from github.GithubObject import deprecated
 
 
-@deprecated.deprecated("Use github.Auth.AppInstallationAuth instead")
+@deprecated("Use github.Auth.AppInstallationAuth instead")
 class AppAuthentication(AppInstallationAuth):
     def __init__(
         self,

--- a/github/CheckRun.py
+++ b/github/CheckRun.py
@@ -34,8 +34,6 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-import deprecated
-
 import github.CheckRunAnnotation
 import github.CheckRunOutput
 import github.CheckSuite
@@ -48,6 +46,7 @@ from github.GithubObject import (
     CompletableGithubObject,
     NotSet,
     Opt,
+    deprecated,
     is_defined,
     is_optional,
     is_optional_list,
@@ -109,7 +108,7 @@ class CheckRun(CompletableGithubObject):
         return self._check_suite.value
 
     @property
-    @deprecated.deprecated("Use property check_suite.id instead")
+    @deprecated("Use property check_suite.id instead")
     def check_suite_id(self) -> int:
         self._completeIfNotSet(self._check_suite_id)
         return self._check_suite_id.value

--- a/github/GithubIntegration.py
+++ b/github/GithubIntegration.py
@@ -36,7 +36,6 @@ import urllib.parse
 import warnings
 from typing import Any
 
-import deprecated
 import urllib3
 from urllib3 import Retry
 
@@ -45,6 +44,7 @@ from github import Consts
 from github.Auth import AppAuth
 from github.GithubApp import GithubApp
 from github.GithubException import GithubException
+from github.GithubObject import deprecated
 from github.Installation import Installation
 from github.InstallationAuthorization import InstallationAuthorization
 from github.PaginatedList import PaginatedList
@@ -241,7 +241,7 @@ class GithubIntegration:
             attributes=response,
         )
 
-    @deprecated.deprecated(
+    @deprecated(
         "Use github.Github(auth=github.Auth.AppAuth), github.Auth.AppAuth.token or github.Auth.AppAuth.create_jwt(expiration) instead"
     )
     def create_jwt(self, expiration: int | None = None) -> str:
@@ -277,7 +277,7 @@ class GithubIntegration:
             attributes=response,
         )
 
-    @deprecated.deprecated("Use get_repo_installation")
+    @deprecated("Use get_repo_installation")
     def get_installation(self, owner: str, repo: str) -> Installation:
         """
         Deprecated by get_repo_installation.

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 
 import email.utils
 import re
+import sys
 import typing
 from abc import ABC
 from datetime import datetime, timezone
@@ -72,6 +73,26 @@ T = typing.TypeVar("T")
 K = typing.TypeVar("K")
 T_co = typing.TypeVar("T_co", covariant=True)
 T_gh = typing.TypeVar("T_gh", bound="GithubObject")
+
+
+if sys.version_info < (3, 13):
+    # For older Python we provide a decorator with the same interface as the new
+    # stdlib one. Note that there are some differences in the warning message
+    # though, for example when decorating classes.
+    from deprecated import deprecated as _thirdparty_deprecated
+
+    _F = typing.TypeVar("_F", bound=Callable[..., Any])
+
+    def deprecated(
+        msg: str, *, category: type[Warning] | None = DeprecationWarning, stacklevel: int = 1
+    ) -> Callable[[_F], _F]:
+        if category is None:
+            return lambda thing: thing
+        # XXX: ignore type error until https://github.com/python/typeshed/pull/13573 is fixed
+        return _thirdparty_deprecated(reason=msg, category=category, extra_stacklevel=stacklevel - 1)  # type: ignore
+
+else:
+    from warnings import deprecated as deprecated
 
 
 class Attribute(Protocol[T_co]):

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -167,8 +167,6 @@ from collections.abc import Iterable
 from datetime import date, datetime, timezone
 from typing import TYPE_CHECKING, Any
 
-from deprecated import deprecated
-
 import github.AdvisoryCredit
 import github.AdvisoryVulnerability
 import github.Artifact
@@ -249,6 +247,7 @@ from github.GithubObject import (
     NotSet,
     Opt,
     _NotSetType,
+    deprecated,
     is_defined,
     is_optional,
     is_optional_list,
@@ -2852,7 +2851,7 @@ class Repository(CompletableGithubObject):
         }
 
     @deprecated(
-        reason="""
+        """
         Repository.get_dir_contents() is deprecated, use
         Repository.get_contents() instead.
         """

--- a/github/RequiredPullRequestReviews.py
+++ b/github/RequiredPullRequestReviews.py
@@ -46,12 +46,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-import deprecated
-
 import github.GithubApp
 import github.NamedUser
 import github.Team
-from github.GithubObject import Attribute, CompletableGithubObject, NonCompletableGithubObject, NotSet
+from github.GithubObject import Attribute, CompletableGithubObject, NonCompletableGithubObject, NotSet, deprecated
 
 if TYPE_CHECKING:
     from github.GithubApp import GithubApp
@@ -212,12 +210,12 @@ class RequiredPullRequestReviews(CompletableGithubObject):
         return self._dismissal_restrictions.value
 
     @property
-    @deprecated.deprecated("Use dismissal_restrictions.teams")
+    @deprecated("Use dismissal_restrictions.teams")
     def dismissal_teams(self) -> list[Team]:
         return self.dismissal_restrictions.teams if self.dismissal_restrictions is not None else None
 
     @property
-    @deprecated.deprecated("Use dismissal_restrictions.users")
+    @deprecated("Use dismissal_restrictions.users")
     def dismissal_users(self) -> list[NamedUser]:
         return self.dismissal_restrictions.users if self.dismissal_restrictions is not None else None
 

--- a/github/Team.py
+++ b/github/Team.py
@@ -67,8 +67,6 @@ import urllib.parse
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from deprecated import deprecated
-
 import github.NamedUser
 import github.Organization
 import github.PaginatedList
@@ -77,7 +75,7 @@ import github.Repository
 import github.TeamDiscussion
 from github import Consts
 from github.GithubException import UnknownObjectException
-from github.GithubObject import Attribute, CompletableGithubObject, NotSet, Opt
+from github.GithubObject import Attribute, CompletableGithubObject, NotSet, Opt, deprecated
 
 if TYPE_CHECKING:
     from github.Membership import Membership
@@ -314,7 +312,7 @@ class Team(CompletableGithubObject):
             return None
 
     @deprecated(
-        reason="""
+        """
         Team.set_repo_permission() is deprecated, use Team.update_team_repository() instead.
         """
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "pyjwt[crypto]>=2.4.0",
   "typing-extensions>=4.0.0",
   "urllib3>=1.26.0",
-  "Deprecated",
+  "Deprecated>=1.2.15; python_version < '3.13'",
 ]
 
 [project.urls]

--- a/tests/Authentication.py
+++ b/tests/Authentication.py
@@ -91,19 +91,18 @@ class Authentication(Framework.BasicTestCase):
         )
 
     def testAppAuthentication(self):
-        with self.assertWarns(DeprecationWarning) as warning:
+        with self.assertWarnsRegex(DeprecationWarning, r"Use github.Auth.AppInstallationAuth instead"):
             app_auth = github.AppAuthentication(
                 app_id=APP_ID,
                 private_key=PRIVATE_KEY,
                 installation_id=29782936,
             )
+        with self.assertWarns(
+            DeprecationWarning,
+            msg="Argument app_auth is deprecated, please use auth=github.Auth.AppInstallationAuth(...) instead",
+        ):
             g = github.Github(app_auth=app_auth)
         self.assertEqual(g.get_user("ammarmallik").name, "Ammar Akbar")
-        self.assertWarnings(
-            warning,
-            "Call to deprecated class AppAuthentication. (Use github.Auth.AppInstallationAuth instead)",
-            "Argument app_auth is deprecated, please use auth=github.Auth.AppInstallationAuth(...) instead",
-        )
 
     def testLoginAuthentication(self):
         # test data copied from testBasicAuthentication to test parity


### PR DESCRIPTION
PyGitHub is using the "deprecated" Python package for deprecations until now, but was only using the provided deprecated() decorator from it, which in Python 3.13 has a stdlib equivalent with [warnings.deprecated()](https://docs.python.org/3/library/warnings.html#warnings.deprecated).

The stdlib variant has multiple advantages:

* Removes the dependency on the "deprecated" package and the transitive "wrapt" package (which is a C extension)
* Mypy can alert users of deprecated APIs since mypy 1.14 (opt-in for now), see https://mypy-lang.blogspot.com/2024/12/mypy-114-released.html
* Pylance in VSCode gives visual hints and warnings when using a deprecated function/class

The make everything still work with older Python we provide a wrapper that implements the new stdlib interface, and we only require the "deprecated" package with older Python. The wrapper requires the "extra_stacklevel" kwarg added in 1.2.15, so make that the minimum version. The wrapper exposed a bug in types-deprecated, which is tracked here: https://github.com/python/typeshed/pull/13573 which is why type checking is skipped in parts there.

For classes the stdlib variants just warns with the provided message while the package converts it to "Call to deprecated class Foo (\<msg\>)". Adjust the tests to use regex matching there, to cover both cases.