### PR TITLE
Upgrade docformatter pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         additional_dependencies: [tomli]
 
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.5
+    rev: v1.7.7
     hooks:
       - id: docformatter
         additional_dependencies: [tomli]


### PR DESCRIPTION
* Updated pre-commit hook for https://github.com/PyCQA/docformatter to `1.7.7` due to
  * https://github.com/PyCQA/docformatter/issues/289
  * https://github.com/PyCQA/docformatter/issues/294
  * https://github.com/PyCQA/docformatter/issues/297