### PR TITLE
Replace `deprecated.deprecated()` with `typing_extensions.deprecated()`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,17 +55,17 @@ $ python scripts/add_attribute.py Commit url string
 
 ## Deprecation warning
 
-Before removing attributes/methods, consider adding deprecation warnings instead. The [Deprecated](https://github.com/tantale/deprecated) packages provides a handy decorator to add deprecation warnings with an optional reason.
+Before removing attributes/methods, consider adding deprecation warnings instead. The [typing_extensions](https://pypi.org/project/typing-extensions/) package provides a handy decorator to add deprecation warnings.
 
 ```python
-from deprecated import deprecated
+from typing_extensions import deprecated
 
 @property
-@deprecated
+@deprecated("Use core instead")
 def rate(self):
    pass
 
-@deprecated(reason="Deprecated in favor of the new branch protection")
+@deprecated("Deprecated in favor of the new branch protection")
 def get_protected_branch(self):
    pass
 ```

--- a/github/AppAuthentication.py
+++ b/github/AppAuthentication.py
@@ -34,12 +34,12 @@
 ################################################################################
 from __future__ import annotations
 
-import deprecated
+from typing_extensions import deprecated
 
 from github.Auth import AppAuth, AppInstallationAuth
 
 
-@deprecated.deprecated("Use github.Auth.AppInstallationAuth instead")
+@deprecated("Use github.Auth.AppInstallationAuth instead")
 class AppAuthentication(AppInstallationAuth):
     def __init__(
         self,

--- a/github/CheckRun.py
+++ b/github/CheckRun.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-import deprecated
+from typing_extensions import deprecated
 
 import github.CheckRunAnnotation
 import github.CheckRunOutput
@@ -109,7 +109,7 @@ class CheckRun(CompletableGithubObject):
         return self._check_suite.value
 
     @property
-    @deprecated.deprecated("Use property check_suite.id instead")
+    @deprecated("Use property check_suite.id instead")
     def check_suite_id(self) -> int:
         self._completeIfNotSet(self._check_suite_id)
         return self._check_suite_id.value

--- a/github/GithubIntegration.py
+++ b/github/GithubIntegration.py
@@ -36,8 +36,8 @@ import urllib.parse
 import warnings
 from typing import Any
 
-import deprecated
 import urllib3
+from typing_extensions import deprecated
 from urllib3 import Retry
 
 import github
@@ -241,7 +241,7 @@ class GithubIntegration:
             attributes=response,
         )
 
-    @deprecated.deprecated(
+    @deprecated(
         "Use github.Github(auth=github.Auth.AppAuth), github.Auth.AppAuth.token or github.Auth.AppAuth.create_jwt(expiration) instead"
     )
     def create_jwt(self, expiration: int | None = None) -> str:
@@ -277,7 +277,7 @@ class GithubIntegration:
             attributes=response,
         )
 
-    @deprecated.deprecated("Use get_repo_installation")
+    @deprecated("Use get_repo_installation")
     def get_installation(self, owner: str, repo: str) -> Installation:
         """
         Deprecated by get_repo_installation.

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -167,7 +167,7 @@ from collections.abc import Iterable
 from datetime import date, datetime, timezone
 from typing import TYPE_CHECKING, Any
 
-from deprecated import deprecated
+from typing_extensions import deprecated
 
 import github.AdvisoryCredit
 import github.AdvisoryVulnerability
@@ -2852,7 +2852,7 @@ class Repository(CompletableGithubObject):
         }
 
     @deprecated(
-        reason="""
+        """
         Repository.get_dir_contents() is deprecated, use
         Repository.get_contents() instead.
         """

--- a/github/RequiredPullRequestReviews.py
+++ b/github/RequiredPullRequestReviews.py
@@ -46,7 +46,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-import deprecated
+from typing_extensions import deprecated
 
 import github.GithubApp
 import github.NamedUser
@@ -212,12 +212,12 @@ class RequiredPullRequestReviews(CompletableGithubObject):
         return self._dismissal_restrictions.value
 
     @property
-    @deprecated.deprecated("Use dismissal_restrictions.teams")
+    @deprecated("Use dismissal_restrictions.teams")
     def dismissal_teams(self) -> list[Team]:
         return self.dismissal_restrictions.teams if self.dismissal_restrictions is not None else None
 
     @property
-    @deprecated.deprecated("Use dismissal_restrictions.users")
+    @deprecated("Use dismissal_restrictions.users")
     def dismissal_users(self) -> list[NamedUser]:
         return self.dismissal_restrictions.users if self.dismissal_restrictions is not None else None
 

--- a/github/Team.py
+++ b/github/Team.py
@@ -67,7 +67,7 @@ import urllib.parse
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from deprecated import deprecated
+from typing_extensions import deprecated
 
 import github.NamedUser
 import github.Organization
@@ -314,7 +314,7 @@ class Team(CompletableGithubObject):
             return None
 
     @deprecated(
-        reason="""
+        """
         Team.set_repo_permission() is deprecated, use Team.update_team_repository() instead.
         """
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,8 @@ dependencies = [
   "pynacl>=1.4.0",
   "requests>=2.14.0",
   "pyjwt[crypto]>=2.4.0",
-  "typing-extensions>=4.0.0",
+  "typing-extensions>=4.5.0",
   "urllib3>=1.26.0",
-  "Deprecated",
 ]
 
 [project.urls]

--- a/requirements/types.txt
+++ b/requirements/types.txt
@@ -1,4 +1,3 @@
 mypy >=1.0.0
-types-deprecated
 types-jwt
 types-requests

--- a/tests/Authentication.py
+++ b/tests/Authentication.py
@@ -101,7 +101,7 @@ class Authentication(Framework.BasicTestCase):
         self.assertEqual(g.get_user("ammarmallik").name, "Ammar Akbar")
         self.assertWarnings(
             warning,
-            "Call to deprecated class AppAuthentication. (Use github.Auth.AppInstallationAuth instead)",
+            "Use github.Auth.AppInstallationAuth instead",
             "Argument app_auth is deprecated, please use auth=github.Auth.AppInstallationAuth(...) instead",
         )
 


### PR DESCRIPTION
PyGitHub is using the `deprecated` Python package for deprecations until now, but was only using the provided `deprecated()` decorator from it, which since Python 3.13 has a stdlib equivalent with `warnings.deprecated()`. See https://peps.python.org/pep-0702/ for details.

Luckily `typing_extensions`, which we already use, provide the same decorator for old Python versions (since 4.5), and just passes through the stdlib one when using Python 3.13+.

The new decorator has multiple advantages:

* Removes the dependency on the `deprecated` package and the transitive `wrapt` package (which is a C extension)
* Mypy can alert users of deprecated APIs since mypy 1.14 (opt-in), see https://mypy-lang.blogspot.com/2024/12/mypy-114-released.html
* Pylance in VSCode gives visual hints and warnings when using a deprecated function/class

There are some small differences between the decorators, which in our case only affect one test case, where the old one would prefix a class deprecation with "Call to deprecated class Foo" while the new one just uses the message as is. Also with the new one a message is required, so adjust the examples in the contribution guide.