### PR TITLE
feat: repositories-scoped app installation tokens

### DIFF
--- a/github/GithubIntegration.py
+++ b/github/GithubIntegration.py
@@ -262,7 +262,7 @@ class GithubIntegration:
         return self.auth.create_jwt(expiration)
 
     def get_access_token(
-        self, installation_id: int, permissions: dict[str, str] | None = None
+        self, installation_id: int, permissions: dict[str, str] | None = None, repositories: list[str] | None = None
     ) -> InstallationAuthorization:
         """
         :calls: `POST /app/installations/{installation_id}/access_tokens <https://docs.github.com/en/rest/apps/apps#create-an-installation-access-token-for-an-app>`
@@ -274,6 +274,11 @@ class GithubIntegration:
             raise GithubException(status=400, data={"message": "Invalid permissions"}, headers=None)
 
         body = {"permissions": permissions}
+        if repositories is not None:
+            if not isinstance(repositories, list):
+                raise GithubException(status=400, data={"message": "Invalid repositories"}, headers=None)
+            
+            body["repositories"] = repositories
         headers, response = self.__requester.requestJsonAndCheck(
             "POST",
             f"/app/installations/{installation_id}/access_tokens",

--- a/tests/GithubIntegration.py
+++ b/tests/GithubIntegration.py
@@ -343,6 +343,14 @@ class GithubIntegration(Framework.BasicTestCase):
         self.assertEqual(raisedexp.exception.message, "The permissions requested are not granted to this installation.")
         self.assertEqual(raisedexp.exception.status, 422)
 
+    def testGetAccessTokenWithInvalidRepositories(self):
+        auth = github.Auth.AppAuth(APP_ID, PRIVATE_KEY)
+        github_integration = github.GithubIntegration(auth=auth)
+        with self.assertRaises(github.GithubException) as raisedexp:
+            github_integration.get_access_token(self.repo_installation_id, repositories="invalid_data")
+        self.assertIsNone(raisedexp.exception.message)
+        self.assertEqual(raisedexp.exception.status, 400)
+        
     def testGetAccessTokenWithInvalidData(self):
         auth = github.Auth.AppAuth(APP_ID, PRIVATE_KEY)
         github_integration = github.GithubIntegration(auth=auth)


### PR DESCRIPTION
# Add support for Repositories-scoped App Installation tokens.

This adds a `repositories` optional parameter to `GitHubIntegration.get_access_token()`, which accepts a list of repository names.
This list will be passed as `repositories` parameter to the GH API call, so that the resulting token only has access to those specific repositories instead of all repositories the Installation has access to.
This allows least-privilege tokens.

As documented here:
https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app
