### PR TITLE
Throw `UnknownObjectException` for missing branch

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -834,7 +834,7 @@ class Requester:
             exc = GithubException.BadUserAgentException
         elif status == 403 and cls.isRateLimitError(lc_message):
             exc = GithubException.RateLimitExceededException
-        elif status == 404 and (lc_message == "not found" or "no object found" in lc_message):
+        elif status == 404 and ("not found" in lc_message or "no object found" in lc_message):
             exc = GithubException.UnknownObjectException
         else:
             # for general GithubException, provide the actual message

--- a/tests/PullRequest.py
+++ b/tests/PullRequest.py
@@ -532,9 +532,8 @@ class PullRequest(Framework.TestCase):
         status = self.delete_restore_pull.merge(delete_branch=True)
         self.assertTrue(status.merged)
         self.assertTrue(self.delete_restore_pull.is_merged())
-        with self.assertRaises(github.GithubException) as raisedexp:
+        with self.assertRaises(github.UnknownObjectException) as raisedexp:
             self.delete_restore_repo.get_branch(self.delete_restore_pull.head.ref)
-        self.assertEqual(raisedexp.exception.message, "Branch not found")
         self.assertEqual(
             raisedexp.exception.data,
             {
@@ -544,9 +543,8 @@ class PullRequest(Framework.TestCase):
         )
 
     def testRestoreBranch(self):
-        with self.assertRaises(github.GithubException) as raisedexp:
+        with self.assertRaises(github.UnknownObjectException) as raisedexp:
             self.delete_restore_repo.get_branch(self.delete_restore_pull.head.ref)
-        self.assertEqual(raisedexp.exception.message, "Branch not found")
         self.assertEqual(raisedexp.exception.status, 404)
         self.assertEqual(
             raisedexp.exception.data,
@@ -561,9 +559,8 @@ class PullRequest(Framework.TestCase):
     def testDeleteBranch(self):
         self.assertTrue(self.delete_restore_repo.get_branch(self.delete_restore_pull.head.ref))
         self.delete_restore_pull.delete_branch(force=False)
-        with self.assertRaises(github.GithubException) as raisedexp:
+        with self.assertRaises(github.UnknownObjectException) as raisedexp:
             self.delete_restore_repo.get_branch(self.delete_restore_pull.head.ref)
-        self.assertEqual(raisedexp.exception.message, "Branch not found")
         self.assertEqual(raisedexp.exception.status, 404)
         self.assertEqual(
             raisedexp.exception.data,
@@ -576,9 +573,8 @@ class PullRequest(Framework.TestCase):
     def testForceDeleteBranch(self):
         self.assertTrue(self.delete_restore_repo.get_branch(self.delete_restore_pull.head.ref))
         self.assertEqual(self.delete_restore_pull.delete_branch(force=True), None)
-        with self.assertRaises(github.GithubException) as raisedexp:
+        with self.assertRaises(github.UnknownObjectException) as raisedexp:
             self.delete_restore_repo.get_branch(self.delete_restore_pull.head.ref)
-        self.assertEqual(raisedexp.exception.message, "Branch not found")
         self.assertEqual(raisedexp.exception.status, 404)
         self.assertEqual(
             raisedexp.exception.data,

--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -1772,10 +1772,9 @@ class Repository(Framework.TestCase):
     def testMergeUpstreamFailure(self):
         # Use fork for being able to update it
         repo = self.g.get_repo("Felixoid/PyGithub")
-        with self.assertRaises(github.GithubException) as raisedexp:
+        with self.assertRaises(github.UnknownObjectException) as raisedexp:
             repo.merge_upstream("doesNotExist")
         self.assertEqual(raisedexp.exception.status, 404)
-        self.assertEqual(raisedexp.exception.message, "Branch not found")
 
         with self.assertRaises(github.GithubException) as raisedexp:
             repo.merge_upstream("merge-conflict")


### PR DESCRIPTION
Fixes #3011

Ideally this code should just check for status code and not touch the
message at all, but I'm sticking with the pattern here.
