### PR TITLE
Add Python 3.14 to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Software Development",
 ]
 description = "Use the full Github API v3"


### PR DESCRIPTION
- Related: #3429

Officially bumps support of the tool itself to 3.14. ~~Includes an explicit bump for pre-commit's "docformatter," as one of their 1.7.7 dependencies not supporting 3.14 and was fixed upstream, but hasn't gotten an official release in that time.~~ **EDIT:** pre-commit changes proved to be more involved, will handle elsewhere