### PR TITLE
Clarify that organization members do not include role or permissions

### DIFF
--- a/github/Organization.py
+++ b/github/Organization.py
@@ -1251,6 +1251,12 @@ class Organization(CompletableGithubObject):
     ) -> PaginatedList[NamedUser]:
         """
         :calls: `GET /orgs/{org}/members <https://docs.github.com/en/rest/reference/orgs#members>`_
+        Note:
+    The GitHub API does not include role or permission details
+    for organization members returned by this method.
+    As a result, attributes such as `user.role` and
+    `user.permissions` will be None for these users.
+
         """
         assert is_optional(filter_, str), filter_
         assert is_optional(role, str), role


### PR DESCRIPTION
Fixes #1477

The GitHub API does not include role or permission details for
organization members returned by Organization.get_members().

PyGithub currently exposes user.role and user.permissions for these
users, which can be misleading as they are always None.

This change adds documentation clarifying this API limitation so users
understand the expected behavior.
