### PR TITLE
Rename `enterprise` argument of `Github.get_enterprise` to `slug`

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -455,16 +455,15 @@ class Github:
             url_parameters,
         )
 
-    # v3: rename enterprise to slug
-    def get_enterprise(self, enterprise: str) -> github.Enterprise.Enterprise:
+    def get_enterprise(self, slug: str) -> github.Enterprise.Enterprise:
         """
         :calls: `GET /enterprises/{enterprise} <https://docs.github.com/en/enterprise-cloud@latest/rest/enterprise-admin>`_
-        :param enterprise: string
+        :param slug: string
         :rtype: :class:`Enterprise`
         """
-        assert isinstance(enterprise, str), enterprise
+        assert isinstance(slug, str), slug
         # There is no native "/enterprises/{enterprise}" api, so this function is a hub for apis that start with "/enterprise/{enterprise}".
-        return github.Enterprise.Enterprise.from_slug(self.__requester, enterprise)
+        return github.Enterprise.Enterprise.from_slug(self.__requester, slug)
 
     def get_repo(self, full_name_or_id: int | str, lazy: bool = False) -> Repository:
         """


### PR DESCRIPTION
This is a breaking change for user code where the single argument of `Github.get_enterprise` is named:

    github.Github().get_enterprise(enterprise="…")

instead use one of the following calls now:

    github.Github().get_enterprise("…")
    github.Github().get_enterprise(slug="…")