### PR TITLE
Fix GithubException.__str__ decoding bytes data

### DIFF
--- a/github/GithubException.py
+++ b/github/GithubException.py
@@ -102,7 +102,10 @@ class GithubException(Exception):
             msg = f"{self.status}"
 
         if self.data is not None:
-            msg += " " + json.dumps(self.data)
+            data = self.data
+            if isinstance(data, bytes):
+                data = data.decode("utf-8", errors="replace")
+            msg += " " + json.dumps(data)
 
         return msg
 

--- a/tests/Exceptions.py
+++ b/tests/Exceptions.py
@@ -115,6 +115,10 @@ class Exceptions(Framework.TestCase):
     def testExceptionPickling(self):
         pickle.loads(pickle.dumps(github.GithubException("foo", "bar", None)))
 
+    def testBytesData(self):
+        exc = github.GithubException(403, b"<html>rate limit</html>", message="rate limit")
+        self.assertEqual(str(exc), 'rate limit: 403 "<html>rate limit</html>"')
+
     def testJSONParseError(self):
         # Replay data was forged to force a JSON error
         with self.assertRaises(ValueError):


### PR DESCRIPTION
`GithubException.__str__` calls `json.dumps(self.data)` directly, which raises `TypeError: Object of type bytes is not JSON serializable` when the exception is constructed from a non-JSON response body that `requests` returns as `bytes` (e.g. an HTML rate-limit page on a 403). Decode bytes to text before serialising so callers can log or stringify these exceptions without crashing.

Fixes #3492.