### PR TITLE
Add Repository.get_workflow_job to wrap GET /actions/jobs/{job_id}

### DIFF
--- a/github/Repository.py
+++ b/github/Repository.py
@@ -252,6 +252,7 @@ import github.Team
 import github.Variable
 import github.View
 import github.Workflow
+import github.WorkflowJob
 import github.WorkflowRun
 from github import Consts
 from github.GeneratedReleaseNotes import GeneratedReleaseNotes
@@ -336,6 +337,7 @@ if TYPE_CHECKING:
     from github.Team import Team
     from github.View import View
     from github.Workflow import Workflow
+    from github.WorkflowJob import WorkflowJob
     from github.WorkflowRun import WorkflowRun
 
 
@@ -3811,6 +3813,16 @@ class Repository(CompletableGithubObject):
         assert isinstance(id_, int)
         url = f"{self.url}/actions/runs/{id_}"
         return github.WorkflowRun.WorkflowRun(self._requester, url=url)
+
+    def get_workflow_job(self, id_: int) -> WorkflowJob:
+        """
+        :calls: `GET /repos/{owner}/{repo}/actions/jobs/{job_id} <https://docs.github.com/en/rest/actions/workflow-jobs#get-a-job-for-a-workflow-run>`_
+        :param id_: int
+        :rtype: :class:`github.WorkflowJob.WorkflowJob`
+        """
+        assert isinstance(id_, int)
+        url = f"{self.url}/actions/jobs/{id_}"
+        return github.WorkflowJob.WorkflowJob(self._requester, url=url)
 
     def has_in_assignees(self, assignee: str | NamedUser) -> bool:
         """


### PR DESCRIPTION
Fixes #3448.

Adds a `get_workflow_job(id_)` method on `Repository`, mirroring the existing `get_workflow_run(id_)` method one for one. Same signature shape, same one-line URL build, same lazy construction of the return type.

### What's new

```python
def get_workflow_job(self, id_: int) -> WorkflowJob:
    """
    :calls: `GET /repos/{owner}/{repo}/actions/jobs/{job_id} <https://docs.github.com/en/rest/actions/workflow-jobs#get-a-job-for-a-workflow-run>`_
    :param id_: int
    :rtype: :class:`github.WorkflowJob.WorkflowJob`
    """
    assert isinstance(id_, int)
    url = f"{self.url}/actions/jobs/{id_}"
    return github.WorkflowJob.WorkflowJob(self._requester, url=url)
```

Plus the matching imports for `WorkflowJob` (runtime and TYPE_CHECKING).

### Why

The `WorkflowJob` class already exists in PyGithub, but the only way to get one is via `repo.get_workflow_run(run_id).jobs()[0]`. The underlying REST endpoint (`GET /repos/{owner}/{repo}/actions/jobs/{job_id}`) takes a job id directly, so a one call wrapper is useful when you already have the id (for example, from a webhook payload).

### Tests

I followed the precedent of `get_workflow_run`, which also has no dedicated direct test in `tests/Repository.py` and is exercised through other tests. The `WorkflowJob` class itself is already covered by `tests/WorkflowJob.py`. Happy to add a dedicated test with a hand crafted or recorded ReplayData if you would like, just say the word.

### Verification

```
$ python -m pytest tests/Repository.py tests/Workflow.py tests/WorkflowRun.py tests/WorkflowJob.py -q
187 passed
```

Diff: +12 / -0, all pure addition.