### PR TITLE
Pin CI lint Python version to 3.13

### DIFF
--- a/.github/actions/pre-commit/action.yml
+++ b/.github/actions/pre-commit/action.yml
@@ -7,7 +7,7 @@ runs:
   steps:
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.x"
+        python-version: "3.13"
     # FIXME: pin pre-commit<4 pending PyCQA/docformatter#287
     - name: install pre-commit
       run: python -m pip install 'pre-commit<4'


### PR DESCRIPTION
Works around https://github.com/myint/untokenize/issues/4.