### PR TITLE
Fix Workflow.create_dispatch

### DIFF
--- a/github/Workflow.py
+++ b/github/Workflow.py
@@ -166,7 +166,7 @@ class Workflow(CompletableGithubObject):
         status, _, _ = self._requester.requestJson(
             "POST", f"{self.url}/dispatches", input={"ref": ref, "inputs": inputs}
         )
-        return status == 204
+        return status == 200
 
     def get_runs(
         self,


### PR DESCRIPTION
Currently` Workflow.create_dispatch` is broken. It returns false even after successful workflow dispatch. This is because status code of underlying API is now 200 instead of 204. This is fixed here

issue for the same: https://github.com/PyGithub/PyGithub/issues/3427