### PR TITLE
Fix selected-repository handling for org variables and secrets

### DIFF
--- a/github/OrganizationSecret.py
+++ b/github/OrganizationSecret.py
@@ -80,7 +80,7 @@ class OrganizationSecret(Secret):
         return PaginatedList(
             github.Repository.Repository,
             self._requester,
-            self._selected_repositories_url.value,
+            self.selected_repositories_url,
             None,
             list_item="repositories",
         )

--- a/github/OrganizationVariable.py
+++ b/github/OrganizationVariable.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import github.Repository
-from github.GithubObject import Attribute, NotSet
+from github.GithubObject import Attribute, NotSet, Opt, is_defined, is_optional_list
 from github.PaginatedList import PaginatedList
 from github.Variable import Variable
 
@@ -82,22 +82,26 @@ class OrganizationVariable(Variable):
         self,
         value: str,
         visibility: str = "all",
+        selected_repositories: Opt[list[Repository]] = NotSet,
     ) -> bool:
         """
         :calls: `PATCH /orgs/{org}/actions/variables/{name} <https://docs.github.com/en/rest/reference/actions/variables#update-an-organization-variable>`_
-        :param variable_name: string
         :param value: string
-        :param visibility: string
+        :param visibility: string options all, private or selected
+        :param selected_repositories: list of :class:`github.Repository.Repository`
         :rtype: bool
         """
         assert isinstance(value, str), value
         assert isinstance(visibility, str), visibility
+        assert is_optional_list(selected_repositories, github.Repository.Repository), selected_repositories
 
         patch_parameters: dict[str, Any] = {
             "name": self.name,
             "value": value,
             "visibility": visibility,
         }
+        if visibility == "selected" and is_defined(selected_repositories):
+            patch_parameters["selected_repository_ids"] = [element.id for element in selected_repositories]
 
         status, _, _ = self._requester.requestJson(
             "PATCH",

--- a/tests/Organization.py
+++ b/tests/Organization.py
@@ -663,6 +663,18 @@ class Organization(Framework.TestCase):
         variable = self.org.get_variable("variable-name")
         self.assertTrue(variable.edit("variable-value-updated"))
 
+    def testEditVariableSelected(self):
+        repos = [self.org.get_repo("TestPyGithub"), self.org.get_repo("FatherBeaver")]
+        variable = self.org.get_variable("variable-name")
+        self.assertTrue(variable.edit("variable-value-updated", visibility="selected", selected_repositories=repos))
+
+    def testLazySecretSelectedRepositories(self):
+        # A lazily loaded secret only knows its name/url; accessing selected_repositories
+        # must complete the object so the repositories URL is resolved rather than None.
+        secret = self.g.withLazy(True).get_organization("BeaverSoftware").get_secret("secret-name")
+        repos = list(secret.selected_repositories)
+        self.assertEqual([repo.name for repo in repos], ["TestPyGithub", "FatherBeaver"])
+
     def testEditSecret(self):
         secret = self.org.get_secret("secret-name")
         self.assertTrue(secret.edit("secret-value-updated"))

--- a/tests/ReplayData/Organization.testEditVariableSelected.txt
+++ b/tests/ReplayData/Organization.testEditVariableSelected.txt
@@ -1,0 +1,42 @@
+https
+GET
+api.github.com
+None
+/repos/BeaverSoftware/TestPyGithub
+{'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python', 'Accept': 'application/vnd.github.nebula-preview+json'}
+None
+200
+[('status', '200 OK'), ('x-ratelimit-remaining', '4992'), ('content-length', '1431'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"4ecd2c151a469cfa6cd45e6beff1269b"'), ('date', 'Fri, 01 Jun 2012 19:40:56 GMT'), ('content-type', 'application/json; charset=utf-8')]
+{"url":"https://api.github.com/repos/BeaverSoftware/TestPyGithub","name":"TestPyGithub","id":3609352,"full_name":"BeaverSoftware/TestPyGithub"}
+
+https
+GET
+api.github.com
+None
+/repos/BeaverSoftware/FatherBeaver
+{'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python', 'Accept': 'application/vnd.github.nebula-preview+json'}
+None
+200
+[('status', '200 OK'), ('x-ratelimit-remaining', '4992'), ('content-length', '1431'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"4ecd2c151a469cfa6cd45e6beff1269b"'), ('date', 'Fri, 01 Jun 2012 19:40:56 GMT'), ('content-type', 'application/json; charset=utf-8')]
+{"url":"https://api.github.com/repos/BeaverSoftware/FatherBeaver","name":"FatherBeaver","id":3400397,"full_name":"BeaverSoftware/FatherBeaver"}
+
+https
+GET
+api.github.com
+None
+/orgs/BeaverSoftware/actions/variables/variable-name
+{'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
+None
+200
+[('status', '200 OK'), ('x-ratelimit-remaining', '4978'), ('content-length', '487'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"1dd282b50e691f8f162ef9355dad8771"'), ('date', 'Thu, 10 May 2012 19:03:19 GMT'), ('content-type', 'application/json; charset=utf-8')]
+{"name": "variable-name","value": "variable-value","created_at": "2019-08-10T14:59:22Z","updated_at": "2020-01-10T14:59:22Z","visibility": "all","url": "https://api.github.com/orgs/BeaverSoftware/actions/variables/variable-name"}
+
+https
+PATCH
+api.github.com
+None
+/orgs/BeaverSoftware/actions/variables/variable-name
+{'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python', 'Content-Type': 'application/json'}
+{"name": "variable-name", "value": "variable-value-updated", "visibility": "selected", "selected_repository_ids": [3609352, 3400397]}
+204
+[('Server', 'GitHub.com'), ('Date', 'Wed, 28 Jun 2023 19:19:33 GMT'), ('X-OAuth-Scopes', 'admin:org'), ('X-Accepted-OAuth-Scopes', 'admin:org'), ('X-GitHub-Media-Type', 'github.v3; format=json'), ('x-github-api-version-selected', '2022-11-28'), ('X-RateLimit-Limit', '5000'), ('X-RateLimit-Remaining', '4998'), ('X-RateLimit-Reset', '1687981543'), ('X-RateLimit-Used', '2'), ('X-RateLimit-Resource', 'core'), ('Access-Control-Allow-Origin', '*'), ('Strict-Transport-Security', 'max-age=31536000; includeSubdomains; preload'), ('X-Frame-Options', 'deny'), ('X-Content-Type-Options', 'nosniff'), ('X-XSS-Protection', '0'), ('Referrer-Policy', 'origin-when-cross-origin, strict-origin-when-cross-origin'), ('Content-Security-Policy', "default-src 'none'"), ('Vary', 'Accept-Encoding, Accept, X-Requested-With')]

--- a/tests/ReplayData/Organization.testLazySecretSelectedRepositories.txt
+++ b/tests/ReplayData/Organization.testLazySecretSelectedRepositories.txt
@@ -1,0 +1,21 @@
+https
+GET
+api.github.com
+None
+/orgs/BeaverSoftware/actions/secrets/secret-name
+{'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
+None
+200
+[('status', '200 OK'), ('x-ratelimit-remaining', '4978'), ('content-length', '487'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"1dd282b50e691f8f162ef9355dad8771"'), ('date', 'Thu, 10 May 2012 19:03:19 GMT'), ('content-type', 'application/json; charset=utf-8')]
+{"name": "secret-name","created_at": "2019-08-10T14:59:22Z","updated_at": "2020-01-10T14:59:22Z","visibility": "selected","selected_repositories_url": "https://api.github.com/orgs/BeaverSoftware/actions/secrets/secret-name/repositories","url": "https://api.github.com/orgs/BeaverSoftware/actions/secrets/secret-name"}
+
+https
+GET
+api.github.com
+None
+/orgs/BeaverSoftware/actions/secrets/secret-name/repositories
+{'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
+None
+200
+[('status', '200 OK'), ('x-ratelimit-remaining', '4978'), ('content-length', '487'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"1dd282b50e691f8f162ef9355dad8771"'), ('date', 'Thu, 10 May 2012 19:03:19 GMT'), ('content-type', 'application/json; charset=utf-8')]
+{"total_count": 2, "repositories": [{"url":"https://api.github.com/repos/BeaverSoftware/TestPyGithub","name":"TestPyGithub","id":3609352,"full_name":"BeaverSoftware/TestPyGithub"}, {"url":"https://api.github.com/repos/BeaverSoftware/FatherBeaver","name":"FatherBeaver","id":3400397,"full_name":"BeaverSoftware/FatherBeaver"}]}


### PR DESCRIPTION
Fixes #3530

Two small, related fixes in the organization Actions secret/variable selected-repository handling.

## 1. OrganizationVariable.edit() selected repositories
Add a `selected_repositories` parameter and include `selected_repository_ids` when `visibility="selected"`, mirroring `Organization.create_variable`.

## 2. OrganizationSecret.selected_repositories lazy completion
The property read `self._selected_repositories_url.value` directly, bypassing lazy completion, so a lazily loaded secret produced a `PaginatedList` over a `None` URL (`ValueError` on iteration). Use the completing `selected_repositories_url` property.

## Tests
- `testEditVariableSelected` asserts (via replay data) the PATCH body carries `selected_repository_ids`.
- `testLazySecretSelectedRepositories` loads a lazy secret and iterates `selected_repositories`, asserting the object is completed first.

Both fail on HEAD (unexpected kwarg / `ValueError`) and pass with the fix.