### PR TITLE
Add support for workflow run pending deployments

### DIFF
--- a/github/PendingDeployment.py
+++ b/github/PendingDeployment.py
@@ -1,0 +1,85 @@
+############################ Copyrights and license ############################
+#                                                                              #
+# Copyright 2026 r1cksync <152320439+r1cksync@users.noreply.github.com>        #
+#                                                                              #
+# This file is part of PyGithub.                                               #
+# http://pygithub.readthedocs.io/                                              #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+################################################################################
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+import github.Environment
+from github.GithubObject import Attribute, NonCompletableGithubObject, NotSet
+
+if TYPE_CHECKING:
+    from github.Environment import Environment
+
+
+class PendingDeployment(NonCompletableGithubObject):
+    """
+    This class represents a pending deployment, i.e. a workflow-run deployment waiting on environment protection rules.
+
+    The reference can be found here
+    https://docs.github.com/en/rest/actions/workflow-runs#get-pending-deployments-for-a-workflow-run
+
+    The OpenAPI schema can be found at
+
+    - /components/schemas/pending-deployment
+
+    """
+
+    def _initAttributes(self) -> None:
+        self._environment: Attribute[Environment] = NotSet
+        self._wait_timer: Attribute[int] = NotSet
+        self._wait_timer_started_at: Attribute[datetime] = NotSet
+        self._current_user_can_approve: Attribute[bool] = NotSet
+        self._reviewers: Attribute[list[dict[str, Any]]] = NotSet
+
+    @property
+    def environment(self) -> Environment:
+        return self._environment.value
+
+    @property
+    def wait_timer(self) -> int:
+        return self._wait_timer.value
+
+    @property
+    def wait_timer_started_at(self) -> datetime:
+        return self._wait_timer_started_at.value
+
+    @property
+    def current_user_can_approve(self) -> bool:
+        return self._current_user_can_approve.value
+
+    @property
+    def reviewers(self) -> list[dict[str, Any]]:
+        return self._reviewers.value
+
+    def _useAttributes(self, attributes: dict[str, Any]) -> None:
+        if "environment" in attributes:  # pragma no branch
+            self._environment = self._makeClassAttribute(github.Environment.Environment, attributes["environment"])
+        if "wait_timer" in attributes:  # pragma no branch
+            self._wait_timer = self._makeIntAttribute(attributes["wait_timer"])
+        if "wait_timer_started_at" in attributes:  # pragma no branch
+            self._wait_timer_started_at = self._makeDatetimeAttribute(attributes["wait_timer_started_at"])
+        if "current_user_can_approve" in attributes:  # pragma no branch
+            self._current_user_can_approve = self._makeBoolAttribute(attributes["current_user_can_approve"])
+        if "reviewers" in attributes:  # pragma no branch
+            self._reviewers = self._makeListOfDictsAttribute(attributes["reviewers"])

--- a/github/WorkflowRun.py
+++ b/github/WorkflowRun.py
@@ -40,8 +40,10 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+import github.Deployment
 import github.GitCommit
 import github.NamedUser
+import github.PendingDeployment
 import github.PullRequest
 import github.Repository
 import github.WorkflowJob
@@ -50,8 +52,10 @@ from github.PaginatedList import PaginatedList
 
 if TYPE_CHECKING:
     from github.Artifact import Artifact
+    from github.Deployment import Deployment
     from github.GitCommit import GitCommit
     from github.NamedUser import NamedUser
+    from github.PendingDeployment import PendingDeployment
     from github.PullRequest import PullRequest
     from github.Repository import Repository
     from github.WorkflowJob import WorkflowJob
@@ -368,6 +372,35 @@ class WorkflowRun(CompletableGithubObject):
         """
         status, _, _ = self._requester.requestJson("DELETE", self.url)
         return status == 204
+
+    def get_pending_deployments(self) -> list[PendingDeployment]:
+        """
+        :calls: `GET /repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments <https://docs.github.com/en/rest/actions/workflow-runs#get-pending-deployments-for-a-workflow-run>`_
+        """
+        headers, data = self._requester.requestJsonAndCheck("GET", f"{self.url}/pending_deployments")
+        return [github.PendingDeployment.PendingDeployment(self._requester, headers, item) for item in data]
+
+    def review_pending_deployments(self, environment_ids: list[int], state: str, comment: str = "") -> list[Deployment]:
+        """
+        :calls: `POST /repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments <https://docs.github.com/en/rest/actions/workflow-runs#review-pending-deployments-for-a-workflow-run>`_
+        :param environment_ids: list of integers, the ids of the environments to approve or reject
+        :param state: string, either ``approved`` or ``rejected``
+        :param comment: string, a comment to accompany the deployment review
+        """
+        assert isinstance(environment_ids, list) and all(
+            isinstance(element, int) for element in environment_ids
+        ), environment_ids
+        assert state in ("approved", "rejected"), state
+        assert isinstance(comment, str), comment
+        post_parameters = {
+            "environment_ids": environment_ids,
+            "state": state,
+            "comment": comment,
+        }
+        headers, data = self._requester.requestJsonAndCheck(
+            "POST", f"{self.url}/pending_deployments", input=post_parameters
+        )
+        return [github.Deployment.Deployment(self._requester, headers, item, completed=True) for item in data]
 
     def jobs(self, _filter: Opt[str] = NotSet) -> PaginatedList[WorkflowJob]:
         """

--- a/tests/ReplayData/WorkflowRun.testGetPendingDeployments.txt
+++ b/tests/ReplayData/WorkflowRun.testGetPendingDeployments.txt
@@ -1,0 +1,10 @@
+https
+GET
+api.github.com
+None
+/repos/PyGithub/PyGithub/actions/runs/3881497935/pending_deployments
+{'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
+None
+200
+[('Server', 'GitHub.com'), ('Content-Type', 'application/json; charset=utf-8'), ('X-GitHub-Media-Type', 'github.v3; format=json'), ('x-github-api-version-selected', '2022-11-28'), ('status', '200 OK')]
+[{"environment":{"id":161088068,"node_id":"MDExOkVudmlyb25tZW50MTYxMDg4MDY4","name":"staging","url":"https://api.github.com/repos/PyGithub/PyGithub/environments/staging","html_url":"https://github.com/PyGithub/PyGithub/deployments/activity_log?environments_filter=staging"},"wait_timer":30,"wait_timer_started_at":"2020-11-23T22:00:40Z","current_user_can_approve":true,"reviewers":[{"type":"User","reviewer":{"login":"nuang-ee","id":50770626,"node_id":"MDQ6VXNlcjUwNzcwNjI2","type":"User"}},{"type":"Team","reviewer":{"id":1,"node_id":"MDQ6VGVhbTE=","name":"Justice League","slug":"justice-league"}}]}]

--- a/tests/ReplayData/WorkflowRun.testReviewPendingDeployments.txt
+++ b/tests/ReplayData/WorkflowRun.testReviewPendingDeployments.txt
@@ -1,0 +1,10 @@
+https
+POST
+api.github.com
+None
+/repos/PyGithub/PyGithub/actions/runs/3881497935/pending_deployments
+{'Content-Type': 'application/json', 'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
+{"environment_ids": [161088068], "state": "approved", "comment": "Ship it"}
+200
+[('Server', 'GitHub.com'), ('Content-Type', 'application/json; charset=utf-8'), ('X-GitHub-Media-Type', 'github.v3; format=json'), ('x-github-api-version-selected', '2022-11-28'), ('status', '200 OK')]
+[{"url":"https://api.github.com/repos/PyGithub/PyGithub/deployments/145988310","id":145988310,"node_id":"MDEwOkRlcGxveW1lbnQxNDU5ODgzMTA=","task":"deploy","original_environment":"staging","environment":"staging","description":"Deploy request from hubot","created_at":"2023-01-10T08:24:19Z","updated_at":"2023-01-10T08:24:19Z","statuses_url":"https://api.github.com/repos/PyGithub/PyGithub/deployments/145988310/statuses","repository_url":"https://api.github.com/repos/PyGithub/PyGithub","ref":"feat/workflow-run","sha":"c6e5cac67a58a4eb11f1f28567a77a6e2cc8ee98"}]

--- a/tests/WorkflowRun.py
+++ b/tests/WorkflowRun.py
@@ -194,6 +194,32 @@ class WorkflowRun(Framework.TestCase):
         wr = self.repo.get_workflow_run(3881497935)
         self.assertFalse(wr.delete())
 
+    def testGetPendingDeployments(self):
+        pending_deployments = self.workflow_run.get_pending_deployments()
+        self.assertEqual(len(pending_deployments), 1)
+        pending_deployment = pending_deployments[0]
+        self.assertEqual(pending_deployment.environment.id, 161088068)
+        self.assertEqual(pending_deployment.environment.name, "staging")
+        self.assertEqual(pending_deployment.wait_timer, 30)
+        self.assertEqual(
+            pending_deployment.wait_timer_started_at,
+            datetime(2020, 11, 23, 22, 0, 40, tzinfo=timezone.utc),
+        )
+        self.assertTrue(pending_deployment.current_user_can_approve)
+        self.assertEqual(len(pending_deployment.reviewers), 2)
+        self.assertEqual(pending_deployment.reviewers[0]["type"], "User")
+        self.assertEqual(pending_deployment.reviewers[0]["reviewer"]["login"], "nuang-ee")
+        self.assertEqual(pending_deployment.reviewers[1]["type"], "Team")
+        self.assertEqual(pending_deployment.reviewers[1]["reviewer"]["slug"], "justice-league")
+
+    def testReviewPendingDeployments(self):
+        deployments = self.workflow_run.review_pending_deployments([161088068], "approved", "Ship it")
+        self.assertEqual(len(deployments), 1)
+        self.assertEqual(deployments[0].id, 145988310)
+        self.assertEqual(deployments[0].environment, "staging")
+        self.assertEqual(deployments[0].ref, "feat/workflow-run")
+        self.assertEqual(deployments[0].task, "deploy")
+
     def test_jobs(self):
         self.assertListKeyEqual(
             self.workflow_run.jobs(),


### PR DESCRIPTION
This adds support for the GitHub Actions **deployment protection rules** API on `WorkflowRun`, which was previously not exposed by PyGithub.

### What's added

- **`WorkflowRun.get_pending_deployments()`** — `GET /repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments`. Returns the list of deployments for a run that are waiting on environment protection rules, as `PendingDeployment` objects.
- **`WorkflowRun.review_pending_deployments(environment_ids, state, comment="")`** — `POST .../pending_deployments`. Approves or rejects pending deployments for the given environments and returns the resulting `Deployment` objects.
- **New `PendingDeployment` class** (`NonCompletableGithubObject`) exposing `environment`, `wait_timer`, `wait_timer_started_at`, `current_user_can_approve` and `reviewers`.

### Tests

Two replay-based tests (`testGetPendingDeployments`, `testReviewPendingDeployments`) with hand-crafted fixtures cover both the GET and the POST paths, including reviewer parsing (User and Team) and the returned deployment objects. The full `tests/WorkflowRun.py` suite passes, and the changes are clean under `black`, `ruff`, `isort`, `docformatter` and `codespell`.

### References

- https://docs.github.com/en/rest/actions/workflow-runs#get-pending-deployments-for-a-workflow-run
- https://docs.github.com/en/rest/actions/workflow-runs#review-pending-deployments-for-a-workflow-run