### PR TITLE
fix: use wildcard for github domains validation

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -1211,6 +1211,10 @@ class Requester:
         # Updates self.__last_requests with current timestamp for given verb
         self.__last_requests[verb] = datetime.now(timezone.utc).timestamp()
 
+    def __extractDomainFromHostname(self, hostname: str) -> str:
+        # Extracts the domain from a hostname
+        return ".".join(hostname.split(".")[-2:])
+
     def __makeAbsoluteUrl(self, url: str) -> str:
         # URLs generated locally will be relative to __base_url
         # URLs returned from the server will start with __base_url
@@ -1218,12 +1222,10 @@ class Requester:
             url = f"{self.__prefix}{url}"
         else:
             o = urllib.parse.urlparse(url)
-            assert o.hostname in [
+            assert self.__extractDomainFromHostname(o.hostname) in [
                 self.__hostname,
-                "uploads.github.com",
-                "status.github.com",
                 "github.com",
-                "objects.githubusercontent.com",
+                "githubusercontent.com",
             ], o.hostname
             assert o.path.startswith((self.__prefix, self.__graphql_prefix, "/api/", "/login/oauth")), o.path
             assert o.port == self.__port, o.port

--- a/tests/Requester.py
+++ b/tests/Requester.py
@@ -263,6 +263,39 @@ class Requester(Framework.TestCase):
             "Following Github server redirection from /api/v3/repos/PyGithub/PyGithub to /repos/PyGithub/PyGithub"
         )
 
+    def testMakeAbsoluteUrl(self):
+        class TestAuth(github.Auth.AppAuth):
+            pass
+
+        # create a Requester with non-default arguments
+        auth = TestAuth(123, "key")
+        requester = github.Requester.Requester(
+            auth=auth,
+            base_url="https://base.url",
+            timeout=1,
+            user_agent="user agent",
+            per_page=123,
+            verify=False,
+            retry=3,
+            pool_size=5,
+            seconds_between_requests=1.2,
+            seconds_between_writes=3.4,
+            lazy=True,
+        )
+
+        with self.assertRaises(AssertionError) as exc:
+            requester._Requester__makeAbsoluteUrl("https://github.com.malicious.com"),
+            self.assertEqual(exc.exception.args, "AssertionError: github.com.malicious.com")
+
+        for url in [
+            "github.com",
+            "uploads.github.com",
+            "status.github.com",
+            "objects.githubusercontent.com",
+            "release-assets.githubusercontent.com",
+        ]:
+            self.assertEqual(requester._Requester__makeAbsoluteUrl(f"https://{url}"), "")
+
     PrimaryRateLimitErrors = [
         "API rate limit exceeded for x.x.x.x. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
     ]


### PR DESCRIPTION
Github recently added a new subdomain `release-assets` to their `githubusercontent.com` creating an issue when validating the incoming requests.

```
15.79 │ │        │                                                                 │ │
15.79 │ │        query='sp=r&sv=2018-11-09&sr=b&spr=https&se=2025-06-12T20%3A29%3… │ │
15.79 │ │        │   fragment=''                                                   │ │
15.79 │ │        )                                                                 │ │
15.79 │ │ self = <github.Requester.Requester object at 0xffffaed27bc0>             │ │
15.79 │ │  url = 'https://release-assets.githubusercontent.com/github-production-… │ │
15.79 │ ╰──────────────────────────────────────────────────────────────────────────╯ │
15.79 ╰──────────────────────────────────────────────────────────────────────────────╯
15.79 AssertionError: release-assets.githubusercontent.com
------
```

This PR updates the validation on the domain name instead of the full subdomain.domain

Message from github:

> Thank you for reaching out to GitHub Support!
> I checked in with our engineering teams about this.
> That’s correct, we have recently turned on a feature flag that adds the address release-assets.githubusercontent.com for release assets.
> This change comes a part of some internal service updates and is planned to be permanent.
> The *.githubusercontent.com address is listed as a wildcard in the GitHub META API Endpoint and depending on the activity performed you may see connections to many different githubusercontent.com subdomains, with some of them being new from time to time.
