### PR TITLE
fix: raise instead of returning False for non-204/404 statuses

### DIFF
--- a/github/Artifact.py
+++ b/github/Artifact.py
@@ -140,7 +140,7 @@ class Artifact(NonCompletableGithubObject):
         :calls: `DELETE /repos/{owner}/{repo}/actions/artifacts/{artifact_id} <https://docs.github.com/en/rest/actions/artifacts#delete-an-artifact>`_
         """
         status, headers, data = self._requester.requestBlob("DELETE", self.url)
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:
         if "archive_download_url" in attributes:  # pragma no branch

--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -980,7 +980,7 @@ class AuthenticatedUser(CompletableGithubObject):
         """
         assert isinstance(following, github.NamedUser.NamedUser), following
         status, headers, data = self._requester.requestJson("GET", f"/user/following/{following._identity}")
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def has_in_starred(self, starred: Repository) -> bool:
         """
@@ -988,7 +988,7 @@ class AuthenticatedUser(CompletableGithubObject):
         """
         assert isinstance(starred, github.Repository.Repository), starred
         status, headers, data = self._requester.requestJson("GET", f"/user/starred/{starred._identity}")
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def has_in_subscriptions(self, subscription: Repository) -> bool:
         """
@@ -996,7 +996,7 @@ class AuthenticatedUser(CompletableGithubObject):
         """
         assert isinstance(subscription, github.Repository.Repository), subscription
         status, headers, data = self._requester.requestJson("GET", f"/user/subscriptions/{subscription._identity}")
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def has_in_watched(self, watched: Repository) -> bool:
         """

--- a/github/CommitComment.py
+++ b/github/CommitComment.py
@@ -220,12 +220,12 @@ class CommitComment(CompletableGithubObject):
         :rtype: bool
         """
         assert isinstance(reaction_id, int), reaction_id
-        status, _, _ = self._requester.requestJson(
+        status, headers, data = self._requester.requestJson(
             "DELETE",
             f"{self.url}/reactions/{reaction_id}",
             headers={"Accept": Consts.mediaTypeReactionsPreview},
         )
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:
         if "author_association" in attributes:  # pragma no branch

--- a/github/Environment.py
+++ b/github/Environment.py
@@ -263,7 +263,7 @@ class Environment(CompletableGithubObject):
         """
         assert isinstance(secret_name, str), secret_name
         status, headers, data = self._requester.requestJson("DELETE", f"{self.url}/secrets/{secret_name}")
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def delete_variable(self, variable_name: str) -> bool:
         """
@@ -273,7 +273,7 @@ class Environment(CompletableGithubObject):
         """
         assert isinstance(variable_name, str), variable_name
         status, headers, data = self._requester.requestJson("DELETE", f"{self.url}/variables/{variable_name}")
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:
         if "created_at" in attributes:  # pragma no branch

--- a/github/Gist.py
+++ b/github/Gist.py
@@ -288,7 +288,7 @@ class Gist(CompletableGithubObject):
         :calls: `GET /gists/{gist_id}/star <https://docs.github.com/en/rest/reference/gists>`_
         """
         status, headers, data = self._requester.requestJson("GET", f"{self.url}/star")
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def reset_starred(self) -> None:
         """

--- a/github/Issue.py
+++ b/github/Issue.py
@@ -694,12 +694,12 @@ class Issue(CompletableGithubObject):
         :calls: `DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id} <https://docs.github.com/en/rest/reference/reactions#delete-an-issue-reaction>`_
         """
         assert isinstance(reaction_id, int), reaction_id
-        status, _, _ = self._requester.requestJson(
+        status, headers, data = self._requester.requestJson(
             "DELETE",
             f"{self.url}/reactions/{reaction_id}",
             headers={"Accept": Consts.mediaTypeReactionsPreview},
         )
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def get_timeline(self) -> PaginatedList[TimelineEvent]:
         """

--- a/github/IssueComment.py
+++ b/github/IssueComment.py
@@ -222,12 +222,12 @@ class IssueComment(CompletableGithubObject):
                 <https://docs.github.com/en/rest/reference/reactions#delete-an-issue-comment-reaction>`_
         """
         assert isinstance(reaction_id, int), reaction_id
-        status, _, _ = self._requester.requestJson(
+        status, headers, data = self._requester.requestJson(
             "DELETE",
             f"{self.url}/reactions/{reaction_id}",
             headers={"Accept": Consts.mediaTypeReactionsPreview},
         )
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def minimize(self, reason: str = "OUTDATED") -> bool:
         """

--- a/github/NamedUser.py
+++ b/github/NamedUser.py
@@ -584,7 +584,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
         """
         assert isinstance(following, github.NamedUser.NamedUser), following
         status, headers, data = self._requester.requestJson("GET", f"{self.url}/following/{following._identity}")
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def get_organization_membership(self, org: str | Organization) -> Membership:
         """
@@ -798,7 +798,7 @@ class OrganizationInvitation(NamedUser):
         :rtype: bool
         """
         status, headers, data = self._requester.requestJson("DELETE", self.url)
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:
         super()._useAttributes(attributes)

--- a/github/Organization.py
+++ b/github/Organization.py
@@ -1466,7 +1466,7 @@ class Organization(CompletableGithubObject):
         """
         assert isinstance(invitee, github.NamedUser.NamedUser), invitee
         status, headers, data = self._requester.requestJson("DELETE", f"{self.url}/invitations/{invitee.id}")
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def has_in_members(self, member: NamedUser) -> bool:
         """
@@ -1478,7 +1478,7 @@ class Organization(CompletableGithubObject):
         status, headers, data = self._requester.requestJson("GET", f"{self.url}/members/{member._identity}")
         if status == 302:
             status, headers, data = self._requester.requestJson("GET", headers["location"])
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def has_in_public_members(self, public_member: NamedUser) -> bool:
         """
@@ -1490,7 +1490,7 @@ class Organization(CompletableGithubObject):
         status, headers, data = self._requester.requestJson(
             "GET", f"{self.url}/public_members/{public_member._identity}"
         )
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def remove_from_membership(self, member: NamedUser) -> None:
         """

--- a/github/OrganizationSecret.py
+++ b/github/OrganizationSecret.py
@@ -110,12 +110,12 @@ class OrganizationSecret(Secret):
             "visibility": visibility,
         }
 
-        status, _, _ = self._requester.requestJson(
+        status, headers, data = self._requester.requestJson(
             "PATCH",
             self.url,
             input=patch_parameters,
         )
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def add_repo(self, repo: Repository) -> bool:
         """

--- a/github/OrganizationVariable.py
+++ b/github/OrganizationVariable.py
@@ -99,12 +99,12 @@ class OrganizationVariable(Variable):
             "visibility": visibility,
         }
 
-        status, _, _ = self._requester.requestJson(
+        status, headers, data = self._requester.requestJson(
             "PATCH",
             self.url,
             input=patch_parameters,
         )
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def add_repo(self, repo: Repository) -> bool:
         """

--- a/github/ProjectCard.py
+++ b/github/ProjectCard.py
@@ -206,12 +206,12 @@ class ProjectCard(NonCompletableGithubObject):
         """
         :calls: `DELETE /projects/columns/cards/{card_id} <https://docs.github.com/en/rest/reference/projects#cards>`_
         """
-        status, _, _ = self._requester.requestJson(
+        status, headers, data = self._requester.requestJson(
             "DELETE",
             self.url,
             headers={"Accept": Consts.mediaTypeProjectsPreview},
         )
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def edit(self, note: Opt[str] = NotSet, archived: Opt[bool] = NotSet) -> None:
         """

--- a/github/ProjectColumn.py
+++ b/github/ProjectColumn.py
@@ -183,12 +183,12 @@ class ProjectColumn(NonCompletableGithubObject):
         """
         :calls: `DELETE /projects/columns/{column_id} <https://docs.github.com/en/rest/reference/projects#delete-a-project-column>`_
         """
-        status, _, _ = self._requester.requestJson(
+        status, headers, data = self._requester.requestJson(
             "DELETE",
             self.url,
             headers={"Accept": Consts.mediaTypeProjectsPreview},
         )
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def edit(self, name: str) -> None:
         """

--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -854,7 +854,7 @@ class PullRequest(CompletableGithubObject):
         :calls: `GET /repos/{owner}/{repo}/pulls/{pull_number}/merge <https://docs.github.com/en/rest/reference/pulls>`_
         """
         status, headers, data = self._requester.requestJson("GET", f"{self.url}/merge")
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def restore_branch(self) -> GitRef:
         """

--- a/github/PullRequestComment.py
+++ b/github/PullRequestComment.py
@@ -319,12 +319,12 @@ class PullRequestComment(CompletableGithubObject):
         :rtype: bool
         """
         assert isinstance(reaction_id, int), reaction_id
-        status, _, _ = self._requester.requestJson(
+        status, headers, data = self._requester.requestJson(
             "DELETE",
             f"{self.url}/reactions/{reaction_id}",
             headers={"Accept": Consts.mediaTypeReactionsPreview},
         )
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:
         if "_links" in attributes:  # pragma no branch

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -2009,7 +2009,7 @@ class Repository(CompletableGithubObject):
         assert is_optional(client_payload, dict), client_payload
         post_parameters = NotSet.remove_unset_items({"event_type": event_type, "client_payload": client_payload})
         status, headers, data = self._requester.requestJson("POST", f"{self.url}/dispatches", input=post_parameters)
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def create_secret(
         self,
@@ -2135,7 +2135,7 @@ class Repository(CompletableGithubObject):
         assert secret_type in ["actions", "dependabot"], "secret_type should be actions or dependabot"
         secret_name = urllib.parse.quote(secret_name, safe="")
         status, headers, data = self._requester.requestJson("DELETE", f"{self.url}/{secret_type}/secrets/{secret_name}")
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def delete_variable(self, variable_name: str) -> bool:
         """
@@ -2146,7 +2146,7 @@ class Repository(CompletableGithubObject):
         assert isinstance(variable_name, str), variable_name
         variable_name = urllib.parse.quote(variable_name, safe="")
         status, headers, data = self._requester.requestJson("DELETE", f"{self.url}/actions/variables/{variable_name}")
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def create_source_import(
         self,
@@ -3847,7 +3847,7 @@ class Repository(CompletableGithubObject):
             assignee = urllib.parse.quote(assignee, safe="")
 
         status, headers, data = self._requester.requestJson("GET", f"{self.url}/assignees/{assignee}")
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def has_in_collaborators(self, collaborator: str | NamedUser) -> bool:
         """
@@ -3863,7 +3863,7 @@ class Repository(CompletableGithubObject):
             collaborator = urllib.parse.quote(collaborator, safe="")
 
         status, headers, data = self._requester.requestJson("GET", f"{self.url}/collaborators/{collaborator}")
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def _legacy_convert_issue(self, attributes: dict[str, Any]) -> dict[str, Any]:
         convertedAttributes = {
@@ -4002,36 +4002,36 @@ class Repository(CompletableGithubObject):
         :calls: `GET /repos/{owner}/{repo}/vulnerability-alerts <https://docs.github.com/en/rest/reference/repos>`_
         :rtype: bool
         """
-        status, _, _ = self._requester.requestJson(
+        status, headers, data = self._requester.requestJson(
             "GET",
             f"{self.url}/vulnerability-alerts",
             headers={"Accept": Consts.vulnerabilityAlertsPreview},
         )
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def enable_vulnerability_alert(self) -> bool:
         """
         :calls: `PUT /repos/{owner}/{repo}/vulnerability-alerts <https://docs.github.com/en/rest/reference/repos>`_
         :rtype: bool
         """
-        status, _, _ = self._requester.requestJson(
+        status, headers, data = self._requester.requestJson(
             "PUT",
             f"{self.url}/vulnerability-alerts",
             headers={"Accept": Consts.vulnerabilityAlertsPreview},
         )
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def disable_vulnerability_alert(self) -> bool:
         """
         :calls: `DELETE /repos/{owner}/{repo}/vulnerability-alerts <https://docs.github.com/en/rest/reference/repos>`_
         :rtype: bool
         """
-        status, _, _ = self._requester.requestJson(
+        status, headers, data = self._requester.requestJson(
             "DELETE",
             f"{self.url}/vulnerability-alerts",
             headers={"Accept": Consts.vulnerabilityAlertsPreview},
         )
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def get_automated_security_fixes(self) -> dict[str, bool]:
         """
@@ -4050,24 +4050,24 @@ class Repository(CompletableGithubObject):
         :calls: `PUT /repos/{owner}/{repo}/automated-security-fixes <https://docs.github.com/en/rest/reference/repos>`_
         :rtype: bool
         """
-        status, _, _ = self._requester.requestJson(
+        status, headers, data = self._requester.requestJson(
             "PUT",
             f"{self.url}/automated-security-fixes",
             headers={"Accept": Consts.automatedSecurityFixes},
         )
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def disable_automated_security_fixes(self) -> bool:
         """
         :calls: `DELETE /repos/{owner}/{repo}/automated-security-fixes <https://docs.github.com/en/rest/reference/repos>`_
         :rtype: bool
         """
-        status, _, _ = self._requester.requestJson(
+        status, headers, data = self._requester.requestJson(
             "DELETE",
             f"{self.url}/automated-security-fixes",
             headers={"Accept": Consts.automatedSecurityFixes},
         )
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def remove_from_collaborators(self, collaborator: str | NamedUser) -> None:
         """
@@ -4097,8 +4097,8 @@ class Repository(CompletableGithubObject):
         if isinstance(runner, github.SelfHostedActionsRunner.SelfHostedActionsRunner):
             runner = runner.id
 
-        status, _, _ = self._requester.requestJson("DELETE", f"{self.url}/actions/runners/{runner}")
-        return status == 204
+        status, headers, data = self._requester.requestJson("DELETE", f"{self.url}/actions/runners/{runner}")
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def remove_autolink(self, autolink: Autolink | int) -> bool:
         """
@@ -4109,10 +4109,10 @@ class Repository(CompletableGithubObject):
         is_autolink = isinstance(autolink, github.Autolink.Autolink)
         assert is_autolink or isinstance(autolink, int), autolink
 
-        status, _, _ = self._requester.requestJson(
+        status, headers, data = self._requester.requestJson(
             "DELETE", f"{self.url}/autolinks/{autolink.id if is_autolink else autolink}"  # type: ignore
         )
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def subscribe_to_hub(self, event: str, callback: str, secret: Opt[str] = NotSet) -> None:
         """

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -667,6 +667,29 @@ class Requester:
             ),
         )
 
+    def checkStatusOrRaise(
+        self,
+        status: int,
+        responseHeaders: dict[str, Any],
+        output: str,
+        false_status: int = 404,
+    ) -> bool:
+        """
+        Interpret a response status as a boolean, for endpoints that use ``204`` to mean
+        ``True`` and ``false_status`` (``404`` by default) to mean ``False``.
+
+        Any other status, such as ``401`` or ``403``, is treated as an error and raises,
+        instead of being silently interpreted as ``False``.
+
+        :raises: :class:`GithubException.GithubException` for any status code other than
+            ``204`` and ``false_status``
+        """
+        if status == 204:
+            return True
+        if status == false_status:
+            return False
+        raise self.createException(status, responseHeaders, self.__structuredFromJson(output))
+
     def requestMultipartAndCheck(
         self,
         verb: str,

--- a/github/Team.py
+++ b/github/Team.py
@@ -375,12 +375,12 @@ class Team(CompletableGithubObject):
         put_parameters = {
             "permission": permission,
         }
-        status, _, _ = self._requester.requestJson(
+        status, headers, data = self._requester.requestJson(
             "PUT",
             f"{self.organization.url}/teams/{self.slug}/repos/{github.Repository.Repository.as_url_param(repo)}",
             input=put_parameters,
         )
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def delete(self) -> None:
         """
@@ -486,7 +486,7 @@ class Team(CompletableGithubObject):
         """
         assert isinstance(member, github.NamedUser.NamedUser), member
         status, headers, data = self._requester.requestJson("GET", f"{self.url}/members/{member._identity}")
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def has_in_repos(self, repo: str | Repository) -> bool:
         """
@@ -496,7 +496,7 @@ class Team(CompletableGithubObject):
         status, headers, data = self._requester.requestJson(
             "GET", f"{self.url}/repos/{github.Repository.Repository.as_url_param(repo)}"
         )
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def remove_membership(self, member: NamedUser) -> None:
         """

--- a/github/Variable.py
+++ b/github/Variable.py
@@ -119,12 +119,12 @@ class Variable(CompletableGithubObject):
             "name": self.name,
             "value": value,
         }
-        status, _, _ = self._requester.requestJson(
+        status, headers, data = self._requester.requestJson(
             "PATCH",
             self.url,
             input=patch_parameters,
         )
-        return status == 204
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def delete(self) -> None:
         """

--- a/github/Workflow.py
+++ b/github/Workflow.py
@@ -183,6 +183,8 @@ class Workflow(CompletableGithubObject):
             self._requester.requestJsonAndCheck("POST", url, input=input)
             return True
         else:
+            # Deliberately swallows every non-204 status (not just 404) as False here: this
+            # branch only exists for callers that opted out of exceptions via throw=False.
             status, _, _ = self._requester.requestJson("POST", url, input=input)
             return status == 204
 
@@ -240,16 +242,16 @@ class Workflow(CompletableGithubObject):
         :calls: `PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/disable <https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#disable-a-workflow>`_
         :rtype: bool
         """
-        status, _, _ = self._requester.requestJson("PUT", f"{self.url}/disable")
-        return status == 204
+        status, headers, data = self._requester.requestJson("PUT", f"{self.url}/disable")
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def enable(self) -> bool:
         """
         :calls: `PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/enable <https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#enable-a-workflow>`_
         :rtype: bool
         """
-        status, _, _ = self._requester.requestJson("PUT", f"{self.url}/enable")
-        return status == 204
+        status, headers, data = self._requester.requestJson("PUT", f"{self.url}/enable")
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:
         if "badge_url" in attributes:  # pragma no branch

--- a/github/WorkflowRun.py
+++ b/github/WorkflowRun.py
@@ -366,8 +366,8 @@ class WorkflowRun(CompletableGithubObject):
         """
         :calls: `DELETE /repos/{owner}/{repo}/actions/runs/{run_id} <https://docs.github.com/en/rest/reference/actions#workflow-runs>`_
         """
-        status, _, _ = self._requester.requestJson("DELETE", self.url)
-        return status == 204
+        status, headers, data = self._requester.requestJson("DELETE", self.url)
+        return self._requester.checkStatusOrRaise(status, headers, data)
 
     def jobs(self, _filter: Opt[str] = NotSet) -> PaginatedList[WorkflowJob]:
         """

--- a/tests/Organization.py
+++ b/tests/Organization.py
@@ -351,7 +351,10 @@ class Organization(Framework.TestCase):
         lyloa = self.g.get_user("Lyloa")
         self.assertTrue(self.org.has_in_members(lyloa))
         self.org.remove_from_members(lyloa)
-        self.assertFalse(self.org.has_in_members(lyloa))
+        with self.assertRaises(github.GithubException) as raisedexp:
+            self.org.has_in_members(lyloa)
+        self.assertEqual(raisedexp.exception.status, 403)
+        self.assertEqual(raisedexp.exception.data["message"], "You need to be a member")
 
     def testGetRepos(self):
         repos = self.org.get_repos()

--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -2500,8 +2500,12 @@ class LazyRepository(Framework.TestCase):
 
     def testChangeAutomateFixWhenNoVulnerabilityAlert(self):
         lazy_repo = self.getLazyRepository()
-        self.assertFalse(lazy_repo.enable_automated_security_fixes())
-        self.assertFalse(lazy_repo.disable_automated_security_fixes())
+        with self.assertRaises(github.GithubException) as raisedexp:
+            lazy_repo.enable_automated_security_fixes()
+        self.assertEqual(raisedexp.exception.status, 422)
+        with self.assertRaises(github.GithubException) as raisedexp:
+            lazy_repo.disable_automated_security_fixes()
+        self.assertEqual(raisedexp.exception.status, 422)
 
     def testGetVulnerabilityAlertWhenTurnedOff(self):
         lazy_repo = self.getEagerRepository()

--- a/tests/Requester.py
+++ b/tests/Requester.py
@@ -647,6 +647,31 @@ class Requester(Framework.TestCase):
                 exc = self.g._Github__requester.createException(status, {}, None)
                 self.assertException(exc, github.GithubException, None, status, None, {}, f"{status}")
 
+    def testCheckStatusOrRaiseTrueOn204(self):
+        requester = self.g._Github__requester
+        self.assertTrue(requester.checkStatusOrRaise(204, {}, ""))
+
+    def testCheckStatusOrRaiseFalseOn404(self):
+        requester = self.g._Github__requester
+        self.assertFalse(requester.checkStatusOrRaise(404, {}, ""))
+
+    def testCheckStatusOrRaiseFalseOnCustomFalseStatus(self):
+        requester = self.g._Github__requester
+        self.assertFalse(requester.checkStatusOrRaise(302, {}, "", false_status=302))
+        # 404 is no longer treated as False when a different false_status was requested.
+        with self.assertRaises(github.GithubException):
+            requester.checkStatusOrRaise(404, {}, "", false_status=302)
+
+    def testCheckStatusOrRaiseRaisesOnUnexpectedStatus(self):
+        # Regression test for https://github.com/PyGithub/PyGithub/issues/2760:
+        # any status other than 204/404 (such as an expired token returning 401) used to be
+        # silently swallowed as False, hiding the real error from the caller.
+        requester = self.g._Github__requester
+        with self.assertRaises(github.BadCredentialsException) as raisedexp:
+            requester.checkStatusOrRaise(401, {}, '{"message": "Bad credentials"}')
+        self.assertEqual(raisedexp.exception.status, 401)
+        self.assertEqual(raisedexp.exception.data["message"], "Bad credentials")
+
 
 class RequesterThrottleTestCase(Framework.TestCase):
     def setUp(self):

--- a/tests/Workflow.py
+++ b/tests/Workflow.py
@@ -170,7 +170,10 @@ class Workflow(Framework.TestCase):
 
     def testDisabledWhenAlreadyDisabled(self):
         workflow = self.g.get_repo("nickrmcclorey/PyGithub").get_workflow("ci.yml")
-        self.assertFalse(workflow.disable())
+        with self.assertRaises(GithubException) as raisedexp:
+            workflow.disable()
+        self.assertEqual(raisedexp.exception.status, 403)
+        self.assertEqual(raisedexp.exception.data["message"], "Unable to disable a workflow that is not active.")
 
     def testEnable(self):
         workflow = self.g.get_repo("nickrmcclorey/PyGithub").get_workflow("ci.yml")

--- a/tests/WorkflowRun.py
+++ b/tests/WorkflowRun.py
@@ -35,6 +35,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from github import GithubException
+
 from . import Framework
 
 
@@ -192,7 +194,10 @@ class WorkflowRun(Framework.TestCase):
 
     def test_delete(self):
         wr = self.repo.get_workflow_run(3881497935)
-        self.assertFalse(wr.delete())
+        with self.assertRaises(GithubException) as raisedexp:
+            wr.delete()
+        self.assertEqual(raisedexp.exception.status, 403)
+        self.assertEqual(raisedexp.exception.data["message"], "Must have admin rights to Repository.")
 
     def test_jobs(self):
         self.assertListKeyEqual(


### PR DESCRIPTION
## Problem

A bunch of boolean-returning methods (`PullRequest.is_merged`, `Organization.has_in_members`, `Workflow.disable`/`enable`, various `delete()` methods, etc.) follow this pattern:

```python
status, headers, data = self._requester.requestJson(...)
return status == 204
```

Any status other than 204 is treated as `False`. That includes real errors like an expired token (401) or missing permissions (403), which get silently swallowed. Callers can't tell "the answer is no" apart from "the request failed for an unrelated reason". Fixes #2760, where this was hit with `PullRequest.is_merged()` returning `False` for an expired GitHub App token instead of raising.

## Fix

Added `Requester.checkStatusOrRaise(status, headers, output, false_status=404)`: returns `True` for 204, `False` for `false_status` (404 by default, since that's how these "does X exist / is X true" endpoints are documented), and raises the normal `GithubException` for anything else. Switched every call site using the old `status == 204` pattern over to it (34 spots across `Repository`, `Organization`, `Team`, `NamedUser`, `AuthenticatedUser`, `Workflow`, `WorkflowRun`, `PullRequest`, `Gist`, `Issue`/`IssueComment`/`PullRequestComment`/`CommitComment` reactions, `Environment`, `Artifact`, `ProjectCard`/`ProjectColumn`, `Variable`, `OrganizationVariable`/`OrganizationSecret`).

`Workflow.create_dispatch` keeps its old behavior in the `throw=False` branch on purpose, since that parameter already exists specifically so callers can opt out of exceptions.

## Testing

Running the existing test suite surfaced a handful of tests whose recorded replay fixtures actually contain 403/422 error responses (e.g. "Vulnerability alerts must be enabled to configure automated security fixes", "Must have admin rights to Repository", "You need to be a member") that were being swallowed as `False` by the old code. Updated those tests (`Organization.testMembers`, `Repository.testChangeAutomateFixWhenNoVulnerabilityAlert`, `Workflow.testDisabledWhenAlreadyDisabled`, `WorkflowRun.test_delete`) to assert the exception is now raised, matching the actual server response.

Also added direct unit tests for `checkStatusOrRaise` in `tests/Requester.py` covering the 204/404/custom-false-status/raise cases.

Full suite: `pytest tests/` passes (1127 passed). Also ran `ruff check`, `black --check` and `mypy` against `github` and `tests`, all clean.