### PR TITLE
Encode boolean query parameters as lowercase

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -503,7 +503,12 @@ class Requester:
         url_params = urllib.parse.parse_qs(query)
         # union parameters in url with given parameters, the latter has precedence
         url_params.update(**{k: v if isinstance(v, list) else [v] for k, v in parameters.items()})
-        parameter_list = [(key, value) for key, values in url_params.items() for value in values]
+        # GitHub expects lowercase booleans (true/false) in the query string
+        parameter_list = [
+            (key, str(value).lower() if isinstance(value, bool) else value)
+            for key, values in url_params.items()
+            for value in values
+        ]
         # remove query from url
         url = urllib.parse.urlunparse((scheme, netloc, url, params, "", fragment))
 

--- a/tests/ReplayData/Github.testGetGlobalAdvisoriesManyFilters.txt
+++ b/tests/ReplayData/Github.testGetGlobalAdvisoriesManyFilters.txt
@@ -2,7 +2,7 @@ https
 GET
 api.github.com
 None
-/advisories?type=reviewed&ecosystem=npm&severity=medium&cwes=200%2C900&is_withdrawn=False&affects=directus%2Cmade_up&modified=%3E2023-07-01&sort=updated&direction=desc
+/advisories?type=reviewed&ecosystem=npm&severity=medium&cwes=200%2C900&is_withdrawn=false&affects=directus%2Cmade_up&modified=%3E2023-07-01&sort=updated&direction=desc
 {'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
 None
 200
@@ -13,7 +13,7 @@ https
 GET
 api.github.com
 None
-/advisories?type=reviewed&ecosystem=npm&severity=medium&cwes=200%2C900&is_withdrawn=False&affects=directus&updated=%3E2023-07-01&sort=updated&direction=desc
+/advisories?type=reviewed&ecosystem=npm&severity=medium&cwes=200%2C900&is_withdrawn=false&affects=directus&updated=%3E2023-07-01&sort=updated&direction=desc
 {'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
 None
 200
@@ -24,7 +24,7 @@ https
 GET
 api.github.com
 None
-/advisories?type=reviewed&ecosystem=npm&severity=medium&cwes=200%2C900&is_withdrawn=False&affects=directus&published=%3E2023-07-01&sort=updated&direction=desc
+/advisories?type=reviewed&ecosystem=npm&severity=medium&cwes=200%2C900&is_withdrawn=false&affects=directus&published=%3E2023-07-01&sort=updated&direction=desc
 {'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
 None
 200

--- a/tests/ReplayData/OrganizationSecretScanAlert.testGetAlertsWithAllArguments.txt
+++ b/tests/ReplayData/OrganizationSecretScanAlert.testGetAlertsWithAllArguments.txt
@@ -2,7 +2,7 @@ https
 GET
 api.github.com
 None
-/orgs/github/secret-scanning/alerts?state=resolved&secret_type=adafruit_io_key&resolution=false_positive&sort=created&direction=asc&validity=inactive&is_publicly_leaked=False&is_multi_repo=False&hide_secret=True
+/orgs/github/secret-scanning/alerts?state=resolved&secret_type=adafruit_io_key&resolution=false_positive&sort=created&direction=asc&validity=inactive&is_publicly_leaked=false&is_multi_repo=false&hide_secret=true
 {'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
 None
 200

--- a/tests/ReplayData/PullRequest1168.testGetIssue.txt
+++ b/tests/ReplayData/PullRequest1168.testGetIssue.txt
@@ -2,7 +2,7 @@ https
 GET
 api.github.com
 None
-/repos/PyGithub/PyGithub/notifications?all=True
+/repos/PyGithub/PyGithub/notifications?all=true
 {'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
 None
 200

--- a/tests/ReplayData/PullRequest1168.testGetPullRequest.txt
+++ b/tests/ReplayData/PullRequest1168.testGetPullRequest.txt
@@ -2,7 +2,7 @@ https
 GET
 api.github.com
 None
-/repos/PyGithub/PyGithub/notifications?all=True
+/repos/PyGithub/PyGithub/notifications?all=true
 {'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
 None
 200

--- a/tests/ReplayData/SecretScanAlert.testGetAlertsWithAllArguments.txt
+++ b/tests/ReplayData/SecretScanAlert.testGetAlertsWithAllArguments.txt
@@ -2,7 +2,7 @@ https
 GET
 api.github.com
 None
-/repos/matt-davis27/PyGithub/secret-scanning/alerts?state=resolved&secret_type=adafruit_io_key&resolution=false_positive&sort=created&direction=asc&validity=inactive&is_publicly_leaked=False&is_multi_repo=False&hide_secret=True
+/repos/matt-davis27/PyGithub/secret-scanning/alerts?state=resolved&secret_type=adafruit_io_key&resolution=false_positive&sort=created&direction=asc&validity=inactive&is_publicly_leaked=false&is_multi_repo=false&hide_secret=true
 {'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
 None
 200

--- a/tests/Requester.py
+++ b/tests/Requester.py
@@ -265,6 +265,10 @@ class Requester(Framework.TestCase):
             "https://github.com/api?item=3&item=4",
             gr.Requester.add_parameters_to_url("https://github.com/api?item=1&item=2&item=3", {"item": [3, 4]}),
         )
+        self.assertEqual(
+            "https://github.com/api?all=true&participating=false",
+            gr.Requester.add_parameters_to_url("https://github.com/api", {"all": True, "participating": False}),
+        )
 
     def testCloseGithub(self):
         mocked_connection = mock.MagicMock()


### PR DESCRIPTION
Closes #3304.

**Problem:** `add_parameters_to_url` passes Python booleans straight to `urllib.parse.urlencode`, which renders them capitalized. So `get_notifications(all=True)` sends `all=True` instead of `all=true`. GitHub expects lowercase booleans and ignores the capitalized value, so the parameter has no effect.

```python
>>> import urllib.parse
>>> urllib.parse.urlencode([("all", True)])
'all=True'
```

**Fix:** Convert boolean values to lowercase strings before encoding.

**Test:** Added a case to `testAddParametersToUrl` covering `all`/`participating`. It fails on the current code (`all=True&participating=False`) and passes with the fix.