### PR TITLE
Improve OpenAPI scripts

### DIFF
--- a/scripts/openapi-update-classes.sh
+++ b/scripts/openapi-update-classes.sh
@@ -210,12 +210,12 @@ update() {
   commit "Sort attributes and methods in $class" && unchanged "sort" || changed "sort" "sort" || return 0
 
   # apply schemas to class
-  ("$python" "$openapi" apply "$spec" "$index" "${classes[@]}" && echo) 1>&2 || failed "$class" || return 0
+  ("$python" "$openapi" apply "$source_path" "$spec" "$index" "${classes[@]}" && echo) 1>&2 || failed "$class" || return 0
   commit "Updated $class according to API spec" && unchanged "$class" || changed "$class" "$class" || return 0
 
   # apply schemas to test class
   if [ ${#classes_with_tests[@]} -gt 0 ]; then
-    ("$python" "$openapi" apply --tests "$spec" "$index" "${classes_with_tests[@]}" && echo) 1>&2 || failed "tests" || return 0
+    ("$python" "$openapi" apply --tests "$source_path" "$spec" "$index" "${classes_with_tests[@]}" && echo) 1>&2 || failed "tests" || return 0
   fi
   # do not perform linting as part of the commit as this step
   # introduces imports that might be needed by assertions

--- a/scripts/openapi.py
+++ b/scripts/openapi.py
@@ -2482,9 +2482,14 @@ class OpenApi:
             available = set()
             implemented = classes.get(cls, {}).get("schemas", [])
             providing_properties = []
+            schema_returned_by = defaultdict(set)
 
             for providing_property, spec_types in provided_schemas.items():
-                available = available.union([t.lstrip("#") for t in spec_types])
+                for spec_type in spec_types:
+                    spec_type = spec_type.lstrip("#")
+                    available.add(spec_type)
+                    schema_returned_by[spec_type].add(providing_property)
+
                 providing_properties.append(providing_property)
 
             schemas_to_implement = sorted(list(available.difference(set(implemented))))
@@ -2494,6 +2499,9 @@ class OpenApi:
                 print(f"Class {cls}:")
                 for schema_to_implement in sorted(schemas_to_implement):
                     print(f"- should implement schema {schema_to_implement}")
+                    print("  Properties returning the schema:")
+                    for providing_class, providing_property in sorted(schema_returned_by[schema_to_implement]):
+                        print(f"  - {providing_class}.{providing_property}")
                 # for schema_to_remove in sorted(schemas_to_remove):
                 #    print(f"- should not implement schema {schema_to_remove}")
                 print("Properties returning the class:")


### PR DESCRIPTION
Implements the following improvements
- fix `scripts/openapi-update-classes.sh` call into `openapi.py`
- provide schemas returned by attributes when suggesting schemas
- consider union classes when suggesting schemas