### PR TITLE
Remove invalid 'side' value from create_review_comment start_side

### DIFF
--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -487,7 +487,6 @@ class PullRequest(CompletableGithubObject):
         assert is_undefined(start_side) or start_side in [
             "LEFT",
             "RIGHT",
-            "side",
         ], start_side
         assert is_optional(in_reply_to, int), in_reply_to
         assert is_undefined(subject_type) or subject_type in [

--- a/tests/PullRequest.py
+++ b/tests/PullRequest.py
@@ -288,6 +288,19 @@ class PullRequest(Framework.TestCase):
         )
         self.assertEqual(comment.id, 886298)
 
+    def testCreateReviewCommentInvalidStartSide(self):
+        # "side" is not a valid start_side; only LEFT and RIGHT are accepted.
+        with self.assertRaises(AssertionError) as raisedexp:
+            self.pull.create_review_comment(
+                "Comment created by PyGithub",
+                "8a4f306d4b223682dd19410d4a9150636ebe4206",
+                "src/github/Issue.py",
+                10,
+                start_line=5,
+                start_side="side",
+            )
+        self.assertEqual(str(raisedexp.exception), "side")
+
     def testGetComments(self):
         epoch = datetime(1970, 1, 1, 0, 0)
         comments = self.pull.get_comments(sort="updated", direction="desc", since=epoch)


### PR DESCRIPTION
Fixes #3534

## Problem

`PullRequest.create_review_comment` allowed `start_side="side"`:

```python
assert is_undefined(start_side) or start_side in ["LEFT", "RIGHT", "side"], start_side
```

`"side"` is a copy/paste typo; GitHub accepts only `LEFT`/`RIGHT`.

## Fix

Remove `"side"` from the accepted values.

## Tests

Added `testCreateReviewCommentInvalidStartSide` asserting `start_side="side"` raises `AssertionError`. Fails on HEAD (no raise), passes with the fix.