### PR TITLE
Send correct UTC instant for timezone-aware query datetimes

### DIFF
--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -98,6 +98,7 @@ from github.GithubObject import (
     CompletableGithubObject,
     NotSet,
     Opt,
+    _format_query_datetime,
     is_defined,
     is_optional,
     is_optional_list,
@@ -755,7 +756,7 @@ class AuthenticatedUser(CompletableGithubObject):
         assert is_optional(since, datetime), since
         url_parameters: dict[str, Any] = {}
         if is_defined(since):
-            url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+            url_parameters["since"] = _format_query_datetime(since)
         return PaginatedList(github.Gist.Gist, self._requester, "/gists", url_parameters)
 
     def get_issues(
@@ -788,7 +789,7 @@ class AuthenticatedUser(CompletableGithubObject):
         if is_defined(direction):
             url_parameters["direction"] = direction
         if is_defined(since):
-            url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+            url_parameters["since"] = _format_query_datetime(since)
         return PaginatedList(github.Issue.Issue, self._requester, "/issues", url_parameters)
 
     def get_user_issues(
@@ -821,7 +822,7 @@ class AuthenticatedUser(CompletableGithubObject):
         if is_defined(direction):
             url_parameters["direction"] = direction
         if is_defined(since):
-            url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+            url_parameters["since"] = _format_query_datetime(since)
         return PaginatedList(github.Issue.Issue, self._requester, "/user/issues", url_parameters)
 
     def get_key(self, id: int) -> UserKey:
@@ -871,9 +872,9 @@ class AuthenticatedUser(CompletableGithubObject):
             # convert True, False to true, false for api parameters
             params["participating"] = "true" if participating else "false"
         if is_defined(since):
-            params["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+            params["since"] = _format_query_datetime(since)
         if is_defined(before):
-            params["before"] = before.strftime("%Y-%m-%dT%H:%M:%SZ")
+            params["before"] = _format_query_datetime(before)
 
         return PaginatedList(github.Notification.Notification, self._requester, "/notifications", params)
 
@@ -1013,7 +1014,7 @@ class AuthenticatedUser(CompletableGithubObject):
         if last_read_at is None:
             last_read_at = datetime.now(timezone.utc)
         assert isinstance(last_read_at, datetime)
-        put_parameters = {"last_read_at": last_read_at.strftime("%Y-%m-%dT%H:%M:%SZ")}
+        put_parameters = {"last_read_at": _format_query_datetime(last_read_at)}
 
         headers, data = self._requester.requestJsonAndCheck("PUT", "/notifications", input=put_parameters)
 

--- a/github/CheckRun.py
+++ b/github/CheckRun.py
@@ -50,6 +50,7 @@ from github.GithubObject import (
     CompletableGithubObject,
     NotSet,
     Opt,
+    _format_query_datetime,
     is_defined,
     is_optional,
     is_optional_list,
@@ -250,9 +251,9 @@ class CheckRun(CompletableGithubObject):
         if is_defined(status):
             post_parameters["status"] = status
         if is_defined(started_at):
-            post_parameters["started_at"] = started_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+            post_parameters["started_at"] = _format_query_datetime(started_at)
         if is_defined(completed_at):
-            post_parameters["completed_at"] = completed_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+            post_parameters["completed_at"] = _format_query_datetime(completed_at)
         if is_defined(conclusion):
             post_parameters["conclusion"] = conclusion
         if is_defined(output):

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -96,6 +96,20 @@ def _datetime_from_http_date(value: str) -> datetime:
     return dt
 
 
+def _format_query_datetime(dt: datetime) -> str:
+    """
+    Format a datetime as an ISO 8601 UTC string for use as a query parameter.
+
+    Timezone-aware datetimes are converted to UTC first, so the correct
+    instant is sent rather than the wall-clock fields with a literal "Z".
+
+    """
+
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def _datetime_from_github_isoformat(value: str) -> datetime:
     """
     Convert an GitHub API timestamps to a datetime object.

--- a/github/Issue.py
+++ b/github/Issue.py
@@ -90,6 +90,7 @@ from github.GithubObject import (
     CompletableGithubObject,
     NotSet,
     Opt,
+    _format_query_datetime,
     is_defined,
     is_optional,
     is_optional_list,
@@ -515,7 +516,7 @@ class Issue(CompletableGithubObject):
         url_parameters = {}
         if is_defined(since):
             assert isinstance(since, datetime), since
-            url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+            url_parameters["since"] = _format_query_datetime(since)
 
         return PaginatedList(
             github.IssueComment.IssueComment,

--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -134,6 +134,7 @@ from github.GithubObject import (
     NotSet,
     Opt,
     _NotSetType,
+    _format_query_datetime,
     is_defined,
     is_undefined,
 )
@@ -576,7 +577,7 @@ class Github:
         assert since is NotSet or isinstance(since, datetime), since
         url_parameters = dict()
         if is_defined(since):
-            url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+            url_parameters["since"] = _format_query_datetime(since)
         return PaginatedList(github.Gist.Gist, self.__requester, "/gists/public", url_parameters)
 
     def get_global_advisory(self, ghsa_id: str) -> GlobalAdvisory:

--- a/github/NamedUser.py
+++ b/github/NamedUser.py
@@ -68,7 +68,7 @@ import github.Permissions
 import github.Plan
 import github.Repository
 from github import Consts
-from github.GithubObject import Attribute, NotSet, Opt, is_defined, is_undefined
+from github.GithubObject import Attribute, NotSet, Opt, _format_query_datetime, is_defined, is_undefined
 from github.PaginatedList import PaginatedList
 
 if TYPE_CHECKING:
@@ -457,7 +457,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
         assert since is NotSet or isinstance(since, datetime), since
         url_parameters = dict()
         if is_defined(since):
-            url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+            url_parameters["since"] = _format_query_datetime(since)
         return github.PaginatedList.PaginatedList(
             github.Gist.Gist, self._requester, f"{self.url}/gists", url_parameters
         )

--- a/github/Organization.py
+++ b/github/Organization.py
@@ -124,6 +124,7 @@ from github.GithubObject import (
     CompletableGithubObject,
     NotSet,
     Opt,
+    _format_query_datetime,
     is_defined,
     is_optional,
     is_optional_list,
@@ -1245,7 +1246,7 @@ class Organization(CompletableGithubObject):
         if is_defined(labels):
             url_parameters["labels"] = ",".join(label.name for label in labels)
         if is_defined(since):
-            url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+            url_parameters["since"] = _format_query_datetime(since)
         return PaginatedList(github.Issue.Issue, self._requester, f"{self.url}/issues", url_parameters)
 
     def get_members(

--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -106,6 +106,7 @@ from github.GithubObject import (
     CompletableGithubObject,
     NotSet,
     Opt,
+    _format_query_datetime,
     is_defined,
     is_optional,
     is_optional_list,
@@ -685,7 +686,7 @@ class PullRequest(CompletableGithubObject):
 
         url_parameters = NotSet.remove_unset_items({"sort": sort, "direction": direction})
         if is_defined(since):
-            url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+            url_parameters["since"] = _format_query_datetime(since)
 
         return PaginatedList(
             github.PullRequestComment.PullRequestComment,

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -262,6 +262,7 @@ from github.GithubObject import (
     NotSet,
     Opt,
     _NotSetType,
+    _format_query_datetime,
     is_defined,
     is_optional,
     is_optional_list,
@@ -2450,9 +2451,9 @@ class Repository(CompletableGithubObject):
         if is_defined(path):
             url_parameters["path"] = path
         if is_defined(since):
-            url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+            url_parameters["since"] = _format_query_datetime(since)
         if is_defined(until):
-            url_parameters["until"] = until.strftime("%Y-%m-%dT%H:%M:%SZ")
+            url_parameters["until"] = _format_query_datetime(until)
         if is_defined(author):
             if isinstance(
                 author,
@@ -3238,7 +3239,7 @@ class Repository(CompletableGithubObject):
         if is_defined(direction):
             url_parameters["direction"] = direction
         if is_defined(since):
-            url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+            url_parameters["since"] = _format_query_datetime(since)
         if is_defined(creator):
             if isinstance(creator, str):
                 url_parameters["creator"] = creator
@@ -3268,7 +3269,7 @@ class Repository(CompletableGithubObject):
         if is_defined(direction):
             url_parameters["direction"] = direction
         if is_defined(since):
-            url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+            url_parameters["since"] = _format_query_datetime(since)
         return PaginatedList(
             github.IssueComment.IssueComment,
             self._requester,
@@ -3511,7 +3512,7 @@ class Repository(CompletableGithubObject):
         if is_defined(direction):
             url_parameters["direction"] = direction
         if is_defined(since):
-            url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+            url_parameters["since"] = _format_query_datetime(since)
         return PaginatedList(
             github.PullRequestComment.PullRequestComment,
             self._requester,
@@ -3927,9 +3928,9 @@ class Repository(CompletableGithubObject):
 
         params = NotSet.remove_unset_items({"all": all, "participating": participating})
         if is_defined(since):
-            params["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
+            params["since"] = _format_query_datetime(since)
         if is_defined(before):
-            params["before"] = before.strftime("%Y-%m-%dT%H:%M:%SZ")
+            params["before"] = _format_query_datetime(before)
 
         return PaginatedList(
             github.Notification.Notification,
@@ -3944,7 +3945,7 @@ class Repository(CompletableGithubObject):
         :param last_read_at: datetime
         """
         assert isinstance(last_read_at, datetime)
-        put_parameters = {"last_read_at": last_read_at.strftime("%Y-%m-%dT%H:%M:%SZ")}
+        put_parameters = {"last_read_at": _format_query_datetime(last_read_at)}
 
         headers, data = self._requester.requestJsonAndCheck("PUT", f"{self.url}/notifications", input=put_parameters)
 
@@ -4247,9 +4248,9 @@ class Repository(CompletableGithubObject):
         )
 
         if is_defined(started_at):
-            post_parameters["started_at"] = started_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+            post_parameters["started_at"] = _format_query_datetime(started_at)
         if is_defined(completed_at):
-            post_parameters["completed_at"] = completed_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+            post_parameters["completed_at"] = _format_query_datetime(completed_at)
 
         headers, data = self._requester.requestJsonAndCheck(
             "POST",

--- a/tests/GithubObject.py
+++ b/tests/GithubObject.py
@@ -243,6 +243,20 @@ class GithubObject(unittest.TestCase):
             self.assertEqual(int, e.exception.expected_type)
             self.assertIsNone(e.exception.transformation_exception)
 
+    def testFormatQueryDatetime(self):
+        # Aware datetimes must be converted to the correct UTC instant, not
+        # emitted as wall-clock fields with a literal "Z" (see issue #2282).
+        aware = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone(timedelta(hours=-5)))
+        self.assertEqual(gho._format_query_datetime(aware), "2024-01-01T17:00:00Z")
+
+        # UTC-aware datetimes are unchanged
+        utc = datetime(2024, 1, 1, 17, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(gho._format_query_datetime(utc), "2024-01-01T17:00:00Z")
+
+        # Naive datetimes are treated as-is (backwards compatible)
+        naive = datetime(2024, 1, 1, 17, 0, 0)
+        self.assertEqual(gho._format_query_datetime(naive), "2024-01-01T17:00:00Z")
+
 
 class CompletableGithubObjectWithPaginatedProperty(Framework.TestCase):
     def testRepoCommitFilesDefault(self):


### PR DESCRIPTION
Fixes #2282.

Query datetime parameters were formatted with `dt.strftime("%Y-%m-%dT%H:%M:%SZ")`, which emits the wall-clock fields plus a literal `Z` while discarding `tzinfo`. An aware datetime in a non-UTC zone was therefore sent as the wrong UTC instant. For example a `since` of `2024-01-01 12:00 -05:00` was sent as `2024-01-01T12:00:00Z` instead of `2024-01-01T17:00:00Z`.

This adds a `_format_query_datetime` helper in `github/GithubObject.py` that converts aware datetimes to UTC before formatting, and applies it at the ~24 query/body datetime call sites across `AuthenticatedUser`, `CheckRun`, `Issue`, `MainClass`, `NamedUser`, `Organization`, `PullRequest` and `Repository`.

- Naive datetimes keep their previous behavior (formatted as-is).
- The milestone `due_on` path, which also accepts a plain `date` (no `tzinfo`), is left unchanged.

Regression test added in `tests/GithubObject.py::testFormatQueryDatetime` (fails on main, passes with the fix). The full test suite passes (1123 passed, 1 skipped).