### PR TITLE
Add support for Python 3.15 and drop EOL 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         # keep in sync with tox.ini [gh-actions] section
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
         os: ["ubuntu-latest"]
         os-label: ["Ubuntu"]
         include:
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "${{ matrix.python-version }}"
+          allow-prereleases: true
       - name: Install tox
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,12 @@ jobs:
       fail-fast: false
       matrix:
         # keep in sync with tox.ini [gh-actions] section
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
         os: ["ubuntu-latest"]
         os-label: ["Ubuntu"]
         include:
-          - {python-version: "3.9", os: "windows-latest", os-label: "Windows"}
-          - {python-version: "3.9", os: "macos-latest", os-label: "macOS"}
+          - {python-version: "3.10", os: "windows-latest", os-label: "Windows"}
+          - {python-version: "3.10", os: "macos-latest", os-label: "macOS"}
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     rev: v3.15.0
     hooks:
       - id: pyupgrade
-        args: ["--py39-plus"]
+        args: ["--py310-plus"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.7

--- a/github/Auth.py
+++ b/github/Auth.py
@@ -34,8 +34,9 @@ import abc
 import base64
 import time
 from abc import ABC
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Callable, Union
+from typing import TYPE_CHECKING, Union
 
 import jwt
 from requests import utils

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -56,12 +56,13 @@ import email.utils
 import re
 import typing
 from abc import ABC
+from collections.abc import Callable
 from datetime import datetime, timezone
 from decimal import Decimal
 from operator import itemgetter
-from typing import TYPE_CHECKING, Any, Callable, Union, overload
+from typing import TYPE_CHECKING, Any, TypeGuard, Union, overload
 
-from typing_extensions import ParamSpec, Protocol, Self, TypeGuard, TypeVar
+from typing_extensions import ParamSpec, Protocol, Self, TypeVar
 
 from . import Consts
 from .GithubException import BadAttributeException, IncompletableObject

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Topic :: Software Development",
 ]
 description = "Use the full Github API v3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -25,7 +24,7 @@ description = "Use the full Github API v3"
 keywords = ["github"]
 name = "PyGithub"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 dynamic = ["version"]
 

--- a/scripts/prepare-for-update-assertions.py
+++ b/scripts/prepare-for-update-assertions.py
@@ -23,7 +23,6 @@
 import argparse
 import difflib
 import sys
-from typing import Union
 
 import libcst as cst
 from libcst import SimpleWhitespace
@@ -52,7 +51,7 @@ class SingleLineStatementTransformer(cst.CSTTransformer):
 
     def leave_Arg(
         self, original_node: cst.Arg, updated_node: cst.Arg
-    ) -> Union[cst.Arg, cst.FlattenSentinel[cst.Arg], cst.RemovalSentinel]:
+    ) -> cst.Arg | cst.FlattenSentinel[cst.Arg] | cst.RemovalSentinel:
         if self.in_function:
             return updated_node.with_changes(
                 whitespace_after_star=SimpleWhitespace(""), whitespace_after_arg=SimpleWhitespace("")
@@ -97,7 +96,7 @@ class SingleLineStatementTransformer(cst.CSTTransformer):
             return updated_node.with_changes(whitespace_before=SimpleWhitespace(""))
         return updated_node
 
-    def leave_Comma(self, original_node: cst.Comma, updated_node: cst.Comma) -> Union[cst.Comma, cst.MaybeSentinel]:
+    def leave_Comma(self, original_node: cst.Comma, updated_node: cst.Comma) -> cst.Comma | cst.MaybeSentinel:
         if self.in_function:
             return updated_node.with_changes(
                 whitespace_before=SimpleWhitespace(""), whitespace_after=SimpleWhitespace(" ")

--- a/tests/Framework.py
+++ b/tests/Framework.py
@@ -67,10 +67,10 @@ import os
 import traceback
 import unittest
 import warnings
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from dataclasses import dataclass
 from io import BytesIO
-from typing import Any, Callable
+from typing import Any
 
 import responses
 from requests.structures import CaseInsensitiveDict

--- a/tests/GithubRetry.py
+++ b/tests/GithubRetry.py
@@ -124,7 +124,7 @@ class GithubRetry(unittest.TestCase):
 
     @contextlib.contextmanager
     def mock_retry_now(self, now):
-        if sys.version_info[0] > 3 or sys.version_info[0] == 3 and sys.version_info[1] >= 11:
+        if sys.version_info >= (3, 11):
             attr = "github.GithubRetry.GithubRetry._GithubRetry__datetime"
         else:
             attr = "github.GithubRetry._GithubRetry__datetime"

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,13 @@
 [tox]
 envlist =
     lint,
-    py{39,310,311,312,313,314,315},
+    py{310-315},
     docs
 
 [gh-actions]
 # this make sure each ci job only run tests once.
 # keey it sync with workflows/ci.yaml matrix
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint,
-    py{39,310,311,312,313,314},
+    py{39,310,311,312,313,314,315},
     docs
 
 [gh-actions]
@@ -14,6 +14,7 @@ python =
     3.12: py312
     3.13: py313
     3.14: py314
+    3.15: py315
 
 [testenv]
 deps = -rrequirements/test.txt


### PR DESCRIPTION
The Python 3.15 beta is out and release candidate is nearly here! 🚀 

The 3.15 release manager (👋 hi, that's me!) [said](https://discuss.python.org/t/python-3-15-0-beta-4-is-here):


> We ***strongly encourage*** maintainers of third-party Python projects to ***test with 3.15*** during the beta phase and report issues found to [the Python bug tracker](https://github.com/python/cpython/issues) as soon as possible. While the release is planned to be feature-complete entering the beta phase, it is possible that features may be modified or, in rare cases, removed up until the start of the release candidate phase (2026-08-04). Our goal is to have ***no ABI changes*** after beta 4 and as few code changes as possible after the first release candidate. To achieve that, it will be ***extremely important*** to get as much exposure for 3.15 as possible during the beta phase.
> 
> This includes creating pre-release wheels for 3.15, as it helps other projects to do their own testing. However, we recommend that your regular production releases wait until 3.15.0rc1, to avoid the risk of ABI breaks.

Also drop EOL 3.9: https://devguide.python.org/versions/
