### PR TITLE
Deprecate paginated properties in Commit and Comparison

### DIFF
--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -639,3 +639,7 @@ class CompletableGithubObject(GithubObject, ABC):
             self._storeAndUseAttributes(headers, data)
             self.__completed = True
             return True
+
+
+class CompletableGithubObjectWithPaginatedProperty(CompletableGithubObject):
+    paginatedPropertyName: str

--- a/tests/Commit.py
+++ b/tests/Commit.py
@@ -60,23 +60,6 @@ class Commit(Framework.TestCase):
             "https://api.github.com/repos/jacquev6/PyGithub/git/commits/1292bf0e22c796e91cc3d6e24b544aece8c21f2a",
         )
         self.assertEqual(self.commit.committer.login, "jacquev6")
-        self.assertEqual(len(list(self.commit.files)), 1)
-        self.assertEqual(self.commit.files.totalCount, 1)
-        self.assertEqual(self.commit.files[0].additions, 0)
-        self.assertEqual(
-            self.commit.files[0].blob_url,
-            "https://github.com/jacquev6/PyGithub/blob/1292bf0e22c796e91cc3d6e24b544aece8c21f2a/github%2FGithubObjects%2FGitAuthor.py",
-        )
-        self.assertEqual(self.commit.files[0].changes, 20)
-        self.assertEqual(self.commit.files[0].deletions, 20)
-        self.assertEqual(self.commit.files[0].filename, "github/GithubObjects/GitAuthor.py")
-        self.assertTrue(isinstance(self.commit.files[0].patch, str))
-        self.assertEqual(
-            self.commit.files[0].raw_url,
-            "https://github.com/jacquev6/PyGithub/raw/1292bf0e22c796e91cc3d6e24b544aece8c21f2a/github%2FGithubObjects%2FGitAuthor.py",
-        )
-        self.assertEqual(self.commit.files[0].sha, "ca6a3c616fc1367b6d01d04a7cf6ee27cf216f26")
-        self.assertEqual(self.commit.files[0].status, "modified")
         self.assertEqual(
             self.commit.html_url, "https://github.com/jacquev6/PyGithub/commit/1292bf0e22c796e91cc3d6e24b544aece8c21f2a"
         )
@@ -97,6 +80,26 @@ class Commit(Framework.TestCase):
         )
         self.assertEqual(self.commit.commit.tree.sha, "4c6bd50994f0f9823f898b1c6c964ad7d4fa11ab")
         self.assertEqual(repr(self.commit), 'Commit(sha="1292bf0e22c796e91cc3d6e24b544aece8c21f2a")')
+
+    def testGetFiles(self):
+        files = self.commit.get_files()
+        self.assertEqual(len(list(files)), 1)
+        self.assertEqual(files.totalCount, 1)
+        self.assertEqual(files[0].additions, 0)
+        self.assertEqual(
+            files[0].blob_url,
+            "https://github.com/jacquev6/PyGithub/blob/1292bf0e22c796e91cc3d6e24b544aece8c21f2a/github%2FGithubObjects%2FGitAuthor.py",
+        )
+        self.assertEqual(files[0].changes, 20)
+        self.assertEqual(files[0].deletions, 20)
+        self.assertEqual(files[0].filename, "github/GithubObjects/GitAuthor.py")
+        self.assertTrue(isinstance(files[0].patch, str))
+        self.assertEqual(
+            files[0].raw_url,
+            "https://github.com/jacquev6/PyGithub/raw/1292bf0e22c796e91cc3d6e24b544aece8c21f2a/github%2FGithubObjects%2FGitAuthor.py",
+        )
+        self.assertEqual(files[0].sha, "ca6a3c616fc1367b6d01d04a7cf6ee27cf216f26")
+        self.assertEqual(files[0].status, "modified")
 
     def testGetBranchesWhereHead(self):
         repo = self.g.get_repo("PyGithub/PyGithub")

--- a/tests/ExposeAllAttributes.py
+++ b/tests/ExposeAllAttributes.py
@@ -148,11 +148,14 @@ class ExposeAllAttributes(Framework.TestCase):
     def findMissingAttributes(self, obj):
         if isinstance(obj, github.GithubObject.CompletableGithubObject):
             obj.update()
+        paginatedPropertyName = None
+        if isinstance(obj, github.GithubObject.CompletableGithubObjectWithPaginatedProperty):
+            paginatedPropertyName = obj.paginatedPropertyName
         className = obj.__class__.__name__
         missingAttributes = {}
         for attribute in obj.raw_data:
             if attribute != "_links":
-                if not hasattr(obj, attribute):
+                if not hasattr(obj, attribute) and attribute != paginatedPropertyName:
                     missingAttributes[attribute] = obj.raw_data[attribute]
         return (className, missingAttributes)
 

--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -846,7 +846,7 @@ class Repository(Framework.TestCase):
         )
         self.assertEqual(comparison.base_commit.sha, "4303c5b90e2216d927155e9609436ccb8984c495")
         self.assertListKeyEqual(
-            comparison.commits,
+            comparison.get_commits(),
             lambda c: c.sha,
             [
                 "5bb654d26dd014d36794acd1e6ecf3736f12aad7",
@@ -872,9 +872,10 @@ class Repository(Framework.TestCase):
         self.assertEqual(comparison.behind_by, 0)
         self.assertEqual(comparison.total_commits, 10)
         self.assertEqual(len(comparison.files), 228)
-        self.assertEqual(comparison.commits.totalCount, 10)
+        commits = comparison.get_commits()
+        self.assertEqual(commits.totalCount, 10)
         self.assertListKeyEqual(
-            comparison.commits,
+            commits,
             lambda c: c.sha,
             [
                 "fab682a5ccfc275c31ec37f1f541254c7bd780f3",


### PR DESCRIPTION
Deprecates paginated properties `Commit.files` and `Comparison.commits`. Use respective getter methods instead.