### PR TITLE
Use `GET` url or `_links.self` as object url

### DIFF
--- a/github/Branch.py
+++ b/github/Branch.py
@@ -104,6 +104,7 @@ class Branch(NonCompletableGithubObject):
         self._protection: Attribute[BranchProtection] = NotSet
         self._protection_url: Attribute[str] = github.GithubObject.NotSet
         self._required_approving_review_count: Attribute[int] = NotSet
+        self._url: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"name": self._name.value})
@@ -141,6 +142,10 @@ class Branch(NonCompletableGithubObject):
     @property
     def required_approving_review_count(self) -> int:
         return self._required_approving_review_count.value
+
+    @property
+    def url(self) -> str:
+        return self._url.value
 
     def get_protection(self) -> BranchProtection:
         """
@@ -658,3 +663,5 @@ class Branch(NonCompletableGithubObject):
             self._required_approving_review_count = self._makeIntAttribute(
                 attributes["required_approving_review_count"]
             )
+        if "url" in attributes:
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/GithubApp.py
+++ b/github/GithubApp.py
@@ -227,6 +227,8 @@ class GithubApp(CompletableGithubObject):
         if "updated_at" in attributes:  # pragma no branch
             self._updated_at = self._makeDatetimeAttribute(attributes["updated_at"])
         if "url" in attributes:
-            self._url = self._makeStringAttribute(attributes["url"])
+            # we give precedence to the slug attribute
+            if "slug" not in attributes:
+                self._url = self._makeStringAttribute(attributes["url"])
         if "webhook_secret" in attributes:  # pragma no branch
             self._webhook_secret = self._makeStringAttribute(attributes["webhook_secret"])

--- a/github/GitignoreTemplate.py
+++ b/github/GitignoreTemplate.py
@@ -60,6 +60,7 @@ class GitignoreTemplate(NonCompletableGithubObject):
     def _initAttributes(self) -> None:
         self._name: Attribute[str] = NotSet
         self._source: Attribute[str] = NotSet
+        self._url: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"name": self._name.value})
@@ -72,8 +73,14 @@ class GitignoreTemplate(NonCompletableGithubObject):
     def source(self) -> str:
         return self._source.value
 
+    @property
+    def url(self) -> str:
+        return self._url.value
+
     def _useAttributes(self, attributes: dict[str, Any]) -> None:
         if "name" in attributes:  # pragma no branch
             self._name = self._makeStringAttribute(attributes["name"])
         if "source" in attributes:  # pragma no branch
             self._source = self._makeStringAttribute(attributes["source"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/github/RateLimitOverview.py
+++ b/github/RateLimitOverview.py
@@ -52,6 +52,7 @@ class RateLimitOverview(NonCompletableGithubObject):
     def _initAttributes(self) -> None:
         self._rate: Attribute[Rate] = NotSet
         self._resources: Attribute[RateLimit] = NotSet
+        self._url: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"rate": self._rate.value})
@@ -64,8 +65,14 @@ class RateLimitOverview(NonCompletableGithubObject):
     def resources(self) -> RateLimit:
         return self._resources.value
 
+    @property
+    def url(self) -> str:
+        return self._url.value
+
     def _useAttributes(self, attributes: dict[str, Any]) -> None:
         if "rate" in attributes:  # pragma no branch
             self._rate = self._makeClassAttribute(github.Rate.Rate, attributes["rate"])
         if "resources" in attributes:  # pragma no branch
             self._resources = self._makeClassAttribute(github.RateLimit.RateLimit, attributes["resources"])
+        if "url" in attributes:  # pragma no branch
+            self._url = self._makeStringAttribute(attributes["url"])

--- a/tests/AuthenticatedUser.py
+++ b/tests/AuthenticatedUser.py
@@ -735,7 +735,7 @@ class AuthenticatedUser(Framework.TestCase):
             notification.updated_at,
             datetime(2013, 3, 15, 5, 43, 11, tzinfo=timezone.utc),
         )
-        self.assertEqual(notification.url, None)
+        self.assertEqual(notification.url, "/notifications/threads/8406712")
         self.assertEqual(notification.subject.url, None)
         self.assertEqual(notification.subject.latest_comment_url, None)
         self.assertEqual(

--- a/tests/Organization.py
+++ b/tests/Organization.py
@@ -784,7 +784,7 @@ class Organization(Framework.TestCase):
         self.assertEqual(custom_property.required, True)
         self.assertEqual(custom_property.default_value, "foo")
         self.assertEqual(custom_property.description, "description")
-        self.assertIsNone(custom_property.url)
+        self.assertEqual(custom_property.url, "https://api.github.com/orgs/BeaverSoftware/properties/schema/property_1")
         self.assertEqual(custom_property.values_editable_by, "org_actors")
 
     def testCreateCustomPropertyValues(self):

--- a/tests/PublicKey.py
+++ b/tests/PublicKey.py
@@ -53,7 +53,9 @@ class PublicKey(Framework.TestCase):
             'PublicKey(key_id="568250167242549743", key="u5e1Z25+z8pmgVVt5Pd8k0z/sKpVL1MXYtRAecE4vm8=")',
         )
         self.assertIsNone(self.public_key.title)
-        self.assertIsNone(self.public_key.url)
+        self.assertEqual(
+            self.public_key.url, "https://api.github.com/repos/jacquev6/PyGithub/actions/secrets/public-key"
+        )
 
     def testAttributes_with_int_key_id(self):
         self.public_key = self.g.get_user().get_repo("PyGithub").get_public_key()

--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -1331,7 +1331,10 @@ class Repository(Framework.TestCase):
         )
 
     def testGetLanguages(self):
-        self.assertEqual(self.repo.get_languages(), {"Python": 127266, "Shell": 673})
+        self.assertEqual(
+            self.repo.get_languages(),
+            {"Python": 127266, "Shell": 673, "url": "https://api.github.com/repos/PyGithub/PyGithub/languages"},
+        )
 
     def testGetMilestones(self):
         self.assertListKeyEqual(self.repo.get_milestones(), lambda m: m.id, [93547])
@@ -2288,7 +2291,11 @@ class Repository(Framework.TestCase):
     def testGetAutomatedSecurityFixes(self):
         self.assertDictEqual(
             self.repo.get_automated_security_fixes(),
-            {"enabled": True, "paused": False},
+            {
+                "enabled": True,
+                "paused": False,
+                "url": "https://api.github.com/repos/PyGithub/PyGithub/automated-security-fixes",
+            },
         )
 
 


### PR DESCRIPTION
The `Requester` extracts an URL from `_links.self` or uses the `GET` url, if a returned Github object misses the `url` attribute.