### PR TITLE
Parse only the query string for `PaginatedList.totalCount`

### DIFF
--- a/github/PaginatedList.py
+++ b/github/PaginatedList.py
@@ -59,7 +59,6 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator
 from typing import Any, Generic, TypeVar, overload
-from urllib.parse import parse_qs
 
 from github import Consts
 from github.GithubObject import GithubObject
@@ -281,7 +280,7 @@ class PaginatedList(PaginatedListBase[T]):
 
             # update totalCount
             if lastUrl:
-                self.__totalCount = int(parse_qs(lastUrl)["page"][0])
+                self.__totalCount = int(Requester.get_parameters_of_url(lastUrl)["page"][0])
             elif data and "total_count" in data:
                 self.__totalCount = data["total_count"]
             elif data:

--- a/tests/PaginatedList.py
+++ b/tests/PaginatedList.py
@@ -316,6 +316,11 @@ class PaginatedList(Framework.TestCase):
         repos = self.g.get_repos()
         self.assertEqual(0, repos.totalCount)
 
+    def testTotalCountWithLastPageAndPageFirst(self):
+        # the last link may list page before per_page, totalCount must still parse
+        repos = self.g.get_repos()
+        self.assertEqual(42, repos.totalCount)
+
     def testTotalCountWithDictionary(self):
         # PullRequest.get_review_requests() actually returns a dictionary that
         # we fudge into two lists, which means data is a dict, not a list.

--- a/tests/ReplayData/PaginatedList.testTotalCountWithLastPageAndPageFirst.txt
+++ b/tests/ReplayData/PaginatedList.testTotalCountWithLastPageAndPageFirst.txt
@@ -1,0 +1,10 @@
+https
+GET
+api.github.com
+None
+/repositories?per_page=1
+{'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
+None
+200
+[('Date', 'Mon, 03 Aug 2020 09:02:17 GMT'), ('Content-Type', 'application/json; charset=utf-8'), ('Transfer-Encoding', 'chunked'), ('Server', 'GitHub.com'), ('Status', '200 OK'), ('Link', '<https://api.github.com/repositories?page=42&per_page=1>; rel="last", <https://api.github.com/repositories?page=2&per_page=1>; rel="next", <https://api.github.com/repositories?page=1&per_page=1>; rel="first"')]
+[]


### PR DESCRIPTION
`PaginatedList` computed `totalCount` with `parse_qs(lastUrl)["page"][0]`, passing the whole URL to `parse_qs`. `parse_qs` expects only a query string, so it splits the entire URL and the first parameter's key ends up prefixed with the scheme/host/path. This only worked because GitHub conventionally puts `page` last in the `rel="last"` link. When `page` comes first (e.g. `...?page=42&per_page=1`), `["page"]` raises `KeyError`.

The fix uses `Requester.get_parameters_of_url`, which extracts the query string before `parse_qs` and is already used by the sibling pagination code in the same file.

Added `testTotalCountWithLastPageAndPageFirst` with a replay fixture whose `rel="last"` link lists `page` first. It raises `KeyError` on the current code and passes with the change; the full `tests/PaginatedList.py` suite passes.

Fixes: #3520, #1006.