### PR TITLE
fix: Improve domain matching in Requester.py

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -850,7 +850,8 @@ class Requester:
             if hostname == domain_or_domains:
                 return True
             domain_suffix = f".{domain_or_domains}"
-            return hostname.endswith(domain_suffix)
+            hostname_suffix = f".{hostname}"
+            return hostname.endswith(domain_suffix) or domain_or_domains.endswith(hostname_suffix)
         return any(cls.__hostnameHasDomain(hostname, d) for d in domain_or_domains)
 
     def __assertUrlAllowed(self, url: str) -> None:


### PR DESCRIPTION
Enhance domain matching logic to support reverse checks.

Related to issues described in here: https://github.com/PyGithub/PyGithub/issues/3398

This PR enables the use of base_urls like "api.github.ORG.com" which would previously have failed to work.

Look into [issue ](https://github.com/PyGithub/PyGithub/issues/3398)for a more detailed report.