### PR TITLE
fix: raise exception in is_merged() for non-204/non-404 status codes

### DIFF
--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -852,7 +852,12 @@ class PullRequest(CompletableGithubObject):
         :calls: `GET /repos/{owner}/{repo}/pulls/{pull_number}/merge <https://docs.github.com/en/rest/reference/pulls>`_
         """
         status, headers, data = self._requester.requestJson("GET", f"{self.url}/merge")
-        return status == 204
+        if status == 204:
+            return True
+        elif status == 404:
+            return False
+        else:
+            raise self._requester.createException(status, headers, data)
 
     def restore_branch(self) -> GitRef:
         """

--- a/tests/PullRequest.py
+++ b/tests/PullRequest.py
@@ -509,6 +509,11 @@ class PullRequest(Framework.TestCase):
             'PullRequestMergeStatus(sha="688208b1a5a074871d0e9376119556897439697d", merged=True)',
         )
 
+    def testIsMergedRaisesOnUnexpectedStatus(self):
+        """Test that is_merged() raises an exception for non-204/non-404 status codes (e.g. 401)."""
+        with self.assertRaises(github.GithubException.BadCredentialsException):
+            self.repo.get_pull(31).is_merged()
+
     def testMergeWithCommitMessage(self):
         self.repo.get_pull(39).merge("Custom commit message created by PyGithub")
 

--- a/tests/ReplayData/PullRequest.testIsMergedRaisesOnUnexpectedStatus.txt
+++ b/tests/ReplayData/PullRequest.testIsMergedRaisesOnUnexpectedStatus.txt
@@ -1,0 +1,10 @@
+https
+GET
+api.github.com
+None
+/repos/PyGithub/PyGithub/pulls/31/merge
+{'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
+None
+401
+[('Server', 'GitHub.com'), ('Content-Type', 'application/json; charset=utf-8')]
+{"message":"Bad credentials","documentation_url":"https://docs.github.com/rest"}


### PR DESCRIPTION
## Summary

Fixes #2760

`PullRequest.is_merged()` previously used raw `requestJson()` which silently returned `False` for **any** non-204 status code, including:
- `401 Bad credentials` (expired/invalid token)
- `403 Forbidden`
- Any other HTTP error

This caused false negatives where an expired authentication token would cause `is_merged()` to return `False` instead of raising the appropriate exception, differing from all other PyGithub methods.

## Changes

The method now explicitly handles each case:
- **204** returns `True` (PR is merged)
- **404** returns `False` (PR is not merged)
- **Any other status** raises the appropriate `GithubException`

A test with replay data is included to verify the 401 case raises `BadCredentialsException`.