### PR TITLE
Handle non-dict JSON error bodies in createException

### DIFF
--- a/github/Requester.py
+++ b/github/Requester.py
@@ -967,9 +967,9 @@ class Requester:
         cls,
         status: int,
         headers: dict[str, Any],
-        output: dict[str, Any],
+        output: Any,
     ) -> GithubException.GithubException:
-        message = output.get("message") if output else None
+        message = output.get("message") if isinstance(output, dict) else None
         lc_message = message.lower() if message else ""
 
         msg = None

--- a/tests/Requester.py
+++ b/tests/Requester.py
@@ -647,6 +647,16 @@ class Requester(Framework.TestCase):
                 exc = self.g._Github__requester.createException(status, {}, None)
                 self.assertException(exc, github.GithubException, None, status, None, {}, f"{status}")
 
+    def testShouldCreateExceptionWithNonDictOutput(self):
+        # GitHub can return a non-object JSON body (list, string, number, bool)
+        # for an error, for example during an incident. createException must not
+        # crash with AttributeError; it should still build a GithubException.
+        for output in ([{"url": "x"}], "boom", 42, True):
+            with self.subTest(output=output):
+                exc = self.g._Github__requester.createException(500, {}, output)
+                self.assertIsInstance(exc, github.GithubException)
+                self.assertEqual(exc.status, 500)
+
 
 class RequesterThrottleTestCase(Framework.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #2958.

`Requester.createException` assumed the parsed error body was a dict and called `output.get("message")`. GitHub can return a JSON list, string, number or bool as an error body (for example during an incident). The existing guard `output.get("message") if output else None` only screens out `None`/empty values, so a non-empty non-dict body raised `AttributeError` and masked the real HTTP error (the case reported in #2958, where a 500 returned a JSON list).

The lookup is now guarded with `isinstance(output, dict)`, and the `output` parameter type is widened to `Any` to reflect the actual input.

Added `testShouldCreateExceptionWithNonDictOutput`, which feeds a list, string, int and bool body and asserts a `GithubException` with the right status is produced. It fails on the previous code with `AttributeError` and passes with the fix.