### PR TITLE
Fix Codecov coverage reporting on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,9 @@ jobs:
           name: Test Results (Python ${{ matrix.python-version }} on ${{ matrix.os-label }})
           path: pytest.xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test_success:
     # this aggregates success state of all jobs listed in `needs`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/badge/license-LGPL-blue.svg)](https://en.wikipedia.org/wiki/GNU_Lesser_General_Public_License)
 [![Slack](https://img.shields.io/badge/Slack%20channel-%20%20-blue.svg)](https://join.slack.com/t/pygithub-project/shared_invite/zt-duj89xtx-uKFZtgAg209o6Vweqm8xeQ)
 [![Open Source Helpers](https://www.codetriage.com/pygithub/pygithub/badges/users.svg)](https://www.codetriage.com/pygithub/pygithub)
-[![codecov](https://codecov.io/gh/PyGithub/PyGithub/branch/master/graph/badge.svg)](https://codecov.io/gh/PyGithub/PyGithub)
+[![codecov](https://codecov.io/gh/PyGithub/PyGithub/branch/main/graph/badge.svg)](https://codecov.io/gh/PyGithub/PyGithub/tree/main)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 PyGitHub is a Python library to access the [GitHub REST API].


### PR DESCRIPTION

Codecov uploads were silently failing on the `main` branch with:
`"Token required because branch is protected"`

## Changes
- Add `CODECOV_TOKEN` secret to the codecov upload step
- Upgrade `codecov/codecov-action` from v5 to v6
- Update Codecov badge URL from `master` to `main`

## Notes
Assuming the secret name is `CODECOV_TOKEN`
