### PR TITLE
Add support for GitHub API versioning (X-GitHub-Api-Version header)

### DIFF
--- a/github/Consts.py
+++ b/github/Consts.py
@@ -185,3 +185,6 @@ DEFAULT_JWT_ALGORITHM = "RS256"
 # https://docs.github.com/en/rest/guides/best-practices-for-integrators?apiVersion=2022-11-28#dealing-with-secondary-rate-limits
 DEFAULT_SECONDS_BETWEEN_REQUESTS = 0.25
 DEFAULT_SECONDS_BETWEEN_WRITES = 1.0
+
+# https://docs.github.com/en/rest/about-the-rest-api/api-versions
+DEFAULT_API_VERSION = "2022-11-28"

--- a/github/GithubIntegration.py
+++ b/github/GithubIntegration.py
@@ -85,6 +85,7 @@ class GithubIntegration:
         jwt_expiry: int = Consts.DEFAULT_JWT_EXPIRY,
         jwt_issued_at: int = Consts.DEFAULT_JWT_ISSUED_AT,
         jwt_algorithm: str = Consts.DEFAULT_JWT_ALGORITHM,
+        api_version: str | None = Consts.DEFAULT_API_VERSION,
         auth: AppAuth | None = None,
         # v3: set lazy = True as the default
         lazy: bool = False,
@@ -101,6 +102,8 @@ class GithubIntegration:
         :param pool_size: int
         :param seconds_between_requests: float
         :param seconds_between_writes: float
+        :param api_version: string, GitHub API version to use (sent as X-GitHub-Api-Version header),
+                            defaults to "2022-11-28", set to None to not send the header
         :param jwt_expiry: int deprecated, use auth=github.Auth.AppAuth(...) instead
         :param jwt_issued_at: int deprecated, use auth=github.Auth.AppAuth(...) instead
         :param jwt_algorithm: string deprecated, use auth=github.Auth.AppAuth(...) instead
@@ -175,6 +178,7 @@ class GithubIntegration:
             seconds_between_requests=seconds_between_requests,
             seconds_between_writes=seconds_between_writes,
             lazy=lazy,
+            api_version=api_version,
         )
 
     def withLazy(self, lazy: bool) -> GithubIntegration:

--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -187,6 +187,7 @@ class Github:
         pool_size: int | None = None,
         seconds_between_requests: float | None = Consts.DEFAULT_SECONDS_BETWEEN_REQUESTS,
         seconds_between_writes: float | None = Consts.DEFAULT_SECONDS_BETWEEN_WRITES,
+        api_version: str | None = Consts.DEFAULT_API_VERSION,
         auth: github.Auth.Auth | None = None,
         # v3: set lazy = True as the default
         lazy: bool = False,
@@ -207,6 +208,8 @@ class Github:
         :param pool_size: int
         :param seconds_between_requests: float
         :param seconds_between_writes: float
+        :param api_version: string, GitHub API version to use (sent as X-GitHub-Api-Version header),
+                            defaults to "2022-11-28", set to None to not send the header
         :param auth: authentication method
         :param lazy: completable objects created from this instance are lazy,
                      as well as completable objects created from those, and so on
@@ -224,6 +227,7 @@ class Github:
         assert pool_size is None or isinstance(pool_size, int), pool_size
         assert seconds_between_requests is None or seconds_between_requests >= 0
         assert seconds_between_writes is None or seconds_between_writes >= 0
+        assert api_version is None or isinstance(api_version, str), api_version
         assert auth is None or isinstance(auth, github.Auth.Auth), auth
         assert isinstance(lazy, bool), lazy
 
@@ -271,6 +275,7 @@ class Github:
             seconds_between_requests,
             seconds_between_writes,
             lazy,
+            api_version,
         )
 
     def withLazy(self, lazy: bool) -> Github:

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -399,6 +399,7 @@ class Requester:
         seconds_between_requests: float | None = None,
         seconds_between_writes: float | None = None,
         lazy: bool = False,
+        api_version: str | None = None,
     ):
         self._initializeDebugFeature()
 
@@ -445,6 +446,7 @@ class Requester:
         self.__userAgent = user_agent
         self.__verify = verify
         self.__lazy = lazy
+        self.__apiVersion = api_version
 
         self.__installation_authorization = None
 
@@ -536,6 +538,7 @@ class Requester:
             seconds_between_requests=self.__seconds_between_requests,
             seconds_between_writes=self.__seconds_between_writes,
             lazy=self.__lazy,
+            api_version=self.__apiVersion,
         )
 
     @property
@@ -1195,6 +1198,8 @@ class Requester:
         if self.__auth is not None:
             self.__auth.authentication(requestHeaders)
         requestHeaders["User-Agent"] = self.__userAgent
+        if self.__apiVersion is not None:
+            requestHeaders["X-GitHub-Api-Version"] = self.__apiVersion
 
         url = self.__makeAbsoluteUrl(url)
         url = Requester.add_parameters_to_url(url, parameters)


### PR DESCRIPTION
## Summary

Adds support for GitHub's versioned REST API by sending the `X-GitHub-Api-Version` header with all requests.

## Changes

- Added `DEFAULT_API_VERSION = "2022-11-28"` constant in `Consts.py`
- Added `api_version` parameter to `Github`, `GithubIntegration`, and `Requester` constructors
- The `X-GitHub-Api-Version` header is included in all API requests when `api_version` is set
- Defaults to `"2022-11-28"` (current stable version per [GitHub docs](https://docs.github.com/en/rest/about-the-rest-api/api-versions))
- Can be set to `None` to omit the header (preserving backward compatibility)

## Usage

```python
# Default: uses '2022-11-28'
g = github.Github(auth=auth)

# Specific version
g = github.Github(auth=auth, api_version="2022-11-28")

# Opt out of sending the header
g = github.Github(auth=auth, api_version=None)
```

Fixes #3442