### PR TITLE
Lazily complete issues obtained from PRs

### DIFF
--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -453,7 +453,7 @@ class PullRequest(CompletableGithubObject):
         """
         :calls: `GET /repos/{owner}/{repo}/issues/{issue_number} <https://docs.github.com/en/rest/reference/issues>`_
         """
-        return github.Issue.Issue(self._requester, url=self.issue_url)
+        return github.Issue.Issue(self._requester, url=self.issue_url, completed=False)
 
     def create_comment(self, body: str, commit: Commit, path: str, position: int) -> PullRequestComment:
         """


### PR DESCRIPTION
Currently when `PullRequest.as_issue` gets called it immediately completes the issue, which triggers an HTTP request which requires `issues: read`.

However this may not be necessary, if the goal is just to e.g. add comments to the PR, that goes through the issue endpoints but it can be accessed with just the issue number and `pull_requests: write` permission (https://docs.github.com/en/rest/issues/comments?apiVersion=2026-03-10#create-an-issue-comment).

By creating the issue uncompleted, `as_issue` can be called with just `pull_requests: read`, and `issue: read` is only necessary when trying to retrieve specific issue attributes.