### PR TITLE
Disable sleeps in tests

### DIFF
--- a/tests/Authentication.py
+++ b/tests/Authentication.py
@@ -180,7 +180,9 @@ class Authentication(Framework.BasicTestCase):
     def testAppInstallationAuthAuthentication(self):
         # test data copied from testAppAuthentication to test parity
         installation_auth = github.Auth.AppInstallationAuth(self.app_auth, 29782936)
-        g = github.Github(auth=installation_auth)
+        g = github.Github(
+            auth=installation_auth, lazy=False, seconds_between_requests=None, seconds_between_writes=None
+        )
 
         # token expires 2024-11-25 01:00:02
         token = installation_auth.token

--- a/tests/GithubIntegration.py
+++ b/tests/GithubIntegration.py
@@ -162,7 +162,9 @@ class GithubIntegration(Framework.BasicTestCase):
 
     def testGetAccessToken(self):
         auth = github.Auth.AppAuth(APP_ID, PRIVATE_KEY)
-        github_integration = github.GithubIntegration(auth=auth)
+        github_integration = github.GithubIntegration(
+            auth=auth, seconds_between_writes=None, seconds_between_requests=None
+        )
 
         # Get repo installation access token
         repo_installation_authorization = github_integration.get_access_token(self.repo_installation_id)

--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -1992,7 +1992,8 @@ class Repository(Framework.TestCase):
         self.repo.unsubscribe_from_hub("push", "http://requestb.in/1bc1sc61")
 
     def testStatisticsContributors(self):
-        stats = self.repo.get_stats_contributors()
+        with mock.patch("github.Requester.Consts.PROCESSING_202_WAIT_TIME", 0):
+            stats = self.repo.get_stats_contributors()
         seenJacquev6 = False
         for s in stats:
             adTotal = 0
@@ -2011,7 +2012,8 @@ class Repository(Framework.TestCase):
         self.assertTrue(seenJacquev6)
 
     def testStatisticsCommitActivity(self):
-        stats = self.repo.get_stats_commit_activity()
+        with mock.patch("github.Requester.Consts.PROCESSING_202_WAIT_TIME", 0):
+            stats = self.repo.get_stats_commit_activity()
         self.assertEqual(
             stats[0].week,
             datetime(2012, 11, 18, 0, 0, tzinfo=timezone.utc),
@@ -2020,7 +2022,8 @@ class Repository(Framework.TestCase):
         self.assertEqual(stats[0].days, [0, 7, 3, 9, 7, 3, 0])
 
     def testStatisticsCodeFrequency(self):
-        stats = self.repo.get_stats_code_frequency()
+        with mock.patch("github.Requester.Consts.PROCESSING_202_WAIT_TIME", 0):
+            stats = self.repo.get_stats_code_frequency()
         self.assertEqual(
             stats[0].week,
             datetime(2012, 2, 12, 0, 0, tzinfo=timezone.utc),
@@ -2029,7 +2032,8 @@ class Repository(Framework.TestCase):
         self.assertEqual(stats[0].deletions, -2098)
 
     def testStatisticsParticipation(self):
-        stats = self.repo.get_stats_participation()
+        with mock.patch("github.Requester.Consts.PROCESSING_202_WAIT_TIME", 0):
+            stats = self.repo.get_stats_participation()
         self.assertEqual(
             stats.owner,
             [
@@ -2146,7 +2150,8 @@ class Repository(Framework.TestCase):
         )
 
     def testStatisticsPunchCard(self):
-        stats = self.repo.get_stats_punch_card()
+        with mock.patch("github.Requester.Consts.PROCESSING_202_WAIT_TIME", 0):
+            stats = self.repo.get_stats_punch_card()
         self.assertEqual(stats.get(4, 12), 7)
         self.assertEqual(stats.get(6, 18), 2)
 


### PR DESCRIPTION
Reduces test times from 20s to 6.6s.