### PR TITLE
fix: run_duration_ms raises key error when not present in response in timing

### DIFF
--- a/github/WorkflowRun.py
+++ b/github/WorkflowRun.py
@@ -69,7 +69,7 @@ class TimingData(NamedTuple):
     """
 
     billable: dict[str, dict[str, int]]
-    run_duration_ms: int
+    run_duration_ms: int | None
 
 
 class WorkflowRun(CompletableGithubObject):
@@ -347,7 +347,7 @@ class WorkflowRun(CompletableGithubObject):
         :calls: `GET /repos/{owner}/{repo}/actions/runs/{run_id}/timing <https://docs.github.com/en/rest/reference/actions#workflow-runs>`_
         """
         headers, data = self._requester.requestJsonAndCheck("GET", f"{self.url}/timing")
-        return TimingData(billable=data["billable"], run_duration_ms=data["run_duration_ms"])  # type: ignore
+        return TimingData(billable=data["billable"], run_duration_ms=data.get("run_duration_ms", None))
 
     def delete(self) -> bool:
         """

--- a/tests/ReplayData/WorkflowRun.test_timing_no_run_duration.txt
+++ b/tests/ReplayData/WorkflowRun.test_timing_no_run_duration.txt
@@ -1,0 +1,10 @@
+https
+GET
+api.github.com
+None
+/repos/PyGithub/PyGithub/actions/runs/3881497935/timing
+{'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
+None
+200
+[('Server', 'GitHub.com'), ('Date', 'Fri, 13 Jan 2023 13:19:58 GMT'), ('Content-Type', 'application/json; charset=utf-8'), ('Transfer-Encoding', 'chunked'), ('Cache-Control', 'public, max-age=60, s-maxage=60'), ('Vary', 'Accept, Accept-Encoding, Accept, X-Requested-With'), ('ETag', 'W/"8ec19a979b8290796ff8c533ce429b277e20807aa5b771b658a04c6375422fb3"'), ('X-GitHub-Media-Type', 'github.v3; format=json'), ('x-github-api-version-selected', '2022-11-28'), ('X-RateLimit-Limit', '60'), ('X-RateLimit-Remaining', '18'), ('X-RateLimit-Reset', '1673619381'), ('X-RateLimit-Used', '42'), ('X-RateLimit-Resource', 'core'), ('Access-Control-Expose-Headers', 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset'), ('Access-Control-Allow-Origin', '*'), ('Strict-Transport-Security', 'max-age=31536000; includeSubdomains; preload'), ('X-Frame-Options', 'deny'), ('X-Content-Type-Options', 'nosniff'), ('X-XSS-Protection', '0'), ('Referrer-Policy', 'origin-when-cross-origin, strict-origin-when-cross-origin'), ('Content-Security-Policy', "default-src 'none'"), ('Content-Encoding', 'gzip'), ('X-GitHub-Request-Id', 'CBC6:0299:F963:14A67:63C15A7D')]
+{"billable":{}}

--- a/tests/WorkflowRun.py
+++ b/tests/WorkflowRun.py
@@ -168,6 +168,11 @@ class WorkflowRun(Framework.TestCase):
         )
         self.assertEqual(timing.run_duration_ms, 241000)
 
+    def test_timing_no_run_duration(self):
+        timing = self.workflow_run.timing()
+        self.assertEqual(timing.billable, {})
+        self.assertEqual(timing.run_duration_ms, None)
+
     def test_rerun(self):
         wr = self.repo.get_workflow_run(3910280793)
         self.assertFalse(wr.rerun())


### PR DESCRIPTION
This PR aims to fix a bug that occurs when a user tries to request the timing of a workflow run, the issue occurs because if the run failed because of a badly formatted ci.yml file the field `run_duration_ms` is not sent in the response of the API call.

As per the documentation [here](https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#get-workflow-run-usage) in the response body the field `run_duration_ms` is not required, see the response schema below. This field is not present in the case for example that the ci file for a workflow was badly formatted. 

In the current implementation since it is accessing the dict that is the data object returned from the request to the api using square brackets if the key is not present it raises a key error.
The implementation on this branch fixes it by using `.get()` and setting the default to None if it does not exist in the returned dict.

The PR includes a test to simulate this behaviour

```json
{
  "title": "Workflow Run Usage",
  "description": "Workflow Run Usage",
  "type": "object",
  "properties": {
    "billable": {
      "type": "object",
      "properties": {
        "UBUNTU": {
          "type": "object",
          "required": [
            "total_ms",
            "jobs"
          ],
          "properties": {
            "total_ms": {
              "type": "integer"
            },
            "jobs": {
              "type": "integer"
            },
            "job_runs": {
              "type": "array",
              "items": {
                "type": "object",
                "required": [
                  "job_id",
                  "duration_ms"
                ],
                "properties": {
                  "job_id": {
                    "type": "integer"
                  },
                  "duration_ms": {
                    "type": "integer"
                  }
                }
              }
            }
          }
        },
        "MACOS": {
          "type": "object",
          "required": [
            "total_ms",
            "jobs"
          ],
          "properties": {
            "total_ms": {
              "type": "integer"
            },
            "jobs": {
              "type": "integer"
            },
            "job_runs": {
              "type": "array",
              "items": {
                "type": "object",
                "required": [
                  "job_id",
                  "duration_ms"
                ],
                "properties": {
                  "job_id": {
                    "type": "integer"
                  },
                  "duration_ms": {
                    "type": "integer"
                  }
                }
              }
            }
          }
        },
        "WINDOWS": {
          "type": "object",
          "required": [
            "total_ms",
            "jobs"
          ],
          "properties": {
            "total_ms": {
              "type": "integer"
            },
            "jobs": {
              "type": "integer"
            },
            "job_runs": {
              "type": "array",
              "items": {
                "type": "object",
                "required": [
                  "job_id",
                  "duration_ms"
                ],
                "properties": {
                  "job_id": {
                    "type": "integer"
                  },
                  "duration_ms": {
                    "type": "integer"
                  }
                }
              }
            }
          }
        }
      }
    },
    "run_duration_ms": {
      "type": "integer"
    }
  },
  "required": [
    "billable"
  ]
}
```