### PR TITLE
Fix IndexError when slicing PaginatedList at or past the end

### DIFF
--- a/github/PaginatedList.py
+++ b/github/PaginatedList.py
@@ -130,7 +130,11 @@ class PaginatedListBase(Generic[T]):
             index = self.__start
             while not self.__finished(index):
                 if self.__list._isBiggerThan(index):
-                    yield self.__list[index]  # type: ignore
+                    try:
+                        element = self.__list[index]  # type: ignore
+                    except IndexError:
+                        return
+                    yield element
                     index += self.__step
                 else:
                     return

--- a/tests/PaginatedList.py
+++ b/tests/PaginatedList.py
@@ -292,6 +292,13 @@ class PaginatedList(Framework.TestCase):
                 ],
             )
 
+    def testSliceIndexingAtOrPastEnd(self):
+        # Slicing at or past the end must return [] like a plain list, not raise IndexError
+        with self.replayData("PaginatedList.testIteration.txt"):
+            self.assertEqual(list(self.list[333:]), [])
+            self.assertEqual(list(self.list[400:405]), [])
+            self.assertEqual(list(self.list[500::3]), [])
+
     def testInterruptedIteration(self):
         # No asserts, but checks that only three pages are fetched
         count = 0


### PR DESCRIPTION
Fixes #3522.

Slicing a `PaginatedList` at or beyond its real length (e.g. `pl[N:]`, `pl[N+2:N+5]`, `pl[N::3]`) raised `IndexError` instead of returning an empty result like a plain list.

`_isBiggerThan` returns `True` whenever more pages could be fetched, but after fetching the requested index may still be beyond the real length, so `PaginatedListBase.__getitem__` raised `IndexError`. This catches `IndexError` in `_Slice.__iter__` and stops iteration, matching plain-list slicing semantics.

Regression test added in `tests/PaginatedList.py::testSliceIndexingAtOrPastEnd` (fails on main with IndexError, passes with the fix).