### PR TITLE
fix totalCount KeyError when last link has no page param

### DIFF
--- a/tests/PaginatedList.py
+++ b/tests/PaginatedList.py
@@ -323,6 +323,13 @@ class PaginatedList(Framework.TestCase):
         self.assertEqual(review_requests[0].totalCount, 0)
         self.assertEqual(review_requests[1].totalCount, 0)
 
+    def testTotalCountWithNoPageParam(self):
+        # When the "last" link uses since-based pagination instead of page-based,
+        # totalCount should fall back to counting via data instead of raising KeyError.
+        # See https://github.com/PyGithub/PyGithub/issues/1006
+        repos = self.g.get_repos()
+        self.assertEqual(repos.totalCount, 1)
+
     def testTotalCountWithDeprecationLink(self):
         # Test the original reported scenario: search_issues with commit SHA
         issues = self.g.search_issues("commit:example_sha")

--- a/tests/ReplayData/PaginatedList.testTotalCountWithNoPageParam.txt
+++ b/tests/ReplayData/PaginatedList.testTotalCountWithNoPageParam.txt
@@ -1,0 +1,10 @@
+https
+GET
+api.github.com
+None
+/repositories?per_page=1
+{'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
+None
+200
+[('Date', 'Mon, 03 Aug 2020 09:02:17 GMT'), ('Content-Type', 'application/json; charset=utf-8'), ('Transfer-Encoding', 'chunked'), ('Server', 'GitHub.com'), ('Status', '200 OK'), ('X-RateLimit-Limit', '5000'), ('X-RateLimit-Remaining', '4996'), ('X-RateLimit-Reset', '1596448362'), ('Cache-Control', 'private, max-age=60, s-maxage=60'), ('Vary', 'Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept, X-Requested-With, Accept-Encoding'), ('ETag', 'W/"d773714fdca21c9206d9d35e50fcd1ff"'), ('X-OAuth-Scopes', 'repo'), ('X-Accepted-OAuth-Scopes', ''), ('X-GitHub-Media-Type', 'github.v3; format=json'), ('Link', '<https://api.github.com/repositories?per_page=1&since=500>; rel="next", <https://api.github.com/repositories?per_page=1&since=99999>; rel="last"'), ('Access-Control-Expose-Headers', 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset'), ('Access-Control-Allow-Origin', '*'), ('Strict-Transport-Security', 'max-age=31536000; includeSubdomains; preload'), ('X-Frame-Options', 'deny'), ('X-Content-Type-Options', 'nosniff'), ('X-XSS-Protection', '1; mode=block'), ('Referrer-Policy', 'origin-when-cross-origin, strict-origin-when-cross-origin'), ('Content-Security-Policy', "default-src 'none'"), ('Content-Encoding', 'gzip'), ('X-GitHub-Request-Id', 'C662:025B:26F607:2FDFF2:5F27D299')]
+[{"id":1,"name":"grit","full_name":"mojombo/grit","owner":{"login":"mojombo","id":1}}]


### PR DESCRIPTION
`PaginatedList.totalCount` crashes with `KeyError: 'page'` when the GitHub API returns a `rel="last"` link that uses `since`-based pagination instead of `page`-based pagination. This happens with endpoints like list-all-public-repositories on GitHub Enterprise.

The root cause is two things:
1. `parse_qs()` was being called on the full URL instead of just the query string — it worked by accident for `page` since it appeared after `&`, but `per_page` (the first param) was being parsed with the full URL path as part of its key.
2. No check for whether `page` actually exists in the parsed params before accessing it.

Fixed by using `urlparse().query` to extract the query string properly, and checking for `page` before accessing it. When `page` isn't present, the code falls through to the existing data-based counting logic.

Fixes #1006