### PR TITLE
Fix BranchProtection.restrictions raising AttributeError

### DIFF
--- a/github/BranchProtection.py
+++ b/github/BranchProtection.py
@@ -213,7 +213,7 @@ class BranchProtection(github.GithubObject.CompletableGithubObject):
                 attributes["required_status_checks"],
             )
         if "restrictions" in attributes:  # pragma no branch
-            self._restrictions = attributes["restrictions"]
+            self._restrictions = self._makeDictAttribute(attributes["restrictions"])
             self._user_push_restrictions = attributes["restrictions"]["users_url"]
             self._team_push_restrictions = attributes["restrictions"]["teams_url"]
         if "url" in attributes:  # pragma no branch

--- a/tests/BranchProtection.py
+++ b/tests/BranchProtection.py
@@ -37,6 +37,10 @@
 
 from __future__ import annotations
 
+from unittest import mock
+
+import github.BranchProtection
+
 from . import Framework
 
 
@@ -79,3 +83,25 @@ class BranchProtection(Framework.TestCase):
         self.assertFalse(self.branch_protection.required_conversation_resolution)
         self.assertFalse(self.branch_protection.lock_branch)
         self.assertFalse(self.branch_protection.allow_fork_syncing)
+
+    def testRestrictionsPopulated(self):
+        # restrictions must be wrapped like every other attribute so that the
+        # restrictions property (which returns self._restrictions.value) works.
+        requester = mock.Mock(is_not_lazy=False)
+        restrictions = {
+            "url": "https://api.github.com/repos/owner/repo/branches/master/protection/restrictions",
+            "users_url": "https://api.github.com/repos/owner/repo/branches/master/protection/restrictions/users",
+            "teams_url": "https://api.github.com/repos/owner/repo/branches/master/protection/restrictions/teams",
+            "apps_url": "https://api.github.com/repos/owner/repo/branches/master/protection/restrictions/apps",
+            "users": [{"login": "octocat"}],
+            "teams": [{"slug": "justice-league"}],
+            "apps": [{"slug": "octoapp"}],
+        }
+        bp = github.BranchProtection.BranchProtection(requester, {}, {"restrictions": restrictions})
+        self.assertEqual(bp.restrictions["users"], [{"login": "octocat"}])
+        self.assertEqual(bp.restrictions["teams"], [{"slug": "justice-league"}])
+
+    def testRestrictionsAbsent(self):
+        requester = mock.Mock(is_not_lazy=False)
+        bp = github.BranchProtection.BranchProtection(requester, {}, {})
+        self.assertIsNone(bp.restrictions)


### PR DESCRIPTION
Fixes #3526.

### Problem

`BranchProtection.restrictions` raises `AttributeError: 'dict' object has no attribute 'value'` whenever push restrictions are present. The property returns `self._restrictions.value`, but `_useAttributes` stored the raw API dict instead of wrapping it like every other attribute. The absent-restrictions case only worked because `NotSet.value` is `None`.

### Solution

Wrap the value with `_makeDictAttribute`, consistent with how all other attributes are handled:

```python
self._restrictions = self._makeDictAttribute(attributes["restrictions"])
```

The `_user_push_restrictions` / `_team_push_restrictions` lines are left unchanged since they read raw URL strings and already work.

### Tests

Added two regression tests in `tests/BranchProtection.py` that construct a `BranchProtection` offline (mock requester, no network):

- `testRestrictionsPopulated` builds a populated top-level `restrictions` object and asserts `bp.restrictions["users"]` / `["teams"]` round-trip.
- `testRestrictionsAbsent` asserts an absent `restrictions` still yields `None`.

The populated test fails on `main` with the reported `AttributeError` and passes with the fix.