### PR TITLE
Add `results-receiver.actions.githubusercontent.com` redirect from workflow run logs in assert URL

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -1224,6 +1224,7 @@ class Requester:
                 "status.github.com",
                 "github.com",
                 "objects.githubusercontent.com",
+                "results-receiver.actions.githubusercontent.com",
             ], o.hostname
             assert o.path.startswith((self.__prefix, self.__graphql_prefix, "/api/", "/login/oauth")), o.path
             assert o.port == self.__port, o.port


### PR DESCRIPTION
When trying to make raw request to download workflow run logs, it's not possible to use `Requester` directly as assert is failing with the redirect URL.

```sh
akmalharith/actions-retry-app/actions_retry via 🐍 3.12.2 
➜ python main.py
Logs location: https://results-receiver.actions.githubusercontent.com/rest/runs/REDACTED

akmalharith/actions-retry-app/actions_retry via 🐍 3.12.2 
➜ python main.py
Traceback (most recent call last):
  File "/Users/akmal/Code/akmalharith/actions-retry-app/actions_retry/main.py", line 48, in <module>
    status, headers, body = g.requester.requestJson(
                            ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/akmal/Code/akmalharith/actions-retry-app/.venv/lib/python3.12/site-packages/github/Requester.py", line 959, in requestJson
    status, responseHeaders, output = self.__requestEncode(
                                      ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/akmal/Code/akmalharith/actions-retry-app/.venv/lib/python3.12/site-packages/github/Requester.py", line 1098, in __requestEncode
    status, responseHeaders, output = self.__requestRaw(
                                      ^^^^^^^^^^^^^^^^^^
  File "/Users/akmal/Code/akmalharith/actions-retry-app/.venv/lib/python3.12/site-packages/github/Requester.py", line 1181, in __requestRaw
    path = self.__makeAbsoluteUrl(location)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/akmal/Code/akmalharith/actions-retry-app/.venv/lib/python3.12/site-packages/github/Requester.py", line 1228, in __makeAbsoluteUrl
    assert o.hostname in [
AssertionError: results-receiver.actions.githubusercontent.com
```

This PR is a fix to this limitation.