### PR TITLE
Deprecate `Reaction.delete`

### DIFF
--- a/github/Reaction.py
+++ b/github/Reaction.py
@@ -44,6 +44,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from typing_extensions import deprecated
+
 import github.Consts
 import github.NamedUser
 import github.Organization
@@ -96,6 +98,9 @@ class Reaction(NonCompletableGithubObject):
     def user(self) -> NamedUser:
         return self._user.value
 
+    @deprecated(
+        "Deprecated, use IssueComment.delete_reaction, PullRequestComment.delete_reaction, CommitComment.delete_reaction or Issue.delete_reaction"
+    )
     def delete(self) -> None:
         """
         :calls: `DELETE /reactions/{id} <https://docs.github.com/en/rest/reference/reactions#delete-a-reaction-legacy>`_


### PR DESCRIPTION
As discussed in https://github.com/PyGithub/PyGithub/issues/3434 . The endpoint no longer exists in public GitHub.