### PR TITLE
Restrict PyPi release workflow permissions

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,4 +1,6 @@
 name: Publish to PyPI
+permissions:
+  contents: read
 on:
   push:
     tags: ["*"]  # this will run full workflow including publish to PyPI


### PR DESCRIPTION
Potential fix for [https://github.com/PyGithub/PyGithub/security/code-scanning/23](https://github.com/PyGithub/PyGithub/security/code-scanning/23)

The fix is to add a `permissions:` block specifying the minimum permissions required for the workflow or for each job. Since neither the `build` job (which reuses another workflow) nor the `publish` job require write access to repository contents (they're downloading artifacts and uploading to PyPI), it's safest to set the permissions to `contents: read` (inheriting only read access to repository files). This block can be added at the workflow root—just after the `name` block and before `jobs:`—ensuring all jobs inherit these least-privilege settings. Alternatively, you could add `permissions:` under each job, but the root-level block is simpler and suffices in this case.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
