### PR TITLE
OpenAPI script improvements

### DIFF
--- a/scripts/openapi.py
+++ b/scripts/openapi.py
@@ -4400,7 +4400,7 @@ class OpenApi:
         self.write_code(orig_source, source, clazz.filename, dry_run=False)
 
         if tests:
-            attr_name = re.sub("[a-z]", "", class_name).lower()
+            attr_name = re.sub("[a-z]", "", clazz.name).lower()
             if filename and Path(clazz.test_filename).exists():
                 # read original source
                 with open(clazz.test_filename) as r:

--- a/scripts/openapi.py
+++ b/scripts/openapi.py
@@ -254,29 +254,43 @@ def string_as_python_type(type: str, classes: dict[str, dict]) -> PythonType | G
     return None
 
 
-def is_pagination_object(schema: dict[str, Any]) -> bool:
+def pagination_list_property(properties: dict[str, Any]) -> str | None:
+    # A pagination object looks like:
     # {
     #   "type": "object",
     #   "properties": {
     #     "total_…": {"type": "integer"},
     #     "…": {"type": "array", "items": …},
     # }
+    # It has exactly one "total_…" integer property and an array property holding
+    # the paginated items. Some objects may have further array properties. In that case the
+    # canonical "items" array identifies the paginated items.
+    #
+    # Returns the name of the paginated array property, or None if this is not a pagination object.
+    total_count_items = [n for n, p in properties.items() if n.startswith("total_") and p.get("type") == "integer"]
+    if len(total_count_items) != 1:
+        return None
+    list_items = [n for n, p in properties.items() if p.get("type") == "array" and "items" in p]
+    if len(list_items) == 1:
+        return list_items[0]
+    if len(list_items) > 1 and "items" in list_items:
+        return "items"
+    return None
+
+
+def is_pagination_object(schema: dict[str, Any]) -> bool:
     return (
         schema.get("type") == "object"
         and "properties" in schema
-        and len(
-            [n for n, p in schema.get("properties").items() if n.startswith("total_") and p.get("type") == "integer"]
-        )
-        == 1
-        and len([p for p in schema.get("properties").values() if p.get("type") == "array" and "items" in p]) == 1
+        and pagination_list_property(schema.get("properties")) is not None
     )
 
 
 def get_paginated_property(schema: dict[str, Any], schema_path: list[str]) -> (dict[str, Any], list[str]):
     # assumes is_pagination_object returns True for this schema
     props = schema.get("properties")
-    list_item = next(((n, p) for n, p in props.items() if p.get("type") == "array" and "items" in p))
-    return list_item[1], schema_path + ["properties", list_item[0]]
+    list_item = pagination_list_property(props)
+    return props.get(list_item), schema_path + ["properties", list_item]
 
 
 def responses_as_python_type(
@@ -3275,10 +3289,8 @@ class OpenApi:
         # extract the inner type of pagination objects
         if "properties" in schema:
             props = schema.get("properties")
-            list_items = [n for n, p in props.items() if p.get("type") == "array" and "items" in p]
-            total_count_items = [n for n, p in props.items() if n.startswith("total_") and p.get("type") == "integer"]
-            if len(list_items) == 1 and len(total_count_items) == 1:
-                list_item = list_items[0]
+            list_item = pagination_list_property(props)
+            if list_item is not None:
                 return self.get_inner_spec_types(
                     props.get(list_item).get("items"), schema_path + ["properties", list_item, "items"]
                 )

--- a/scripts/openapi.py
+++ b/scripts/openapi.py
@@ -986,9 +986,11 @@ class IndexPythonClassesVisitor(CstVisitorBase):
                     while len(lines) > idx + 1 and not lines[idx + 1].strip():
                         idx = idx + 1
                     for schema in lines[idx + 1 :]:
-                        if not schema.strip().lstrip("- "):
+                        schema = schema.strip().lstrip("- ")
+                        if not schema:
                             break
-                        class_schemas.append(schema.strip().lstrip("- "))
+                        if schema not in class_schemas:
+                            class_schemas.append(schema)
 
         if class_name_short in classes:
             print(f"Duplicate class definition for {class_name_short}")

--- a/scripts/openapi.py
+++ b/scripts/openapi.py
@@ -452,11 +452,45 @@ class GithubClass:
                 )
 
 
+# readable Python words for characters that are not allowed in Python identifiers
+_PROPERTY_NAME_SPECIAL_CHARS = {"+": "plus", "-": "minus", "1": "one"}
+
+
+def to_python_name(name: str) -> str:
+    """
+    Turn an OpenAPI property name into a valid Python identifier.
+
+    Names that already are valid identifiers are returned unchanged. Names with characters that are
+    not allowed in Python identifiers (e.g. the reaction rollup properties ``+1`` and ``-1``) are
+    translated: known special characters become readable words (``+`` -> ``plus``, ``1`` -> ``one``)
+    and any other invalid character becomes an underscore. So ``+1`` becomes ``plus_one``.
+
+    """
+    if name.isidentifier():
+        return name
+    result = name
+    for char, word in _PROPERTY_NAME_SPECIAL_CHARS.items():
+        result = result.replace(char, f"_{word}_")
+    # replace any remaining invalid characters and collapse / strip underscores
+    result = re.sub(r"\W", "_", result)
+    result = re.sub(r"_+", "_", result).strip("_")
+    # a valid identifier must not start with a digit
+    if result and result[0].isdigit():
+        result = f"_{result}"
+    return result
+
+
 @dataclasses.dataclass(frozen=True)
 class Property:
     name: str
     data_type: PythonType | GithubClass | None
     deprecated: bool
+    # the Python identifier for this property; defaults to a sanitized version of name
+    python_name: str = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.python_name is None:
+            object.__setattr__(self, "python_name", to_python_name(self.name))
 
     @staticmethod
     def from_tuples(properties: dict[str, (PythonType | GithubClass | None, bool)]) -> list[Property]:
@@ -1243,7 +1277,7 @@ class ApplySchemaBaseTransformer(CstTransformerBase, abc.ABC):
         super().__init__()
         self.module_name = module_name
         self.class_name = class_name
-        self.properties = sorted(properties, key=lambda p: p.name)
+        self.properties = sorted(properties, key=lambda p: p.python_name)
         self.all_properties = self.properties.copy()
         self.deprecate = deprecate
 
@@ -1435,7 +1469,7 @@ class ApplySchemaTransformer(ApplySchemaBaseTransformer):
         if updated_node.name.value == "_useAttributes":
             while self.current_property:
                 prop = self.properties.pop(0)
-                node = self.create_property_function(prop.name, prop.data_type, prop.deprecated)
+                node = self.create_property_function(prop.python_name, prop.data_type, prop.deprecated)
                 nodes.append(cst.EmptyLine(indent=False))
                 nodes.append(node)
             nodes.append(self.update_use_attrs(updated_node))
@@ -1445,24 +1479,24 @@ class ApplySchemaTransformer(ApplySchemaBaseTransformer):
 
         while self.current_property and (
             updated_node_is_github_object_property
-            and self.current_property.name < updated_node.name.value
+            and self.current_property.python_name < updated_node.name.value
             or not updated_node_is_github_object_property
         ):
             prop = self.properties.pop(0)
-            node = self.create_property_function(prop.name, prop.data_type, prop.deprecated)
+            node = self.create_property_function(prop.python_name, prop.data_type, prop.deprecated)
             nodes.append(cst.EmptyLine(indent=False))
             nodes.append(node)
 
         if updated_node_is_github_object_property:
             if (
                 not self.current_property
-                or updated_node.name.value != self.current_property.name
+                or updated_node.name.value != self.current_property.python_name
                 or self.current_property.deprecated
             ):
                 nodes.append(self.deprecate_function(updated_node) if self.deprecate else updated_node)
             else:
                 nodes.append(updated_node)
-            if self.current_property and updated_node.name.value == self.current_property.name:
+            if self.current_property and updated_node.name.value == self.current_property.python_name:
                 self.properties.pop(0)
         else:
             nodes.append(updated_node)
@@ -1500,7 +1534,7 @@ class ApplySchemaTransformer(ApplySchemaBaseTransformer):
     def create_init_attr(cls, prop: Property) -> cst.SimpleStatementLine:
         # we need to make the 'headers' attribute truly private,
         # otherwise it conflicts with GithubObject._headers
-        attr_name = f"__{prop.name}" if prop.name == "headers" else f"_{prop.name}"
+        attr_name = f"__{prop.python_name}" if prop.python_name == "headers" else f"_{prop.python_name}"
         return cst.SimpleStatementLine(
             [
                 cst.AnnAssign(
@@ -1642,7 +1676,7 @@ class ApplySchemaTransformer(ApplySchemaBaseTransformer):
     def create_use_attr(cls, prop: Property) -> cst.BaseStatement:
         # we need to make the 'headers' attribute truly private,
         # otherwise it conflicts with GithubObject._headers
-        attr_name = f"__{prop.name}" if prop.name == "headers" else f"_{prop.name}"
+        attr_name = f"__{prop.python_name}" if prop.python_name == "headers" else f"_{prop.python_name}"
         return cst.If(
             test=cst.Comparison(
                 left=cst.SimpleString(f'"{prop.name}"'),
@@ -1819,7 +1853,9 @@ class ApplySchemaTestTransformer(ApplySchemaBaseTransformer):
                 and isinstance(prop.data_type.inner_types[0], GithubClass)
                 and prop.data_type.inner_types[0].ids
             ):
-                prop = dataclasses.replace(prop, name=f"{prop.name}[0]", data_type=prop.data_type.inner_types[0])
+                prop = dataclasses.replace(
+                    prop, python_name=f"{prop.python_name}[0]", data_type=prop.data_type.inner_types[0]
+                )
 
             if (
                 isinstance(prop.data_type, GithubClass)
@@ -1853,7 +1889,7 @@ class ApplySchemaTestTransformer(ApplySchemaBaseTransformer):
                                     args=[
                                         cst.Arg(
                                             self.create_attribute(
-                                                (["self"] if self_attribute else []) + [attribute, prop.name, id]
+                                                (["self"] if self_attribute else []) + [attribute, prop.python_name, id]
                                             )
                                         ),
                                         cst.Arg(cst.SimpleString('""')),
@@ -1870,7 +1906,9 @@ class ApplySchemaTestTransformer(ApplySchemaBaseTransformer):
                             func=self.create_attribute(["self", "assertEqual"]),
                             args=[
                                 cst.Arg(
-                                    self.create_attribute((["self"] if self_attribute else []) + [attribute, prop.name])
+                                    self.create_attribute(
+                                        (["self"] if self_attribute else []) + [attribute, prop.python_name]
+                                    )
                                 ),
                                 cst.Arg(self.get_value(prop.data_type)),
                             ],
@@ -1942,7 +1980,9 @@ class ApplySchemaTestTransformer(ApplySchemaBaseTransformer):
             }
 
             # we can remove all properties that already exist in the test file
-            self.properties = [property for property in self.properties if property.name not in existing_properties]
+            self.properties = [
+                property for property in self.properties if property.python_name not in existing_properties
+            ]
 
             i = 0
             stmts = list(updated_node.body.body)
@@ -1967,12 +2007,12 @@ class ApplySchemaTestTransformer(ApplySchemaBaseTransformer):
 
                 if len(attrs) >= 2 and attrs[0] == attribute:
                     asserted_property = attrs[1]
-                    while self.properties and self.properties[0].name < asserted_property:
+                    while self.properties and self.properties[0].python_name < asserted_property:
                         prop = self.properties.pop(0)
                         stmt = create_statement(prop, self_attribute)
                         stmts = stmts[:i] + [stmt] + stmts[i:]
                         i = i + 1
-                    if self.properties and self.properties[0].name == asserted_property:
+                    if self.properties and self.properties[0].python_name == asserted_property:
                         self.properties.pop(0)
                 i = i + 1
             while self.properties:

--- a/scripts/openapi.py
+++ b/scripts/openapi.py
@@ -166,9 +166,8 @@ def as_python_type(
                 for class_name in classes:
                     if class_name not in classes:
                         print(f"Class not found in index: {class_name}")
-            return PythonType(
-                type="union",
-                inner_types=[GithubClass(**classes.get(cls)) for cls in sorted(classes_of_schema) if cls in classes],
+            return PythonType.union(
+                *[GithubClass(**classes.get(cls)) for cls in sorted(classes_of_schema) if cls in classes]
             )
         if collect_new_schemas is not None:
             if schema.split("/")[-1].startswith("_"):

--- a/scripts/openapi.py
+++ b/scripts/openapi.py
@@ -2000,35 +2000,54 @@ class AddSchemasTransformer(CstTransformerBase):
                 lines = docstring.splitlines()
                 first_line = lines[1]
                 indent = first_line[: len(first_line) - len(first_line.lstrip())]
-                heading = len(lines) - 1  # if there is no heading, we place it before the last line (the closing """)
-                empty_footing = lines[-2].strip() == ""
-                schema_lines = []
+                # locate the existing schema list (the bullet lines following the heading);
+                # anything after those bullets (e.g. a trailing ".. warning::" block) is
+                # preserved verbatim and must not be treated as schema lines
+                heading = None
                 for idx, line in enumerate(lines):
                     if "The OpenAPI schema can be found at" in line:
                         heading = idx
-                        schema_lines = lines[idx + 1 : -2 if empty_footing else -1]
                         break
-                schema_lines = {schema_line for schema_line in schema_lines if schema_line}
+                if heading is not None:
+                    end = heading + 1
+                    while end < len(lines) and not lines[end].strip():  # skip blank lines after the heading
+                        end += 1
+                    existing_lines = []
+                    while end < len(lines) and lines[end].strip().startswith("- "):
+                        existing_lines.append(lines[end])
+                        end += 1
+                    prefix = lines[:heading]
+                    trailing = lines[end:]  # blank line(s), any trailing content and the closing """
+                else:
+                    # no heading yet: place the schema list right before the closing """
+                    existing_lines = []
+                    prefix = lines[:-1]
+                    trailing = lines[-1:]
+
+                schema_lines = {schema_line for schema_line in existing_lines if schema_line}
                 before = len(schema_lines)
                 schema_lines = sorted(list(schema_lines.union({f"{indent}- {schema}" for schema in self.schemas})))
                 after = len(schema_lines)
-                lines = (
-                    lines[:heading]
-                    +
-                    # we add an empty line before the schema lines title if there is none
-                    ([""] if lines[heading - 1].strip() else [])
-                    + [indent + "The OpenAPI schema can be found at"]
-                    # we add an empty line after the schema lines title to get a proper bullet list in the docs
-                    + [""]
-                    + schema_lines
-                    + [""]
-                    + lines[-1:]
-                )
-                docstring = "\n".join(lines)
-                stmt = cst.SimpleStatementLine([cst.Expr(cst.SimpleString(docstring))])
-                stmts = [stmt] + list(updated_node.body.body[1:])
-                updated_node = updated_node.with_changes(body=updated_node.body.with_changes(body=stmts))
-                self.schema_added += after - before
+                # do not add an empty schema heading to classes without any schemas
+                if schema_lines:
+                    lines = (
+                        prefix
+                        +
+                        # we add an empty line before the schema lines title if there is none
+                        ([""] if prefix and prefix[-1].strip() else [])
+                        + [indent + "The OpenAPI schema can be found at"]
+                        # we add an empty line after the schema lines title to get a proper bullet list in the docs
+                        + [""]
+                        + schema_lines
+                        # keep a blank line between the schema list and any trailing content
+                        + ([""] if trailing and trailing[0].strip() else [])
+                        + trailing
+                    )
+                    docstring = "\n".join(lines)
+                    stmt = cst.SimpleStatementLine([cst.Expr(cst.SimpleString(docstring))])
+                    stmts = [stmt] + list(updated_node.body.body[1:])
+                    updated_node = updated_node.with_changes(body=updated_node.body.with_changes(body=stmts))
+                    self.schema_added += after - before
 
         return super().leave_ClassDef(original_node, updated_node)
 
@@ -3348,7 +3367,11 @@ class OpenApi:
         transformer = AddSchemasTransformer(class_name, schemas)
         tree = cst.parse_module(code)
         updated_tree = tree.visit(transformer)
-        cls.write_code(code, updated_tree.code, filename, dry_run)
+        # only announce and write when the schema list actually changes; an
+        # unchanged list (already sorted and distinct) produces no output
+        if updated_tree.code != code:
+            print(f"Adding schemas to {class_name}")
+            cls.write_code(code, updated_tree.code, filename, dry_run)
         return transformer.schema_added
 
     @staticmethod
@@ -4084,14 +4107,16 @@ class OpenApi:
                 for providing_class, providing_property in sorted(providing_properties):
                     print(f"- {providing_class}.{providing_property}")
 
-                if add and schemas_to_implement:
-                    filename = clazz.get("filename")
-                    clazz_name = clazz.get("name")
-                    if not filename or not clazz_name:
+            # adding sorts and de-duplicates the schema list, so run it whenever
+            # --add is given, even when there are no new schemas to implement
+            if add:
+                filename = clazz.get("filename")
+                clazz_name = clazz.get("name")
+                if not filename or not clazz_name:
+                    if schemas_to_implement:
                         print(f"Class name or filename for class {cls} not known")
                         sys.exit(1)
-
-                    print(f"Adding schemas to {cls}")
+                else:
                     added = self.add_schema_to_class(clazz_name, filename, schemas_to_implement, dry_run)
                     schemas_added += added
             schemas_suggested += len(schemas_to_implement)
@@ -4195,13 +4220,15 @@ class OpenApi:
                     for path in sorted(verb_paths):
                         print(f"- {verb.upper()} {path}")
 
-                if add and schemas_to_implement:
-                    filename = clazz.get("filename")
-                    if not filename:
+            # adding sorts and de-duplicates the schema list, so run it whenever
+            # --add is given, even when there are no new schemas to implement
+            if add:
+                filename = clazz.get("filename")
+                if not filename:
+                    if schemas_to_implement:
                         print(f"Filename for class {cls} not known")
                         sys.exit(1)
-
-                    print(f"Adding schemas to {cls}")
+                else:
                     added = self.add_schema_to_class(cls, filename, schemas_to_implement, dry_run)
                     schemas_added += added
             schemas_suggested += len(schemas_to_implement)

--- a/scripts/openapi.py
+++ b/scripts/openapi.py
@@ -4309,6 +4309,10 @@ class OpenApi:
         github_parent_path = str(Path(github_path).parent)
         clazz = GithubClass.from_class_name(class_name, github_parent_path=github_parent_path)
         parent_class = GithubClass.from_class_name(parent_name, index)
+        if filename is None and "." in class_name:
+            # a long class name like github.Commit.CommitSearchResult implies --file Commit.py
+            _, module, _ = class_name.split(".", 2)
+            filename = f"{module}.py"
         clazz = clazz.with_filename(github_parent_path, filename)
         print(f"Creating class {clazz.full_class_name} with parent {parent_class.full_class_name} in {clazz.filename}")
         if not filename and os.path.exists(clazz.filename):


### PR DESCRIPTION
- Improved detection of pagination objects
- Fix union type of duplicate inner types
- Deduplicated schemas in index
- Sort existing schemas when suggesting schemas with `--add`
- Support docstrings with content after schema list
- Handle special characters when creating Python property names
- Make `create class --tests` work with long class names
- Derive `--file` from long class name

Co-Authored-By: Claude <noreply@anthropic.com>