### PR TITLE
Add `delete_self_hosted_runner` to `Organization`

### DIFF
--- a/github/Organization.py
+++ b/github/Organization.py
@@ -1616,6 +1616,22 @@ class Organization(CompletableGithubObject):
             list_item="runners",
         )
 
+    def delete_self_hosted_runner(self, runner_id: str) -> None:
+        """
+        :calls: `DELETE /orgs/{org}/actions/runners/{runner_id} <https://docs.github.com/en/rest/actions/self-hosted-runners?apiVersion=2022-11-28#delete-a-self-hosted-runner-from-an-organization>`_
+        :param runner_id: string
+        :rtype: None
+        """
+        assert isinstance(runner_id, str), runner_id
+        headers, data = self._requester.requestJsonAndCheck(
+            "DELETE",
+            f"{self.url}/actions/runners/{runner_id}",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+
     def get_code_security_configs(self, target_type: Opt[str] = NotSet) -> PaginatedList[CodeSecurityConfig]:
         """
         :calls: `GET /orgs/{org}/code-security/configurations <https://docs.github.com/en/rest/code-security/configurations#get-code-security-configurations-for-an-organization>`_

--- a/github/Organization.py
+++ b/github/Organization.py
@@ -1605,7 +1605,7 @@ class Organization(CompletableGithubObject):
 
     def get_self_hosted_runners(self) -> PaginatedList[SelfHostedActionsRunner]:
         """
-        :calls: `GET /orgs/{org}/actions/runners <https://docs.github.com/en/rest/actions/self-hosted-runner-groups#list-self-hosted-runner-groups-for-an-organization>`_
+        :calls: `GET /orgs/{org}/actions/runners <https://docs.github.com/en/rest/actions/self-hosted-runners?apiVersion=2022-11-28#list-self-hosted-runners-for-an-organization>`_
         :rtype: :class:`PaginatedList` of :class:`github.SelfHostedActionsRunner.SelfHostedActionsRunner`
         """
         return PaginatedList(

--- a/tests/Organization.py
+++ b/tests/Organization.py
@@ -745,6 +745,9 @@ class Organization(Framework.TestCase):
         runners = self.org.get_self_hosted_runners()
         self.assertEqual(runners.totalCount, 602)
 
+    def testDeleteSelfHostedRunner(self):
+        self.org.delete_self_hosted_runner("42")
+
     def testGetCodeSecurityConfigs(self):
         configs = list(self.org.get_code_security_configs())
         self.assertEqual(configs.pop().id, 17)

--- a/tests/ReplayData/Organization.testDeleteSelfHostedRunner.txt
+++ b/tests/ReplayData/Organization.testDeleteSelfHostedRunner.txt
@@ -3,7 +3,7 @@ DELETE
 api.github.com
 None
 /orgs/BeaverSoftware/actions/runners/42
-{'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
+{'Accept': 'application/vnd.github+json', 'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python', 'X-GitHub-Api-Version': '2022-11-28'}
 None
 204
 [('Date', 'Mon, 17 Feb 2025 06:13:40 GMT'), ('X-OAuth-Scopes', 'admin:org, repo, user'), ('X-Accepted-OAuth-Scopes', 'admin:org'), ('github-authentication-token-expiration', '2025-03-19 04:09:19 UTC'), ('X-GitHub-Media-Type', 'github.v3; format=json'), ('x-github-api-version-selected', '2022-11-28'), ('X-RateLimit-Limit', '5000'), ('X-RateLimit-Remaining', '4975'), ('X-RateLimit-Reset', '1739775594'), ('X-RateLimit-Used', '25'), ('X-RateLimit-Resource', 'core'), ('Access-Control-Expose-Headers', 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset'), ('Access-Control-Allow-Origin', '*'), ('Strict-Transport-Security', 'max-age=31536000; includeSubdomains; preload'), ('X-Frame-Options', 'deny'), ('X-Content-Type-Options', 'nosniff'), ('X-XSS-Protection', '0'), ('Referrer-Policy', 'origin-when-cross-origin, strict-origin-when-cross-origin'), ('Content-Security-Policy', "default-src 'none'"), ('Vary', 'Accept-Encoding, Accept, X-Requested-With'), ('X-GitHub-Request-Id', '6214:2DF157:15BB370:2BF35BD:67B2D394'), ('Server', 'github.com')]

--- a/tests/ReplayData/Organization.testDeleteSelfHostedRunner.txt
+++ b/tests/ReplayData/Organization.testDeleteSelfHostedRunner.txt
@@ -1,0 +1,9 @@
+https
+DELETE
+api.github.com
+None
+/orgs/BeaverSoftware/actions/runners/42
+{'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
+None
+204
+[('Date', 'Mon, 17 Feb 2025 06:13:40 GMT'), ('X-OAuth-Scopes', 'admin:org, repo, user'), ('X-Accepted-OAuth-Scopes', 'admin:org'), ('github-authentication-token-expiration', '2025-03-19 04:09:19 UTC'), ('X-GitHub-Media-Type', 'github.v3; format=json'), ('x-github-api-version-selected', '2022-11-28'), ('X-RateLimit-Limit', '5000'), ('X-RateLimit-Remaining', '4975'), ('X-RateLimit-Reset', '1739775594'), ('X-RateLimit-Used', '25'), ('X-RateLimit-Resource', 'core'), ('Access-Control-Expose-Headers', 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset'), ('Access-Control-Allow-Origin', '*'), ('Strict-Transport-Security', 'max-age=31536000; includeSubdomains; preload'), ('X-Frame-Options', 'deny'), ('X-Content-Type-Options', 'nosniff'), ('X-XSS-Protection', '0'), ('Referrer-Policy', 'origin-when-cross-origin, strict-origin-when-cross-origin'), ('Content-Security-Policy', "default-src 'none'"), ('Vary', 'Accept-Encoding, Accept, X-Requested-With'), ('X-GitHub-Request-Id', '6214:2DF157:15BB370:2BF35BD:67B2D394'), ('Server', 'github.com')]


### PR DESCRIPTION
PR related to #3189

This PR introduces a new function `delete_self_hosted_runner` to handle the deletion of self-hosted runners at the organization level.
Additionally, it includes a documentation update to correct the description of the `get_self_hosted_runners` function.

For guidance on tests, I referred to PRs #3190 and #3203 (huge thanks to @climbfuji and @billnapier)