### PR TITLE
Add `max_rate_limit_wait` to `GithubRetry` to cap rate limit backoff

### DIFF
--- a/github/GithubException.py
+++ b/github/GithubException.py
@@ -136,6 +136,32 @@ class RateLimitExceededException(GithubException):
     """
 
 
+class RateLimitExceededExceedsMaxWait(RateLimitExceededException):
+    """
+    Exception raised when the wait required to respect a rate limit reset exceeds the configured
+    ``max_rate_limit_wait`` on ``GithubRetry``, instead of blocking until the rate limit resets.
+    """
+
+    def __init__(
+        self,
+        status: int,
+        data: Any = None,
+        headers: dict[str, str] | None = None,
+        message: str | None = None,
+        wait: float | None = None,
+    ):
+        super().__init__(status, data, headers, message)
+        self.__wait = wait
+
+    @property
+    def wait(self) -> float | None:
+        """
+        The backoff in seconds that would have been required to respect the rate limit reset, before it was capped by
+        ``max_rate_limit_wait``.
+        """
+        return self.__wait
+
+
 class BadAttributeException(Exception):
     """
     Exception raised when Github returns an attribute with the wrong type.

--- a/github/GithubRetry.py
+++ b/github/GithubRetry.py
@@ -45,7 +45,7 @@ from urllib3.connectionpool import ConnectionPool
 from urllib3.exceptions import MaxRetryError
 from urllib3.response import HTTPResponse
 
-from github.GithubException import GithubException
+from github.GithubException import GithubException, RateLimitExceededExceedsMaxWait
 from github.Requester import Requester
 
 DEFAULT_SECONDARY_RATE_WAIT: int = 60
@@ -72,12 +72,22 @@ class GithubRetry(Retry):
     # references the class, not the module (due to re-exporting in github/__init__.py)
     __datetime = datetime
 
-    def __init__(self, secondary_rate_wait: float = DEFAULT_SECONDARY_RATE_WAIT, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        secondary_rate_wait: float = DEFAULT_SECONDARY_RATE_WAIT,
+        max_rate_limit_wait: float | None = None,
+        **kwargs: Any,
+    ) -> None:
         """
         :param secondary_rate_wait: seconds to wait before retrying secondary rate limit errors
+        :param max_rate_limit_wait: maximum seconds to wait for a primary or secondary rate limit reset;
+            if the required backoff would exceed this, raises
+            :class:`~github.GithubException.RateLimitExceededExceedsMaxWait` instead of waiting.
+            ``None`` (the default) means no cap is applied.
         :param kwargs: see urllib3.Retry for more arguments
         """
         self.secondary_rate_wait = secondary_rate_wait
+        self.max_rate_limit_wait = max_rate_limit_wait
         # 403 is too broad to be retried, but GitHub API signals rate limits via 403
         # we retry 403 and look into the response header via Retry.increment
         # to determine if we really retry that 403
@@ -86,7 +96,7 @@ class GithubRetry(Retry):
         super().__init__(**kwargs)
 
     def new(self, **kw: Any) -> Self:
-        kw.update(dict(secondary_rate_wait=self.secondary_rate_wait))
+        kw.update(dict(secondary_rate_wait=self.secondary_rate_wait, max_rate_limit_wait=self.max_rate_limit_wait))
         return super().new(**kw)  # type: ignore
 
     def increment(  # type: ignore[override]
@@ -161,6 +171,18 @@ class GithubRetry(Retry):
                                         backoff = resetBackoff + 1
                             else:
                                 backoff = self.secondary_rate_wait
+                            if self.max_rate_limit_wait is not None and backoff > self.max_rate_limit_wait:
+                                self.__log(
+                                    logging.INFO,
+                                    f"Required backoff of {backoff}s exceeds "
+                                    f"max_rate_limit_wait of {self.max_rate_limit_wait}s".replace(".0s", "s"),
+                                )
+                                raise RateLimitExceededExceedsMaxWait(
+                                    response.status,  # type: ignore
+                                    content,  # type: ignore
+                                    response.headers,  # type: ignore
+                                    wait=backoff,
+                                )
 
                             # we backoff at least retry's next backoff
                             retry_backoff = retry.get_backoff_time()

--- a/github/GithubRetry.py
+++ b/github/GithubRetry.py
@@ -83,6 +83,7 @@ class GithubRetry(Retry):
         :param max_rate_limit_wait: maximum seconds to wait for a primary or secondary rate limit reset;
             if the required backoff would exceed this, raises
             :class:`~github.GithubException.RateLimitExceededExceedsMaxWait` instead of waiting.
+            Note that ``max_rate_limit_wait < secondary_rate_wait`` causes any secondary rate limit error to raise an exception and never wait.
             ``None`` (the default) means no cap is applied.
         :param kwargs: see urllib3.Retry for more arguments
         """

--- a/github/__init__.py
+++ b/github/__init__.py
@@ -59,6 +59,7 @@ from .GithubException import (
     BadUserAgentException,
     GithubException,
     IncompletableObject,
+    RateLimitExceededExceedsMaxWait,
     RateLimitExceededException,
     TwoFactorException,
     UnknownObjectException,
@@ -107,6 +108,7 @@ __all__ = [
     "InputGitAuthor",
     "InputGitTreeElement",
     "RateLimitExceededException",
+    "RateLimitExceededExceedsMaxWait",
     "TwoFactorException",
     "UnknownObjectException",
 ]

--- a/tests/GithubRetry.py
+++ b/tests/GithubRetry.py
@@ -406,3 +406,39 @@ class GithubRetry(unittest.TestCase):
             )
 
         log.assert_called_once_with(logging.INFO, "Request TEST URL failed with 403: NOT GOOD")
+
+    def test_primary_rate_error_exceeds_max_wait(self):
+        retry = github.GithubRetry(total=3, max_rate_limit_wait=10)
+        response = self.response_func(PrimaryRateLimitJson, 1644768012)
+
+        with self.mock_retry_now(1644768000):
+            # reset is 12 seconds away, +1s = 13s backoff, which exceeds max_rate_limit_wait=10
+            with self.assertRaises(github.RateLimitExceededExceedsMaxWait) as exp:
+                retry.increment("TEST", "URL", response())
+
+            self.assertEqual(13, exp.exception.wait)
+            self.assertEqual(403, exp.exception.status)
+            self.assertEqual(PrimaryRateLimitMessage, exp.exception.data.get("message"))
+
+    def test_primary_rate_error_within_max_wait(self):
+        retry = github.GithubRetry(total=3, max_rate_limit_wait=20)
+        response = self.response_func(PrimaryRateLimitJson, 1644768012)
+
+        with self.mock_retry_now(1644768000):
+            # reset is 12 seconds away, +1s = 13s backoff, under max_rate_limit_wait=20
+            retry = retry.increment("TEST", "URL", response())
+
+            self.assertEqual(2, retry.total)
+            self.assertEqual(13, retry.get_backoff_time())
+
+    def test_secondary_rate_error_exceeds_max_wait(self):
+        retry = github.GithubRetry(total=3, secondary_rate_wait=60, max_rate_limit_wait=10)
+        response = self.response_func(SecondaryRateLimitJson, reset=None)
+
+        # secondary backoff is fixed at secondary_rate_wait=60, which exceeds max_rate_limit_wait=10
+        with self.assertRaises(github.RateLimitExceededExceedsMaxWait) as exp:
+            retry.increment("TEST", "URL", response())
+
+        self.assertEqual(60, exp.exception.wait)
+        self.assertEqual(403, exp.exception.status)
+        self.assertEqual(SecondaryRateLimitMessage, exp.exception.data.get("message"))


### PR DESCRIPTION
## Problem

GithubRetry currently waits until X-RateLimit-Reset (primary rate limit) or
secondary_rate_wait (secondary rate limit) before retrying, with no way to cap
that wait. If GitHub reports a reset far in the future, callers with hard
timeouts (e.g. Celery tasks) end up blocked well past their own deadline.

## Approach

Adds an optional `max_rate_limit_wait` parameter to `GithubRetry.__init__`.
When the computed backoff for either a primary or secondary rate limit error
would exceed this cap, `GithubRetry.increment()` raises a new
`RateLimitExceededExceedsMaxWait` exception (subclass of
`RateLimitExceededException`) instead of waiting. The exception exposes
`.wait` (the backoff that would have been required) and the usual
`.status` / `.data` / `.headers` from `GithubException`, so callers can
inspect the raw rate-limit response and decide how to handle it themselves.

Defaults to `None` (no cap), so existing behavior is unchanged unless a
caller opts in.

## Tests

Added three tests in `tests/GithubRetry.py`:
- `test_primary_rate_error_exceeds_max_wait` — primary rate limit backoff
  exceeding the cap raises with the correct `.wait`/`.status`/`.data`
- `test_primary_rate_error_within_max_wait` — backoff under the cap still
  retries normally
- `test_secondary_rate_error_exceeds_max_wait` — same cap behavior on the
  secondary rate limit path

Fixes #3473