### PR TITLE
Fix lazy "latest" GitRelease returning tag_name "latest"

### DIFF
--- a/github/GitRelease.py
+++ b/github/GitRelease.py
@@ -448,8 +448,9 @@ class GitRelease(CompletableGithubObject):
             self._tag_name = self._makeStringAttribute(attributes["tag_name"])
         elif "url" in attributes and attributes["url"] and isinstance(attributes["url"], str):
             quoted_tag_name = attributes["url"].split("/")[-1]
-            tag_name = urllib.parse.unquote(quoted_tag_name)
-            self._tag_name = self._makeStringAttribute(tag_name)
+            if quoted_tag_name != "latest":
+                tag_name = urllib.parse.unquote(quoted_tag_name)
+                self._tag_name = self._makeStringAttribute(tag_name)
         if "tarball_url" in attributes:
             self._tarball_url = self._makeStringAttribute(attributes["tarball_url"])
         if "target_commitish" in attributes:

--- a/tests/GitRelease.py
+++ b/tests/GitRelease.py
@@ -50,6 +50,7 @@ import os
 import zipfile
 from datetime import datetime, timezone
 
+import github.GitRelease
 from github import GithubException
 
 from . import Framework
@@ -222,6 +223,20 @@ class GitRelease(Framework.TestCase):
     def testGetLatestRelease(self):
         latest_release = self.repo.get_latest_release()
         self.assertEqual(latest_release.tag_name, tag)
+
+    def testLazyLatestReleaseDoesNotDeriveTagNameFromUrl(self):
+        # A lazily-constructed release pointing at .../releases/latest must not
+        # derive a tag_name of "latest" from the URL; _tag_name must stay NotSet
+        # so that lazy completion fetches the real tag_name.
+        from github.GithubObject import NotSet
+
+        release = github.GitRelease.GitRelease(
+            self.g.requester,
+            {},
+            {"url": "https://api.github.com/repos/edx/edx-platform/releases/latest"},
+            completed=False,
+        )
+        self.assertIs(release._tag_name, NotSet)
 
     def testGetAssets(self):
         repo = self.repo


### PR DESCRIPTION
Fixes #3486.

A `GitRelease` fetched via `get_latest_release()` has a URL ending in `.../releases/latest`. When `tag_name` was absent, `GitRelease._useAttributes` derived `tag_name` from the last URL path segment (`"latest"`) and marked `_tag_name` as set, which short-circuits lazy completion and returns the literal string `"latest"` instead of the real tag.

This skips the URL fallback when the last segment is `"latest"`, leaving `_tag_name` unset so lazy completion fetches the real `tag_name`.

Regression test added in `tests/GitRelease.py::testLazyLatestReleaseDoesNotDeriveTagNameFromUrl` (fails on main, passes with the fix).