### PR TITLE
Point deprecation warnings to the caller code rather than inner class

### DIFF
--- a/github/GithubIntegration.py
+++ b/github/GithubIntegration.py
@@ -138,6 +138,7 @@ class GithubIntegration:
                 "Arguments integration_id, private_key, jwt_expiry, jwt_issued_at and jwt_algorithm are deprecated, "
                 "please use auth=github.Auth.AppAuth(...) instead",
                 category=DeprecationWarning,
+                stacklevel=2,
             )
             if jwt_algorithm != Consts.DEFAULT_JWT_ALGORITHM:
                 auth = AppAuth(

--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -231,12 +231,14 @@ class Github:
                 "Arguments login_or_token and password are deprecated, please use "
                 "auth=github.Auth.Login(...) instead",
                 category=DeprecationWarning,
+                stacklevel=2,
             )
             auth = github.Auth.Login(login_or_token, password)  # type: ignore
         elif login_or_token is not None:
             warnings.warn(
                 "Argument login_or_token is deprecated, please use " "auth=github.Auth.Token(...) instead",
                 category=DeprecationWarning,
+                stacklevel=2,
             )
             auth = github.Auth.Token(login_or_token)
         elif jwt is not None:
@@ -245,12 +247,14 @@ class Github:
                 "auth=github.Auth.AppAuth(...) or "
                 "auth=github.Auth.AppAuthToken(...) instead",
                 category=DeprecationWarning,
+                stacklevel=2,
             )
             auth = github.Auth.AppAuthToken(jwt)
         elif app_auth is not None:
             warnings.warn(
                 "Argument app_auth is deprecated, please use " "auth=github.Auth.AppInstallationAuth(...) instead",
                 category=DeprecationWarning,
+                stacklevel=2,
             )
             auth = app_auth
 

--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -1055,6 +1055,7 @@ class Github:
                 "Argument slug is mandatory, calling this method without the slug argument is deprecated, please use "
                 "github.GithubIntegration(auth=github.Auth.AppAuth(...)).get_app() instead",
                 category=DeprecationWarning,
+                stacklevel=2,
             )
             return GithubIntegration(**self.__requester.kwargs).get_app()
         else:


### PR DESCRIPTION
By default `warnings.warn` will point at the location of the `warn` call itself, and provides no stacktrace information, which can make it much harder to find the relevant application code.

By setting the stacklevel to 2, `warnings` will provide a link (file and line number) to the *caller* of `Github()`, which is the location to fix.