### PR TITLE
Replace `black`, `pyupgrade`, and `docformatter` with `ruff`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,6 @@ e113e37de1ec687c68337d777f3629251b35ab28
 
 # Run pre-commit autoupdate and run all hooks
 4c24c73d34b54a061b0c800eeea64dc64c230a63
+
+# Apply ruff to whole codebase
+b6ec6ced59915a52703b025ccb79d74472a49bf2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,35 +14,16 @@ repos:
         args:
           - "--fix=lf"
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
-    hooks:
-      - id: pyupgrade
-        args: ["--py39-plus"]
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.7
+    rev: v0.15.12
     hooks:
-      - id: ruff
-        args:
-          - "--fix"
-          - "--fixable=ALL"
-          - "--exit-non-zero-on-fix"
+      - id: ruff-check
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+        args: [--exit-non-zero-on-format]
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:
       - id: codespell
         additional_dependencies: [tomli]
-
-  - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.7
-    hooks:
-      - id: docformatter
-        additional_dependencies: [tomli]
-        args: ["--in-place"]
-
-  - repo: https://github.com/psf/black
-    rev: 23.12.0
-    hooks:
-      - id: black

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Slack](https://img.shields.io/badge/Slack%20channel-%20%20-blue.svg)](https://join.slack.com/t/pygithub-project/shared_invite/zt-duj89xtx-uKFZtgAg209o6Vweqm8xeQ)
 [![Open Source Helpers](https://www.codetriage.com/pygithub/pygithub/badges/users.svg)](https://www.codetriage.com/pygithub/pygithub)
 [![codecov](https://codecov.io/gh/PyGithub/PyGithub/branch/master/graph/badge.svg)](https://codecov.io/gh/PyGithub/PyGithub)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Code style: ruff](https://img.shields.io/badge/Code_style-ruff-blue.svg)](https://github.com/astral-sh/ruff)
 
 PyGitHub is a Python library to access the [GitHub REST API].
 This library enables you to manage [GitHub] resources such as repositories, user profiles, and organizations in your Python applications.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -75,7 +75,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "PyGithub"
-copyright = "%d, Vincent Jacques, Liuyang Wan, Steve Kowalik, Enrico Minack" % datetime.date.today().year
+copyright = f"{datetime.date.today().year}, Vincent Jacques, Liuyang Wan, Steve Kowalik, Enrico Minack"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/github/AdvisoryVulnerability.py
+++ b/github/AdvisoryVulnerability.py
@@ -146,9 +146,9 @@ class AdvisoryVulnerability(NonCompletableGithubObject):
             assert isinstance(vulnerability["vulnerable_version_range"], (str, type(None))), vulnerability
 
         else:
-            assert (
-                vulnerability.package is github.AdvisoryVulnerabilityPackage.AdvisoryVulnerabilityPackage
-            ), vulnerability
+            assert vulnerability.package is github.AdvisoryVulnerabilityPackage.AdvisoryVulnerabilityPackage, (
+                vulnerability
+            )
 
     @staticmethod
     def _to_github_dict(

--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -842,7 +842,6 @@ class AuthenticatedUser(CompletableGithubObject):
         """
         :calls: `GET /notifications/threads/{thread_id} <http://docs.github.com/en/rest/reference/activity#notifications>`_
         """
-
         assert isinstance(id, str), id
         headers, data = self._requester.requestJsonAndCheck("GET", f"/notifications/threads/{id}")
         return github.Notification.Notification(self._requester, headers, data, completed=True)
@@ -857,7 +856,6 @@ class AuthenticatedUser(CompletableGithubObject):
         """
         :calls: `GET /notifications <http://docs.github.com/en/rest/reference/activity#notifications>`_
         """
-
         assert is_optional(all, bool), all
         assert is_optional(participating, bool), participating
         assert is_optional(since, datetime), since

--- a/github/Authorization.py
+++ b/github/Authorization.py
@@ -145,12 +145,12 @@ class Authorization(github.GithubObject.CompletableGithubObject):
         :rtype: None
         """
         assert isinstance(scopes, _NotSetType) or all(isinstance(element, str) for element in scopes), scopes
-        assert isinstance(add_scopes, _NotSetType) or all(
-            isinstance(element, str) for element in add_scopes
-        ), add_scopes
-        assert isinstance(remove_scopes, _NotSetType) or all(
-            isinstance(element, str) for element in remove_scopes
-        ), remove_scopes
+        assert isinstance(add_scopes, _NotSetType) or all(isinstance(element, str) for element in add_scopes), (
+            add_scopes
+        )
+        assert isinstance(remove_scopes, _NotSetType) or all(isinstance(element, str) for element in remove_scopes), (
+            remove_scopes
+        )
         assert isinstance(note, (_NotSetType, str)), note
         assert isinstance(note_url, (_NotSetType, str)), note_url
 

--- a/github/Branch.py
+++ b/github/Branch.py
@@ -258,17 +258,17 @@ class Branch(NonCompletableGithubObject):
             if is_defined(dismiss_stale_reviews):
                 post_parameters["required_pull_request_reviews"]["dismiss_stale_reviews"] = dismiss_stale_reviews
             if is_defined(require_code_owner_reviews):
-                post_parameters["required_pull_request_reviews"][
-                    "require_code_owner_reviews"
-                ] = require_code_owner_reviews
+                post_parameters["required_pull_request_reviews"]["require_code_owner_reviews"] = (
+                    require_code_owner_reviews
+                )
             if is_defined(required_approving_review_count):
-                post_parameters["required_pull_request_reviews"][
-                    "required_approving_review_count"
-                ] = required_approving_review_count
+                post_parameters["required_pull_request_reviews"]["required_approving_review_count"] = (
+                    required_approving_review_count
+                )
             if is_defined(require_last_push_approval):
-                post_parameters["required_pull_request_reviews"][
-                    "require_last_push_approval"
-                ] = require_last_push_approval
+                post_parameters["required_pull_request_reviews"]["require_last_push_approval"] = (
+                    require_last_push_approval
+                )
 
             dismissal_restrictions = {}
             if is_defined(dismissal_users):
@@ -290,9 +290,9 @@ class Branch(NonCompletableGithubObject):
                 bypass_pull_request_allowances["apps"] = apps_bypass_pull_request_allowances
 
             if bypass_pull_request_allowances:
-                post_parameters["required_pull_request_reviews"][
-                    "bypass_pull_request_allowances"
-                ] = bypass_pull_request_allowances
+                post_parameters["required_pull_request_reviews"]["bypass_pull_request_allowances"] = (
+                    bypass_pull_request_allowances
+                )
         else:
             post_parameters["required_pull_request_reviews"] = None
         if (

--- a/github/GitReleaseAsset.py
+++ b/github/GitReleaseAsset.py
@@ -167,12 +167,10 @@ class GitReleaseAsset(CompletableGithubObject):
         return True
 
     @overload
-    def download_asset(self, path: None = None, chunk_size: int | None = 1) -> tuple[int, dict[str, Any], Iterator]:
-        ...
+    def download_asset(self, path: None = None, chunk_size: int | None = 1) -> tuple[int, dict[str, Any], Iterator]: ...
 
     @overload
-    def download_asset(self, path: str, chunk_size: int | None = 1) -> None:
-        ...
+    def download_asset(self, path: str, chunk_size: int | None = 1) -> None: ...
 
     def download_asset(
         self, path: None | str = None, chunk_size: int | None = 1

--- a/github/GithubIntegration.py
+++ b/github/GithubIntegration.py
@@ -163,9 +163,9 @@ class GithubIntegration:
                     jwt_issued_at=jwt_issued_at,
                 )
 
-        assert isinstance(
-            auth, AppAuth
-        ), f"GithubIntegration requires github.Auth.AppAuth authentication, not {type(auth)}"
+        assert isinstance(auth, AppAuth), (
+            f"GithubIntegration requires github.Auth.AppAuth authentication, not {type(auth)}"
+        )
 
         self.auth = auth
 
@@ -198,7 +198,8 @@ class GithubIntegration:
         return GithubIntegration(**kwargs)
 
     def close(self) -> None:
-        """Close connections to the server. Alternatively, use the
+        """
+        Close connections to the server. Alternatively, use the
         GithubIntegration object as a context manager:
 
         .. code-block:: python
@@ -345,6 +346,5 @@ class GithubIntegration:
         """
         :calls: `GET /app <https://docs.github.com/en/rest/reference/apps#get-the-authenticated-app>`_
         """
-
         headers, data = self.__requester.requestJsonAndCheck("GET", "/app", headers=self._get_headers())
         return GithubApp(requester=self.__requester, headers=headers, attributes=data, completed=True)

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -88,7 +88,6 @@ def _datetime_from_http_date(value: str) -> datetime:
     Raises ValueError for invalid dates.
 
     """
-
     dt = email.utils.parsedate_to_datetime(value)
     if dt.tzinfo is None:
         # RFC7231 states that UTC is assumed if no timezone info is present
@@ -103,7 +102,6 @@ def _datetime_from_github_isoformat(value: str) -> datetime:
     Raises ValueError for invalid timestamps.
 
     """
-
     # Github always returns YYYY-MM-DDTHH:MM:SSZ, so we can use the stdlib parser
     # with some minor adjustments for Python < 3.11 which doesn't support "Z"
     # https://docs.github.com/en/rest/overview/resources-in-the-rest-api#schema
@@ -154,13 +152,11 @@ camel_to_snake_case_regexp = re.compile(r"(?<!^)(?=[A-Z])")
 
 
 @overload
-def as_rest_api_attributes(graphql_attributes: dict[str, Any]) -> dict[str, Any]:
-    ...
+def as_rest_api_attributes(graphql_attributes: dict[str, Any]) -> dict[str, Any]: ...
 
 
 @overload
-def as_rest_api_attributes(graphql_attributes: None) -> None:
-    ...
+def as_rest_api_attributes(graphql_attributes: None) -> None: ...
 
 
 def as_rest_api_attributes(graphql_attributes: dict[str, Any] | None) -> dict[str, Any] | None:

--- a/github/GithubRetry.py
+++ b/github/GithubRetry.py
@@ -110,7 +110,7 @@ class GithubRetry(Retry):
                     # Sleeping 'Retry-After' seconds is implemented in urllib3.Retry.sleep() and called by urllib3
                     self.__log(
                         logging.INFO,
-                        f'Retrying after {response.headers.get("Retry-After")} seconds',
+                        f"Retrying after {response.headers.get('Retry-After')} seconds",
                     )
                 else:
                     content = response.reason

--- a/github/GlobalAdvisory.py
+++ b/github/GlobalAdvisory.py
@@ -115,14 +115,14 @@ class GlobalAdvisory(AdvisoryBase):
         if "epss" in attributes:  # pragma no branch
             self._epss = self._makeDictAttribute(attributes["epss"])
         if "github_reviewed_at" in attributes:  # pragma no branch
-            assert attributes["github_reviewed_at"] is None or isinstance(
-                attributes["github_reviewed_at"], str
-            ), attributes["github_reviewed_at"]
+            assert attributes["github_reviewed_at"] is None or isinstance(attributes["github_reviewed_at"], str), (
+                attributes["github_reviewed_at"]
+            )
             self._github_reviewed_at = self._makeDatetimeAttribute(attributes["github_reviewed_at"])
         if "nvd_published_at" in attributes:  # pragma no branch
-            assert attributes["nvd_published_at"] is None or isinstance(
-                attributes["nvd_published_at"], str
-            ), attributes["nvd_published_at"]
+            assert attributes["nvd_published_at"] is None or isinstance(attributes["nvd_published_at"], str), (
+                attributes["nvd_published_at"]
+            )
             self._nvd_published_at = self._makeDatetimeAttribute(attributes["nvd_published_at"])
         if "references" in attributes:  # pragma no branch
             self._references = self._makeListOfStringsAttribute(attributes["references"])

--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -230,7 +230,6 @@ class Github:
                             Note that some PyGithub methods might downgrade this version if it is not supported by the implementation.
                             Set to None to not specify any version
         """
-
         assert login_or_token is None or isinstance(login_or_token, str), login_or_token
         assert password is None or isinstance(password, str), password
         assert jwt is None or isinstance(jwt, str), jwt
@@ -305,7 +304,8 @@ class Github:
         return Github(**kwargs)
 
     def close(self) -> None:
-        """Close connections to the server. Alternatively, use the Github
+        """
+        Close connections to the server. Alternatively, use the Github
         object as a context manager:
 
         .. code-block:: python
@@ -391,7 +391,6 @@ class Github:
         """
         :calls: `GET /license/{license} <https://docs.github.com/en/rest/reference/licenses#get-a-license>`_
         """
-
         assert isinstance(key, str), key
         key = urllib.parse.quote(key)
         headers, data = self.__requester.requestJsonAndCheck("GET", f"/licenses/{key}")
@@ -401,7 +400,6 @@ class Github:
         """
         :calls: `GET /licenses <https://docs.github.com/en/rest/reference/licenses#get-all-commonly-used-licenses>`_
         """
-
         url_parameters: dict[str, Any] = {}
 
         return PaginatedList(github.License.License, self.__requester, "/licenses", url_parameters)
@@ -410,16 +408,13 @@ class Github:
         """
         :calls: `GET /events <https://docs.github.com/en/rest/reference/activity#list-public-events>`_
         """
-
         return PaginatedList(github.Event.Event, self.__requester, "/events", None)
 
     @overload
-    def get_user(self, login: _NotSetType = NotSet, lazy: Opt[bool] = NotSet) -> AuthenticatedUser:
-        ...
+    def get_user(self, login: _NotSetType = NotSet, lazy: Opt[bool] = NotSet) -> AuthenticatedUser: ...
 
     @overload
-    def get_user(self, login: str, lazy: Opt[bool] = NotSet) -> NamedUser:
-        ...
+    def get_user(self, login: str, lazy: Opt[bool] = NotSet) -> NamedUser: ...
 
     # v3: remove lazy argument, laziness is fully controlled via requester
     def get_user(self, login: Opt[str] = NotSet, lazy: Opt[bool] = NotSet) -> NamedUser | AuthenticatedUser:
@@ -1097,7 +1092,6 @@ class Github:
         """
         :calls: `GET /apps/{app_slug} <https://docs.github.com/en/rest/reference/apps>`_ or `GET /app <https://docs.github.com/en/rest/reference/apps>`_
         """
-
         if slug is NotSet:
             # with no slug given, calling /app returns the authenticated app,
             # including the actual /apps/{slug}

--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -556,7 +556,7 @@ class Github:
         """
         headers, data = self.__requester.requestJsonAndCheck(
             "GET",
-            "/projects/columns/%d" % id,
+            f"/projects/columns/{id}",
             headers={"Accept": Consts.mediaTypeProjectsPreview},
         )
         return github.ProjectColumn.ProjectColumn(self.__requester, headers, data)

--- a/github/Organization.py
+++ b/github/Organization.py
@@ -706,7 +706,8 @@ class Organization(CompletableGithubObject):
         include_all_branches: Opt[bool] = NotSet,
         private: Opt[bool] = NotSet,
     ) -> Repository:
-        """self.name
+        """
+        self.name
         :calls: `POST /repos/{template_owner}/{template_repo}/generate <https://docs.github.com/en/rest/reference/repos#create-a-repository-using-a-template>`_
         """
         assert isinstance(name, str), name
@@ -1272,7 +1273,6 @@ class Organization(CompletableGithubObject):
         """
         :calls: `GET /orgs/{org}/projects <https://docs.github.com/en/rest/reference/projects#list-organization-projects>`_
         """
-
         url_parameters = NotSet.remove_unset_items({"state": state})
 
         return PaginatedList(
@@ -1572,7 +1572,6 @@ class Organization(CompletableGithubObject):
         :calls: `GET /orgs/{org}/installations <https://docs.github.com/en/rest/reference/orgs#list-app-installations-for-an-organization>`_
         :rtype: :class:`PaginatedList` of :class:`github.Installation.Installation`
         """
-
         return PaginatedList(
             github.Installation.Installation,
             self._requester,
@@ -1662,9 +1661,9 @@ class Organization(CompletableGithubObject):
         allowed_severities = ["critical", "high", "medium", "low", "warning", "note", "error"]
         assert is_optional(tool_name, str), tool_name
         assert is_optional(tool_guid, str), tool_guid
-        assert (
-            tool_name is NotSet or tool_guid is NotSet
-        ), "You can specify the tool by using either tool_guid or tool_name, but not both."
+        assert tool_name is NotSet or tool_guid is NotSet, (
+            "You can specify the tool by using either tool_guid or tool_name, but not both."
+        )
         assert is_optional(ref, str), ref
         assert is_optional(pr, int), pr
         assert sort in allowed_sorts + [NotSet], f"Sort can be one of {', '.join(allowed_sorts)}"
@@ -1732,9 +1731,9 @@ class Organization(CompletableGithubObject):
         # assert secret_type in allowed_secret_types + [NotSet], \
         # "Secret_type can be one of the tokens listed on \
         # https://docs.github.com/en/code-security/secret-scanning/introduction/supported-secret-scanning-patterns#supported-secrets"
-        assert resolution in allowed_resolutions + [
-            NotSet
-        ], f"Resolution can be one of {', '.join(allowed_resolutions)}"
+        assert resolution in allowed_resolutions + [NotSet], (
+            f"Resolution can be one of {', '.join(allowed_resolutions)}"
+        )
         assert sort in allowed_sorts + [NotSet], f"Sort can be one of {', '.join(allowed_sorts)}"
         assert direction in allowed_directions + [NotSet], f"Direction can be one of {', '.join(allowed_directions)}"
         assert validity in allowed_validities + [NotSet], f"Validity can be one of {', '.join(allowed_validities)}"
@@ -2186,7 +2185,6 @@ class Organization(CompletableGithubObject):
         """
         :calls: `GET /orgs/{org}/actions/runners/{runner_id} <https://docs.github.com/en/rest/actions/self-hosted-runners#get-a-self-hosted-runner-for-an-organization>`_
         """
-
         headers, data = self._requester.requestJsonAndCheck(
             "GET",
             f"{self.url}/actions/runners/{runner_id}",
@@ -2197,7 +2195,6 @@ class Organization(CompletableGithubObject):
         """
         :calls: `DELETE /orgs/{org}/actions/runners/{runner_id} <https://docs.github.com/en/rest/actions/self-hosted-runners#delete-a-self-hosted-runner-from-an-organization>`_
         """
-
         headers, data = self._requester.requestJsonAndCheck(
             "DELETE",
             f"{self.url}/actions/runners/{runner_id}",

--- a/github/PaginatedList.py
+++ b/github/PaginatedList.py
@@ -81,12 +81,10 @@ class PaginatedListBase(Generic[T]):
         self.__elements = [] if elements is None else elements
 
     @overload
-    def __getitem__(self, index: int) -> T:
-        ...
+    def __getitem__(self, index: int) -> T: ...
 
     @overload
-    def __getitem__(self, index: slice) -> _Slice:
-        ...
+    def __getitem__(self, index: slice) -> _Slice: ...
 
     def __getitem__(self, index: int | slice) -> T | _Slice:
         assert isinstance(index, (int, slice))
@@ -274,7 +272,10 @@ class PaginatedList(PaginatedListBase[T]):
             # set per_page = 1 so the totalCount is just the number of pages
             params.update({"per_page": 1})
             headers, data = self.__requester.requestJsonAndCheck(
-                "GET", self.__firstUrl, parameters=params, headers=self.__headers  # type: ignore
+                "GET",
+                self.__firstUrl,
+                parameters=params,
+                headers=self.__headers,  # type: ignore
             )
             links = self.__parseLinkHeader(headers)
             lastUrl = links.get("last")
@@ -327,7 +328,10 @@ class PaginatedList(PaginatedListBase[T]):
 
     def _getLastPageUrl(self) -> str | None:
         headers, data = self.__requester.requestJsonAndCheck(
-            "GET", self.__firstUrl, parameters=self.__nextParams, headers=self.__headers  # type: ignore
+            "GET",
+            self.__firstUrl,
+            parameters=self.__nextParams,
+            headers=self.__headers,  # type: ignore
         )
         links = self.__parseLinkHeader(headers)
         return links.get("last")
@@ -398,7 +402,10 @@ class PaginatedList(PaginatedListBase[T]):
         if self.is_rest:
             # REST API pagination
             headers, data = self.__requester.requestJsonAndCheck(
-                "GET", self.__nextUrl, parameters=self.__nextParams, headers=self.__headers  # type: ignore
+                "GET",
+                self.__nextUrl,
+                parameters=self.__nextParams,
+                headers=self.__headers,  # type: ignore
             )
             data = data if data else []
             return self._getPage(data, headers)
@@ -492,7 +499,10 @@ class PaginatedList(PaginatedListBase[T]):
         if self.__requester.per_page != Consts.DEFAULT_PER_PAGE:
             params["per_page"] = self.__requester.per_page
         headers, data = self.__requester.requestJsonAndCheck(
-            "GET", self.__firstUrl, parameters=params, headers=self.__headers  # type: ignore
+            "GET",
+            self.__firstUrl,
+            parameters=params,
+            headers=self.__headers,  # type: ignore
         )
 
         if self.__list_item in data:

--- a/github/PaginatedList.py
+++ b/github/PaginatedList.py
@@ -271,6 +271,7 @@ class PaginatedList(PaginatedListBase[T]):
             params = self.__nextParams.copy()
             # set per_page = 1 so the totalCount is just the number of pages
             params.update({"per_page": 1})
+            assert self.__firstUrl is not None
             headers, data = self.__requester.requestJsonAndCheck(
                 "GET",
                 self.__firstUrl,
@@ -327,6 +328,7 @@ class PaginatedList(PaginatedListBase[T]):
         return self.__incomplete_results
 
     def _getLastPageUrl(self) -> str | None:
+        assert self.__firstUrl is not None
         headers, data = self.__requester.requestJsonAndCheck(
             "GET",
             self.__firstUrl,
@@ -401,6 +403,7 @@ class PaginatedList(PaginatedListBase[T]):
     def _fetchNextPage(self) -> list[T]:
         if self.is_rest:
             # REST API pagination
+            assert self.__nextUrl is not None
             headers, data = self.__requester.requestJsonAndCheck(
                 "GET",
                 self.__nextUrl,
@@ -498,6 +501,7 @@ class PaginatedList(PaginatedListBase[T]):
             params["page"] = page + 1
         if self.__requester.per_page != Consts.DEFAULT_PER_PAGE:
             params["per_page"] = self.__requester.per_page
+        assert self.__firstUrl is not None
         headers, data = self.__requester.requestJsonAndCheck(
             "GET",
             self.__firstUrl,

--- a/github/Project.py
+++ b/github/Project.py
@@ -219,7 +219,6 @@ class Project(CompletableGithubObject):
         """
         :calls: `GET /projects/{project_id}/columns <https://docs.github.com/en/rest/reference/projects#list-project-columns>`_
         """
-
         return PaginatedList(
             github.ProjectColumn.ProjectColumn,
             self._requester,

--- a/github/ProjectCard.py
+++ b/github/ProjectCard.py
@@ -154,12 +154,10 @@ class ProjectCard(NonCompletableGithubObject):
         return self._url.value
 
     @overload
-    def get_content(self, content_type: Literal["PullRequest"]) -> PullRequest | None:
-        ...
+    def get_content(self, content_type: Literal["PullRequest"]) -> PullRequest | None: ...
 
     @overload
-    def get_content(self, content_type: Literal["Issue"] | _NotSetType = NotSet) -> Issue | None:
-        ...
+    def get_content(self, content_type: Literal["Issue"] | _NotSetType = NotSet) -> Issue | None: ...
 
     # Note that the content_url for any card will be an "issue" URL, from
     # which you can retrieve either an Issue or a PullRequest. Unfortunately

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1598,9 +1598,9 @@ class Repository(CompletableGithubObject):
         assert isinstance(tag_name, str), tag_name
         assert isinstance(previous_tag_name, str) or is_optional(previous_tag_name, str), previous_tag_name
         assert isinstance(target_commitish, str) or is_optional(target_commitish, str), target_commitish
-        assert isinstance(configuration_file_path, str) or is_optional(
-            configuration_file_path, str
-        ), configuration_file_path
+        assert isinstance(configuration_file_path, str) or is_optional(configuration_file_path, str), (
+            configuration_file_path
+        )
 
         post_parameters = NotSet.remove_unset_items(
             {
@@ -2363,7 +2363,6 @@ class Repository(CompletableGithubObject):
         :param permission: string
         :rtype: :class:`PaginatedList` of :class:`github.NamedUser.NamedUser`
         """
-
         url_parameters = dict()
         allowed_affiliations = ["outside", "direct", "all"]
         allowed_permissions = ["pull", "triage", "push", "maintain", "admin"]
@@ -2726,7 +2725,6 @@ class Repository(CompletableGithubObject):
         :rtype: :class:`PaginatedList` of :class:`github.Project.Project`
         :param state: string
         """
-
         url_parameters = dict()
         if is_defined(state):
             url_parameters["state"] = state
@@ -3356,7 +3354,6 @@ class Repository(CompletableGithubObject):
         :calls: `GET /repos/{owner}/{repo}/license <https://docs.github.com/en/rest/reference/licenses>`_
         :rtype: :class:`github.ContentFile.ContentFile`
         """
-
         headers, data = self._requester.requestJsonAndCheck("GET", f"{self.url}/license")
         return github.ContentFile.ContentFile(self._requester, headers, data, completed=True)
 
@@ -3919,7 +3916,6 @@ class Repository(CompletableGithubObject):
         :param before: datetime
         :rtype: :class:`PaginatedList` of :class:`github.Notification.Notification`
         """
-
         assert is_optional(all, bool), all
         assert is_optional(participating, bool), participating
         assert is_optional(since, datetime), since
@@ -4090,9 +4086,9 @@ class Repository(CompletableGithubObject):
         :param runner: int or :class:`github.SelfHostedActionsRunner.SelfHostedActionsRunner`
         :rtype: bool
         """
-        assert isinstance(runner, github.SelfHostedActionsRunner.SelfHostedActionsRunner) or isinstance(
-            runner, int
-        ), runner
+        assert isinstance(runner, github.SelfHostedActionsRunner.SelfHostedActionsRunner) or isinstance(runner, int), (
+            runner
+        )
 
         if isinstance(runner, github.SelfHostedActionsRunner.SelfHostedActionsRunner):
             runner = runner.id
@@ -4110,7 +4106,8 @@ class Repository(CompletableGithubObject):
         assert is_autolink or isinstance(autolink, int), autolink
 
         status, _, _ = self._requester.requestJson(
-            "DELETE", f"{self.url}/autolinks/{autolink.id if is_autolink else autolink}"  # type: ignore
+            "DELETE",
+            f"{self.url}/autolinks/{autolink.id if is_autolink else autolink}",  # type: ignore
         )
         return status == 204
 
@@ -4274,7 +4271,6 @@ class Repository(CompletableGithubObject):
         :param name: str
         :rtype: :class:`PaginatedList` of :class:`github.Artifact.Artifact`
         """
-
         assert is_optional(name, str), name
 
         param = {key: value for key, value in {"name": name}.items() if is_defined(value)}
@@ -4326,9 +4322,9 @@ class Repository(CompletableGithubObject):
         allowed_severities = ["critical", "high", "medium", "low", "warning", "note", "error"]
         assert is_optional(tool_name, str), tool_name
         assert is_optional(tool_guid, str), tool_guid
-        assert (
-            tool_name is NotSet or tool_guid is NotSet
-        ), "You can specify the tool by using either tool_guid or tool_name, but not both."
+        assert tool_name is NotSet or tool_guid is NotSet, (
+            "You can specify the tool by using either tool_guid or tool_name, but not both."
+        )
         assert is_optional(ref, str), ref
         assert is_optional(pr, int), pr
         assert sort in allowed_sorts + [NotSet], f"Sort can be one of {', '.join(allowed_sorts)}"
@@ -4406,9 +4402,9 @@ class Repository(CompletableGithubObject):
         # assert secret_type in allowed_secret_types + [NotSet], \
         # "Secret_type can be one of the tokens listed on \
         # https://docs.github.com/en/code-security/secret-scanning/introduction/supported-secret-scanning-patterns#supported-secrets"
-        assert resolution in allowed_resolutions + [
-            NotSet
-        ], f"Resolution can be one of {', '.join(allowed_resolutions)}"
+        assert resolution in allowed_resolutions + [NotSet], (
+            f"Resolution can be one of {', '.join(allowed_resolutions)}"
+        )
         assert sort in allowed_sorts + [NotSet], f"Sort can be one of {', '.join(allowed_sorts)}"
         assert direction in allowed_directions + [NotSet], f"Direction can be one of {', '.join(allowed_directions)}"
         assert validity in allowed_validities + [NotSet], f"Validity can be one of {', '.join(allowed_validities)}"
@@ -4624,7 +4620,9 @@ class Repository(CompletableGithubObject):
                 "no_bandwidth",
                 "not_used",
                 "tolerable_risk",
-            ], "Dismissed reason can be one of ['fix_started', 'inaccurate', 'no_bandwidth', 'not_used', 'tolerable_risk']"
+            ], (
+                "Dismissed reason can be one of ['fix_started', 'inaccurate', 'no_bandwidth', 'not_used', 'tolerable_risk']"
+            )
         assert is_optional(dismissed_comment, str), dismissed_comment
         headers, data = self._requester.requestJsonAndCheck(
             "PATCH",

--- a/github/RepositoryAdvisory.py
+++ b/github/RepositoryAdvisory.py
@@ -275,9 +275,9 @@ class RepositoryAdvisory(AdvisoryBase):
         """
         assert summary is NotSet or isinstance(summary, str), summary
         assert description is NotSet or isinstance(description, str), description
-        assert severity_or_cvss_vector_string is NotSet or isinstance(
-            severity_or_cvss_vector_string, str
-        ), severity_or_cvss_vector_string
+        assert severity_or_cvss_vector_string is NotSet or isinstance(severity_or_cvss_vector_string, str), (
+            severity_or_cvss_vector_string
+        )
         assert cve_id is NotSet or isinstance(cve_id, str), cve_id
         assert vulnerabilities is NotSet or isinstance(vulnerabilities, Iterable), vulnerabilities
         if isinstance(vulnerabilities, Iterable):

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -1338,7 +1338,7 @@ class Requester:
         # and self.__seconds_between_writes seconds have passed since last write request (if verb refers to a write).
         # Uses self.__last_requests.
         requests = self.__last_requests.values()
-        writes = [l for v, l in self.__last_requests.items() if v != "GET"]
+        writes = [last for verb, last in self.__last_requests.items() if verb != "GET"]
 
         last_request = max(requests) if requests else 0
         last_write = max(writes) if writes else 0

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -100,7 +100,7 @@ from collections import deque
 from collections.abc import Callable, ItemsView, Iterator
 from datetime import datetime, timezone
 from io import IOBase
-from typing import TYPE_CHECKING, Any, BinaryIO, Deque, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, BinaryIO, Generic, TypeVar
 
 import requests
 import requests.adapters
@@ -433,7 +433,7 @@ class Requester:
             assert False, "Unknown URL scheme"
         self.__connection: HTTPRequestsConnectionClass | HTTPSRequestsConnectionClass | None = None
         self.__connection_lock = threading.Lock()
-        self.__custom_connections: Deque[HTTPRequestsConnectionClass | HTTPSRequestsConnectionClass] = deque()
+        self.__custom_connections: deque[HTTPRequestsConnectionClass | HTTPSRequestsConnectionClass] = deque()
         self.rate_limiting = (-1, -1)
         self.rate_limiting_resettime = 0
         self.FIX_REPO_GET_GIT_REF = True

--- a/github/__init__.py
+++ b/github/__init__.py
@@ -78,7 +78,7 @@ logger.addHandler(logging.StreamHandler())
 
 def set_log_level(level: int) -> None:
     """
-    Set the log level of the github logger, e.g. set_log_level(logging.WARNING) :param level: log level.
+    Set the log level of the github logger.
     """
     logger.setLevel(level)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,10 +49,10 @@ integrations = []
 packages = ["github"]
 
 [tool.setuptools.package-data]
-github = ["py.typed", '*.pyi']
+github = ["py.typed", "*.pyi"]
 
 [tool.mypy]
-python_version = '3.12'
+python_version = "3.12"
 ignore_missing_imports = true
 namespace_packages = true
 
@@ -62,21 +62,8 @@ check_untyped_defs = true
 disallow_untyped_defs = true
 warn_no_return = false
 
-[tool.black]
-# https://github.com/psf/black
-line-length = 120
-
-[tool.docformatter]
-recursive = true
-# some docstring start with r"""
-wrap-summaries = 119
-wrap-descriptions = 120
-blank = true
-pre-summary-newline = true
-make-summary-multi-line = true
-
 [tool.codespell]
-skip = 'tests/*'
+skip = "tests/*"
 quiet-level = 3
 # comma separated list of words; waiting for:
 #  https://github.com/codespell-project/codespell/issues/2839#issuecomment-1731601603
@@ -86,19 +73,26 @@ ignore-words-list = "bloaded,nto,pullrequest,pullrequests,thi,tim,wan,Wan,chang,
 
 [tool.ruff]
 line-length = 120
-# Enable Pyflakes `E` and `F` codes by default.
-select = [
-  "E",
-  # see: https://pypi.org/project/pycodestyle
-  "W",
-  # see: https://pypi.org/project/pyflakes
-  "F",
-  # see: isort
-  "I",
+
+[tool.ruff.lint]
+extend-select = [
+  "I",  # isort
+  "UP", # pyupgrade
+  "FA", # flake8-future-annotations
+  "D",  # pydocstyle
 ]
-ignore = ["E501", "E741"]
-ignore-init-module-imports = true
-unfixable = ["F401"]
+extend-ignore = [
+  "D1",   # undocumented-* (Should address gradually)
+  "D200", # unnecessary-multiline-docstring
+  "D203", # incorrect-blank-line-before-class (Mutually exclusive with D211)
+  "D205", # missing-blank-line-after-summary
+  "D212", # multi-line-summary-first-line (Mutually exclusive with D213)
+  "D400", # missing-trailing-period
+  "D401", # non-imperative-mood
+  "D404", # docstring-starts-with-this
+  "D415", # missing-terminal-punctuation
+]
+extend-safe-fixes = ["ALL"]
 
 [tool.pytest.ini_options]
 python_files = "tests/*.py"

--- a/scripts/prepare-for-update-assertions.py
+++ b/scripts/prepare-for-update-assertions.py
@@ -20,10 +20,11 @@
 #                                                                              #
 ################################################################################
 
+from __future__ import annotations
+
 import argparse
 import difflib
 import sys
-from typing import Union
 
 import libcst as cst
 from libcst import SimpleWhitespace
@@ -52,7 +53,7 @@ class SingleLineStatementTransformer(cst.CSTTransformer):
 
     def leave_Arg(
         self, original_node: cst.Arg, updated_node: cst.Arg
-    ) -> Union[cst.Arg, cst.FlattenSentinel[cst.Arg], cst.RemovalSentinel]:
+    ) -> cst.Arg | cst.FlattenSentinel[cst.Arg] | cst.RemovalSentinel:
         if self.in_function:
             return updated_node.with_changes(
                 whitespace_after_star=SimpleWhitespace(""), whitespace_after_arg=SimpleWhitespace("")
@@ -97,7 +98,7 @@ class SingleLineStatementTransformer(cst.CSTTransformer):
             return updated_node.with_changes(whitespace_before=SimpleWhitespace(""))
         return updated_node
 
-    def leave_Comma(self, original_node: cst.Comma, updated_node: cst.Comma) -> Union[cst.Comma, cst.MaybeSentinel]:
+    def leave_Comma(self, original_node: cst.Comma, updated_node: cst.Comma) -> cst.Comma | cst.MaybeSentinel:
         if self.in_function:
             return updated_node.with_changes(
                 whitespace_before=SimpleWhitespace(""), whitespace_after=SimpleWhitespace(" ")

--- a/scripts/sort_class.py
+++ b/scripts/sort_class.py
@@ -146,9 +146,11 @@ class SortMethodsTransformer(cst.CSTTransformer):
                 stmts = updated_node.body.body
                 attrs = sorted(
                     stmts[start_attr:end_attr],
-                    key=lambda stmt: stmt.body[0].target.attr.value
-                    if isinstance(stmt.body[0], cst.AnnAssign)
-                    else stmt.body[0].targets[0].target.attr.value,
+                    key=lambda stmt: (
+                        stmt.body[0].target.attr.value
+                        if isinstance(stmt.body[0], cst.AnnAssign)
+                        else stmt.body[0].targets[0].target.attr.value
+                    ),
                 )
                 updated_node = updated_node.with_changes(
                     body=updated_node.body.with_changes(
@@ -162,9 +164,11 @@ class SortMethodsTransformer(cst.CSTTransformer):
                 stmts = updated_node.body.body
                 ifs = sorted(
                     stmts[start_if:end_if],
-                    key=lambda stmt: stmt.test.left.value
-                    if isinstance(stmt.test, cst.Comparison)
-                    else stmt.test.children[0].left.value,
+                    key=lambda stmt: (
+                        stmt.test.left.value
+                        if isinstance(stmt.test, cst.Comparison)
+                        else stmt.test.children[0].left.value
+                    ),
                 )
                 updated_node = updated_node.with_changes(
                     body=updated_node.body.with_changes(
@@ -231,7 +235,7 @@ def main(index_filename: str, class_names: list[str], dry_run: bool):
             cls = index.get("classes", {}).get(class_name)
             if not cls:
                 raise ValueError(f"Class {class_name} does not exist in index")
-            full_class_name = f'{cls.get("package")}.{cls.get("module")}.{cls.get("name")}'
+            full_class_name = f"{cls.get('package')}.{cls.get('module')}.{cls.get('name')}"
         package, module, class_name = full_class_name.split(".", maxsplit=2)
         filename = f"{package}/{module}.py"
         filenames[class_name] = filename

--- a/tests/CheckRun.py
+++ b/tests/CheckRun.py
@@ -209,15 +209,19 @@ class CheckRun(Framework.TestCase):
         self.assertEqual(check_run.name, "completed_check_run")
         self.assertEqual(check_run.head_sha, "0283d46537193f1fed7d46859f15c5304b9836f9")
         self.assertEqual(check_run.status, "completed")
-        self.assertEqual(
-            check_run.started_at,
-            datetime(2020, 10, 20, 10, 30, 29, tzinfo=timezone.utc),
-        ),
+        (
+            self.assertEqual(
+                check_run.started_at,
+                datetime(2020, 10, 20, 10, 30, 29, tzinfo=timezone.utc),
+            ),
+        )
         self.assertEqual(check_run.conclusion, "success")
-        self.assertEqual(
-            check_run.completed_at,
-            datetime(2020, 10, 20, 11, 30, 50, tzinfo=timezone.utc),
-        ),
+        (
+            self.assertEqual(
+                check_run.completed_at,
+                datetime(2020, 10, 20, 11, 30, 50, tzinfo=timezone.utc),
+            ),
+        )
         self.assertEqual(check_run.output.annotations_count, 2)
 
     def testUpdateCheckRunSuccess(self):

--- a/tests/Requester.py
+++ b/tests/Requester.py
@@ -659,9 +659,10 @@ class RequesterThrottleTestCase(Framework.TestCase):
 
     @contextlib.contextmanager
     def mock_sleep(self):
-        with mock.patch("github.Requester.time.sleep", side_effect=self.sleep) as sleep_mock, mock.patch(
-            "github.Requester.datetime"
-        ) as datetime_mock:
+        with (
+            mock.patch("github.Requester.time.sleep", side_effect=self.sleep) as sleep_mock,
+            mock.patch("github.Requester.datetime") as datetime_mock,
+        ):
             datetime_mock.now = self.now
             yield sleep_mock
 


### PR DESCRIPTION
- Related: #3437

Originally the above PR updated `docformatter` to support Python 3.14, but that ended up having a lot of unintended side effects, so I started looking for alternatives. I realized that this tool was somewhat redundant, as we already had `ruff`, which has the capability to handle docstring logic on its own. Turns out, this went beyond that, as we don't really have a need for `black` nor `pyupgrade` either; the former was what `ruff` was initially designed as a drop-in replacement for, and the latter has a dedicated ruleset already built-in

This PR removes the pre-commit hooks and settings for `black`, `pyupgrade`, and `docformatter` entirely. They've been replaced with `ruff` linting and formatting equivalents. Docstrings could undergo further changes, but I held off in this PR as that level of noise warrants isolation. This has the bonus of ensuring `pre-commit` will function as expected when using 3.14 and later