### PR TITLE
Fix connection pooling to improve connection performance

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -1244,6 +1244,8 @@ class Requester:
             return self.__connection
 
         with self.__connection_lock:
+            if self.__persist and self.__connection is not None and hostname == self.__connection.host:
+                return self.__connection
             if self.__connection is not None:
                 self.__connection.close()
                 self.__connection = None


### PR DESCRIPTION
Fixes #3288

In #3060 logic was added to allow making requests to different hostnames in order to follow redirects. However, I believe this logic is incorrect:

```python
if self.__persist and self.__connection is not None and hostname is not None and hostname == self.__hostname:
    return self.__connection
```

The problem is that `__createConnection` is almost always called with `hostname=None`, so it compares `None` to `github.com` and does not reuse the connection. Additionally, I think there may be a bug where `self.__connection` can be instantiated to a new connection with a non-standard hostname and get incorrectly reused as comparisons are done against `self.__hostname` instead of the actual hostname of the connection.

To fix this, I am handling the `hostname=None` case and comparing against the actual hostname of the connection.

## Validation

I am re-using the reproduction code from the issue report:

```python
import os, logging
logging.basicConfig(level=logging.DEBUG)

from github import Github, Auth
auth = Auth.Token(os.environ['GITHUB_TOKEN'])
g = Github(auth=auth)
print(list(g.get_user().get_repos()))
```

Output before:
```
$ GITHUB_TOKEN=xxx python test.py
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): api.github.com:443
DEBUG:urllib3.connectionpool:https://api.github.com:443 "GET /user/repos HTTP/1.1" 200 None
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): api.github.com:443
DEBUG:urllib3.connectionpool:https://api.github.com:443 "GET /user/repos?page=2 HTTP/1.1" 200 None
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): api.github.com:443
DEBUG:urllib3.connectionpool:https://api.github.com:443 "GET /user/repos?page=3 HTTP/1.1" 200 None
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): api.github.com:443
DEBUG:urllib3.connectionpool:https://api.github.com:443 "GET /user/repos?page=4 HTTP/1.1" 200 None
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): api.github.com:443
DEBUG:urllib3.connectionpool:https://api.github.com:443 "GET /user/repos?page=5 HTTP/1.1" 200 None
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): api.github.com:443
```

Output after this PR:
```
$ GITHUB_TOKEN=xxx python test.py
DEBUG:urllib3.connectionpool:https://api.github.com:443 "GET /user/repos HTTP/1.1" 200 None
DEBUG:urllib3.connectionpool:https://api.github.com:443 "GET /user/repos?page=2 HTTP/1.1" 200 None
DEBUG:urllib3.connectionpool:https://api.github.com:443 "GET /user/repos?page=3 HTTP/1.1" 200 None
DEBUG:urllib3.connectionpool:https://api.github.com:443 "GET /user/repos?page=4 HTTP/1.1" 200 None
DEBUG:urllib3.connectionpool:https://api.github.com:443 "GET /user/repos?page=5 HTTP/1.1" 200 None
```

I have also verified that this fixes the performance regression in our code (reducing time taken for a script making many requests from ~13 minutes to ~7 minutes).