### PR TITLE
Expand list-valued search qualifiers into repeated chunks

### DIFF
--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -693,6 +693,19 @@ class Github:
             url_parameters,
         )
 
+    @staticmethod
+    def _build_query_qualifiers(qualifiers: dict[str, Any]) -> list[str]:
+        # A list/tuple value must be expanded into repeated "qualifier:value" chunks
+        # (the GitHub-idiomatic form), otherwise it would be serialized as a Python
+        # list repr on the wire (e.g. "language:['python', 'ruby']").
+        chunks = []
+        for qualifier, value in qualifiers.items():
+            if isinstance(value, (list, tuple)):
+                chunks.extend(f"{qualifier}:{item}" for item in value)
+            else:
+                chunks.append(f"{qualifier}:{value}")
+        return chunks
+
     def search_repositories(
         self,
         query: str,
@@ -727,8 +740,7 @@ class Github:
         if query:  # pragma no branch (Should be covered)
             query_chunks.append(query)
 
-        for qualifier, value in qualifiers.items():
-            query_chunks.append(f"{qualifier}:{value}")
+        query_chunks.extend(self._build_query_qualifiers(qualifiers))
 
         url_parameters["q"] = " ".join(query_chunks)
         assert url_parameters["q"], "need at least one qualifier"
@@ -774,8 +786,7 @@ class Github:
         if query:
             query_chunks.append(query)
 
-        for qualifier, value in qualifiers.items():
-            query_chunks.append(f"{qualifier}:{value}")
+        query_chunks.extend(self._build_query_qualifiers(qualifiers))
 
         url_parameters["q"] = " ".join(query_chunks)
         assert url_parameters["q"], "need at least one qualifier"
@@ -821,8 +832,7 @@ class Github:
         if query:  # pragma no branch (Should be covered)
             query_chunks.append(query)
 
-        for qualifier, value in qualifiers.items():
-            query_chunks.append(f"{qualifier}:{value}")
+        query_chunks.extend(self._build_query_qualifiers(qualifiers))
 
         url_parameters["q"] = " ".join(query_chunks)
         assert url_parameters["q"], "need at least one qualifier"
@@ -865,8 +875,7 @@ class Github:
         if query:  # pragma no branch (Should be covered)
             query_chunks.append(query)
 
-        for qualifier, value in qualifiers.items():
-            query_chunks.append(f"{qualifier}:{value}")
+        query_chunks.extend(self._build_query_qualifiers(qualifiers))
 
         url_parameters["q"] = " ".join(query_chunks)
         assert url_parameters["q"], "need at least one qualifier"
@@ -915,8 +924,7 @@ class Github:
         if query:
             query_chunks.append(query)
 
-        for qualifier, value in qualifiers.items():
-            query_chunks.append(f"{qualifier}:{value}")
+        query_chunks.extend(self._build_query_qualifiers(qualifiers))
 
         url_parameters["q"] = " ".join(query_chunks)
         assert url_parameters["q"], "need at least one qualifier"
@@ -949,8 +957,7 @@ class Github:
         if query:  # pragma no branch (Should be covered)
             query_chunks.append(query)
 
-        for qualifier, value in qualifiers.items():
-            query_chunks.append(f"{qualifier}:{value}")
+        query_chunks.extend(self._build_query_qualifiers(qualifiers))
 
         url_parameters["q"] = " ".join(query_chunks)
         assert url_parameters["q"], "need at least one qualifier"

--- a/tests/Search.py
+++ b/tests/Search.py
@@ -299,3 +299,20 @@ class Search(Framework.TestCase):
         # Example taken from #236
         issues = self.g.search_issues("repo:saltstack/salt-api type:Issues updated:>2014-03-04T18:28:11Z")
         self.assertEqual(issues[0].id, 29138794)
+
+    def testSearchListQualifierExpandsToRepeatedChunks(self):
+        # A list-valued qualifier must expand into repeated "qualifier:value" chunks
+        # rather than being serialized as a Python list repr on the wire.
+        repos = self.g.search_repositories("x", language=["python", "ruby"])
+        q = repos._PaginatedList__firstParams["q"]
+        self.assertEqual(q, "x language:python language:ruby")
+
+    def testSearchTupleQualifierExpandsToRepeatedChunks(self):
+        repos = self.g.search_repositories("x", language=("python", "ruby"))
+        q = repos._PaginatedList__firstParams["q"]
+        self.assertEqual(q, "x language:python language:ruby")
+
+    def testSearchScalarQualifierUnchanged(self):
+        repos = self.g.search_repositories("x", language="python")
+        q = repos._PaginatedList__firstParams["q"]
+        self.assertEqual(q, "x language:python")


### PR DESCRIPTION
Fixes #3532

## Problem

The six `search_*` methods built qualifiers with `f"{qualifier}:{value}"`, so a list/tuple value was serialized as a Python list repr on the wire:

```python
g.search_repositories("x", language=["python", "ruby"])
# q -> "x language:['python', 'ruby']"
```

## Fix

Add a shared `_build_query_qualifiers` helper that expands list/tuple values into repeated `qualifier:value` chunks (the GitHub-idiomatic form) and leaves scalar values unchanged. Applied to all six search methods.

```python
# q -> "x language:python language:ruby"
```

Multi-word-value quoting is intentionally left unchanged.

## Tests

Added offline tests asserting the constructed `q` for list, tuple, and scalar qualifiers. The list/tuple tests fail on HEAD (list repr) and pass with the fix; the scalar test is unchanged behavior.