### PR TITLE
fix(CodeScanAlert): add missing attributes

### DIFF
--- a/github/CodeScanAlert.py
+++ b/github/CodeScanAlert.py
@@ -53,7 +53,9 @@ class CodeScanAlert(NonCompletableGithubObject):
         self._created_at: Attribute[datetime] = NotSet
         self._dismissed_at: Attribute[datetime | None] = NotSet
         self._dismissed_by: Attribute[github.NamedUser.NamedUser | None] = NotSet
+        self._dismissed_comment: Attribute[str | None] = NotSet
         self._dismissed_reason: Attribute[str | None] = NotSet
+        self._fixed_at: Attribute[datetime | None] = NotSet
         self._html_url: Attribute[str] = NotSet
         self._instances_url: Attribute[str] = NotSet
         self._most_recent_instance: Attribute[github.CodeScanAlertInstance.CodeScanAlertInstance] = NotSet
@@ -79,8 +81,16 @@ class CodeScanAlert(NonCompletableGithubObject):
         return self._dismissed_by.value
 
     @property
+    def dismissed_comment(self) -> str | None:
+        return self._dismissed_comment.value
+
+    @property
     def dismissed_reason(self) -> str | None:
         return self._dismissed_reason.value
+
+    @property
+    def fixed_at(self) -> datetime | None:
+        return self._fixed_at.value
 
     @property
     def html_url(self) -> str:
@@ -135,8 +145,12 @@ class CodeScanAlert(NonCompletableGithubObject):
             self._dismissed_at = self._makeDatetimeAttribute(attributes["dismissed_at"])
         if "dismissed_by" in attributes:  # pragma no branch
             self._dismissed_by = self._makeClassAttribute(github.NamedUser.NamedUser, attributes["dismissed_by"])
+        if "dismissed_comment" in attributes:  # pragma no branch
+            self._dismissed_comment = self._makeStringAttribute(attributes["dismissed_comment"])
         if "dismissed_reason" in attributes:  # pragma no branch
             self._dismissed_reason = self._makeStringAttribute(attributes["dismissed_reason"])
+        if "fixed_at" in attributes:  # pragma no branch
+            self._fixed_at = self._makeDatetimeAttribute(attributes["fixed_at"])
         if "html_url" in attributes:  # pragma no branch
             self._html_url = self._makeStringAttribute(attributes["html_url"])
         if "instances_url" in attributes:  # pragma no branch


### PR DESCRIPTION
This PR adds two missing attributes to code scanning alerts. I don't know if these are new or were skipped initially.

Note: I did not use the script to add the attributes as I did this from the GitHub UI. Please let me know if anything was missed and I will make the necessary updates.