### PR TITLE
Remove deprecated usage of `lazy` argument in `get_repo` test calls

### DIFF
--- a/tests/BadAttributes.py
+++ b/tests/BadAttributes.py
@@ -100,7 +100,7 @@ class BadAttributes(Framework.TestCase):
         self.assertEqual(raisedexp.exception.actual_value, 42)
 
     def testBadTransformedAttributeInList(self):
-        commit = self.g.get_repo("klmitch/turnstile", lazy=True).get_commit("38d9082a898d0822b5ccdfd78f3a536e2efa6c26")
+        commit = self.g.withLazy(True).get_repo("klmitch/turnstile").get_commit("38d9082a898d0822b5ccdfd78f3a536e2efa6c26")
 
         with self.assertRaises(github.BadAttributeException) as raisedexp:
             commit.parents

--- a/tests/BadAttributes.py
+++ b/tests/BadAttributes.py
@@ -100,7 +100,9 @@ class BadAttributes(Framework.TestCase):
         self.assertEqual(raisedexp.exception.actual_value, 42)
 
     def testBadTransformedAttributeInList(self):
-        commit = self.g.withLazy(True).get_repo("klmitch/turnstile").get_commit("38d9082a898d0822b5ccdfd78f3a536e2efa6c26")
+        commit = (
+            self.g.withLazy(True).get_repo("klmitch/turnstile").get_commit("38d9082a898d0822b5ccdfd78f3a536e2efa6c26")
+        )
 
         with self.assertRaises(github.BadAttributeException) as raisedexp:
             commit.parents

--- a/tests/Branch.py
+++ b/tests/Branch.py
@@ -53,7 +53,7 @@ class Branch(Framework.TestCase):
         self.repo = self.g.get_user().get_repo("PyGithub")
         self.branch = self.repo.get_branch("topic/RewriteWithGeneratedCode")
         self.protected_branch = self.repo.get_branch("integrations")
-        self.organization_branch = self.g.get_repo("PyGithub/PyGithub", lazy=True).get_branch("master")
+        self.organization_branch = self.g.withLazy(True).get_repo("PyGithub/PyGithub").get_branch("master")
 
     def testAttributes(self):
         self.assertEqual(

--- a/tests/CommitCombinedStatus.py
+++ b/tests/CommitCombinedStatus.py
@@ -47,7 +47,8 @@ class CommitCombinedStatus(Framework.TestCase):
     def setUp(self):
         super().setUp()
         self.combined_status = (
-            self.g.get_repo("edx/edx-platform", lazy=True)
+            self.g.withLazy(True)
+            .get_repo("edx/edx-platform")
             .get_commit("74e70119a23fa3ffb3db19d4590eccfebd72b659")
             .get_combined_status()
         )

--- a/tests/GitCommitVerification.py
+++ b/tests/GitCommitVerification.py
@@ -32,7 +32,8 @@ class GitCommitVerification(Framework.TestCase):
     def setUp(self):
         super().setUp()
         self.commit = (
-            self.g.get_repo("PyGithub/PyGithub", lazy=True)
+            self.g.withLazy(True)
+            .get_repo("PyGithub/PyGithub")
             .get_commit("801d64a4c5c0fcb63f695e0f6799117e76e5fe67")
             .complete()
         )

--- a/tests/GitReleaseAsset.py
+++ b/tests/GitReleaseAsset.py
@@ -44,7 +44,7 @@ from . import Framework
 class GitReleaseAsset(Framework.TestCase):
     def setUp(self):
         super().setUp()
-        self.release = self.g.get_repo("EnricoMi/PyGithub", lazy=True).get_release(197548596)
+        self.release = self.g.withLazy(True).get_repo("EnricoMi/PyGithub").get_release(197548596)
         self.asset = self.release.assets[0]
 
     def testAttributes(self):

--- a/tests/GithubObject.py
+++ b/tests/GithubObject.py
@@ -249,7 +249,7 @@ class CompletableGithubObjectWithPaginatedProperty(Framework.TestCase):
         for lazy in [True, False]:
             with self.subTest(lazy=lazy):
                 with self.captureRequests() as requests:
-                    repo = self.g.get_repo("PyGithub/PyGithub", lazy=lazy)
+                    repo = self.g.withLazy(lazy).get_repo("PyGithub/PyGithub")
                     commit = repo.get_commit("3253acaabd86de12b73d0a24c98eb9c13d1987b5")
                     files = list(commit.files)
 
@@ -276,7 +276,7 @@ class CompletableGithubObjectWithPaginatedProperty(Framework.TestCase):
             with self.subTest(lazy=lazy):
                 with self.captureRequests() as requests:
                     self.g.per_page = 2
-                    repo = self.g.get_repo("PyGithub/PyGithub", lazy=lazy)
+                    repo = self.g.withLazy(lazy).get_repo("PyGithub/PyGithub")
                     commit = repo.get_commit("3253acaabd86de12b73d0a24c98eb9c13d1987b5")
                     files = list(commit.files)
 
@@ -306,7 +306,7 @@ class CompletableGithubObjectWithPaginatedProperty(Framework.TestCase):
             with self.subTest(lazy=lazy):
                 with self.captureRequests() as requests:
                     self.g.per_page = 2
-                    repo = self.g.get_repo("PyGithub/PyGithub", lazy=lazy)
+                    repo = self.g.withLazy(lazy).get_repo("PyGithub/PyGithub")
                     commit = repo.get_commit("3253acaabd86de12b73d0a24c98eb9c13d1987b5", commit_files_per_page=3)
                     files = list(commit.files)
 
@@ -335,7 +335,7 @@ class CompletableGithubObjectWithPaginatedProperty(Framework.TestCase):
         for lazy in [True, False]:
             with self.subTest(lazy=lazy):
                 with self.captureRequests() as requests:
-                    repo = self.g.get_repo("PyGithub/PyGithub", lazy=lazy)
+                    repo = self.g.withLazy(lazy).get_repo("PyGithub/PyGithub")
                     commit = repo.get_commit("3253acaabd86de12b73d0a24c98eb9c13d1987b5")
                     files = list(commit.get_files())
 
@@ -371,7 +371,7 @@ class CompletableGithubObjectWithPaginatedProperty(Framework.TestCase):
             with self.subTest(lazy=lazy):
                 with self.captureRequests() as requests:
                     self.g.per_page = 2
-                    repo = self.g.get_repo("PyGithub/PyGithub", lazy=lazy)
+                    repo = self.g.withLazy(lazy).get_repo("PyGithub/PyGithub")
                     commit = repo.get_commit("3253acaabd86de12b73d0a24c98eb9c13d1987b5")
                     files = list(commit.get_files())
 
@@ -408,7 +408,7 @@ class CompletableGithubObjectWithPaginatedProperty(Framework.TestCase):
             with self.subTest(lazy=lazy):
                 with self.captureRequests() as requests:
                     self.g.per_page = 2
-                    repo = self.g.get_repo("PyGithub/PyGithub", lazy=lazy)
+                    repo = self.g.withLazy(lazy).get_repo("PyGithub/PyGithub")
                     commit = repo.get_commit("3253acaabd86de12b73d0a24c98eb9c13d1987b5", commit_files_per_page=1)
                     files = list(commit.get_files(commit_files_per_page=3))
 
@@ -445,7 +445,7 @@ class CompletableGithubObjectWithPaginatedProperty(Framework.TestCase):
             with self.subTest(lazy=lazy):
                 with self.captureRequests() as requests:
                     self.g.per_page = 2
-                    repo = self.g.get_repo("PyGithub/PyGithub", lazy=lazy)
+                    repo = self.g.withLazy(lazy).get_repo("PyGithub/PyGithub")
                     commits = repo.get_commits(sha="release-v2-0")
                     commit = commits[0]
                     files = list(commit.files)
@@ -476,7 +476,7 @@ class CompletableGithubObjectWithPaginatedProperty(Framework.TestCase):
             with self.subTest(lazy=lazy):
                 with self.captureRequests() as requests:
                     # tests paginated property of Comparison.commits and Commit.files
-                    repo = self.g.get_repo("PyGithub/PyGithub", lazy=lazy)
+                    repo = self.g.withLazy(lazy).get_repo("PyGithub/PyGithub")
                     comparison = repo.compare(
                         "6cfe46b712e2bf65560bd8189c4654cd6c56eeca", "cef98416f45a9cdaf84d7f53cea13ac074a2c05d"
                     )
@@ -509,7 +509,7 @@ class CompletableGithubObjectWithPaginatedProperty(Framework.TestCase):
                 with self.captureRequests() as requests:
                     # tests paginated property of Comparison.commits and Commit.files
                     self.g.per_page = 2
-                    repo = self.g.get_repo("PyGithub/PyGithub", lazy=lazy)
+                    repo = self.g.withLazy(lazy).get_repo("PyGithub/PyGithub")
                     comparison = repo.compare(
                         "19e1c5032397a95c58fe25760723ffc24cbe0ec8",
                         "4bf07a2f5123f78fc6759bc2ade0c74154c1ba86",
@@ -545,7 +545,7 @@ class CompletableGithubObjectWithPaginatedProperty(Framework.TestCase):
                 with self.captureRequests() as requests:
                     # tests paginated property of Comparison.commits and Commit.files
                     self.g.per_page = 2
-                    repo = self.g.get_repo("PyGithub/PyGithub", lazy=lazy)
+                    repo = self.g.withLazy(lazy).get_repo("PyGithub/PyGithub")
                     comparison = repo.compare(
                         "19e1c5032397a95c58fe25760723ffc24cbe0ec8",
                         "4bf07a2f5123f78fc6759bc2ade0c74154c1ba86",
@@ -582,7 +582,7 @@ class CompletableGithubObjectWithPaginatedProperty(Framework.TestCase):
                 with self.captureRequests() as requests:
                     # tests paginated property of Comparison.commits and Commit.files
                     self.g.per_page = 2
-                    repo = self.g.get_repo("PyGithub/PyGithub", lazy=lazy)
+                    repo = self.g.withLazy(lazy).get_repo("PyGithub/PyGithub")
                     comparison = repo.compare(
                         "19e1c5032397a95c58fe25760723ffc24cbe0ec8",
                         "4bf07a2f5123f78fc6759bc2ade0c74154c1ba86",
@@ -620,7 +620,7 @@ class CompletableGithubObjectWithPaginatedProperty(Framework.TestCase):
                 with self.captureRequests() as requests:
                     # tests paginated property of Comparison.commits and Commit.files
                     self.g.per_page = 2
-                    repo = self.g.get_repo("PyGithub/PyGithub", lazy=lazy)
+                    repo = self.g.withLazy(lazy).get_repo("PyGithub/PyGithub")
                     comparison = repo.compare(
                         "19e1c5032397a95c58fe25760723ffc24cbe0ec8",
                         "4bf07a2f5123f78fc6759bc2ade0c74154c1ba86",
@@ -654,7 +654,7 @@ class CompletableGithubObjectWithPaginatedProperty(Framework.TestCase):
         for lazy in [True, False]:
             with self.subTest(lazy=lazy):
                 with self.captureRequests() as requests:
-                    repo = self.g.get_repo("PyGithub/PyGithub", lazy=lazy)
+                    repo = self.g.withLazy(lazy).get_repo("PyGithub/PyGithub")
                     pull = repo.get_pull(3370)
                     # PaginatedList commits should use default per_page
                     commits = list(pull.get_commits())
@@ -690,7 +690,7 @@ class CompletableGithubObjectWithPaginatedProperty(Framework.TestCase):
             with self.subTest(lazy=lazy):
                 with self.captureRequests() as requests:
                     self.g.per_page = 2
-                    repo = self.g.get_repo("PyGithub/PyGithub", lazy=lazy)
+                    repo = self.g.withLazy(lazy).get_repo("PyGithub/PyGithub")
                     pull = repo.get_pull(3370)
                     # PaginatedList commits should respect configured per_page
                     commits = list(pull.get_commits())
@@ -726,7 +726,7 @@ class CompletableGithubObjectWithPaginatedProperty(Framework.TestCase):
         for lazy in [True, False]:
             with self.subTest(lazy=lazy):
                 with self.captureRequests() as requests:
-                    repo = self.g.get_repo("PyGithub/PyGithub", lazy=lazy)
+                    repo = self.g.withLazy(lazy).get_repo("PyGithub/PyGithub")
                     pull = repo.get_pull(3370)
                     # PaginatedList commits should respect configured per_page
                     commits = list(pull.get_commits())
@@ -762,7 +762,7 @@ class CompletableGithubObjectWithPaginatedProperty(Framework.TestCase):
             with self.subTest(lazy=lazy):
                 with self.captureRequests() as requests:
                     self.g.per_page = 2
-                    repo = self.g.get_repo("PyGithub/PyGithub", lazy=lazy)
+                    repo = self.g.withLazy(lazy).get_repo("PyGithub/PyGithub")
                     pull = repo.get_pull(3370)
                     # PaginatedList commits should respect configured per_page
                     commits = list(pull.get_commits())
@@ -799,7 +799,7 @@ class CompletableGithubObjectWithPaginatedProperty(Framework.TestCase):
             with self.subTest(lazy=lazy):
                 with self.captureRequests() as requests:
                     self.g.per_page = 2
-                    repo = self.g.get_repo("PyGithub/PyGithub", lazy=lazy)
+                    repo = self.g.withLazy(lazy).get_repo("PyGithub/PyGithub")
                     pull = repo.get_pull(3370)
                     # PaginatedList commits should respect configured per_page
                     commits = list(pull.get_commits())

--- a/tests/Issue494.py
+++ b/tests/Issue494.py
@@ -40,7 +40,7 @@ from . import Framework
 class Issue494(Framework.TestCase):
     def setUp(self):
         super().setUp()
-        self.repo = self.g.get_repo("apache/brooklyn-server", lazy=True)
+        self.repo = self.g.withLazy(True).get_repo("apache/brooklyn-server")
         self.pull = self.repo.get_pull(465).complete()
 
     def testRepr(self):

--- a/tests/IssueDependencies.py
+++ b/tests/IssueDependencies.py
@@ -30,7 +30,7 @@ from . import Framework
 class IssueDependencies(Framework.TestCase):
     def setUp(self):
         super().setUp()
-        self.repo = self.g.get_repo("EnricoMi/PyGithub", lazy=True)
+        self.repo = self.g.withLazy(True).get_repo("EnricoMi/PyGithub")
         self.issue = self.repo.get_issue(24).complete()
         self.blocking_issue = self.repo.get_issue(13).complete()
 

--- a/tests/PaginatedList.py
+++ b/tests/PaginatedList.py
@@ -498,7 +498,7 @@ class PaginatedList(Framework.TestCase):
     def testWithFirstPage(self):
         # fetching the commit also fetches the fist page of files
         with self.captureRequests() as requests:
-            repo = self.g.get_repo("PyGithub/PyGithub", lazy=True)
+            repo = self.g.withLazy(True).get_repo("PyGithub/PyGithub")
             commit = repo.get_commit("e359b83a04e8f34bedab0f2180169012d238a135", commit_files_per_page=3)
             # repo is lazy, so this commit is also lazy, here we test with an eager (fetched) commit
             commit.complete()
@@ -545,7 +545,7 @@ class PaginatedList(Framework.TestCase):
     def testWithFirstSinglePage(self):
         # fetching the commit also fetches the fist page of files
         with self.captureRequests() as requests:
-            repo = self.g.get_repo("PyGithub/PyGithub", lazy=True)
+            repo = self.g.withLazy(True).get_repo("PyGithub/PyGithub")
             commit = repo.get_commit("f5f9756a1dd52a53820cc54927abb34725377987", commit_files_per_page=3)
             # repo is lazy, so this commit is also lazy, here we test with an eager (fetched) commit
             commit.complete()
@@ -568,7 +568,7 @@ class PaginatedList(Framework.TestCase):
     def testReversedWithFirstPage(self):
         # this is all lazy, no requests fired
         with self.captureRequests() as requests:
-            repo = self.g.get_repo("PyGithub/PyGithub", lazy=True)
+            repo = self.g.withLazy(True).get_repo("PyGithub/PyGithub")
             commit = repo.get_commit("e359b83a04e8f34bedab0f2180169012d238a135", commit_files_per_page=3)
             # repo is lazy, so this commit is also lazy, here we test with an eager (fetched) commit
             commit.complete()
@@ -623,7 +623,7 @@ class PaginatedList(Framework.TestCase):
     def testReversedWithFirstSinglePage(self):
         # fetching the commit also fetches the fist page of files
         with self.captureRequests() as requests:
-            repo = self.g.get_repo("PyGithub/PyGithub", lazy=True)
+            repo = self.g.withLazy(True).get_repo("PyGithub/PyGithub")
             commit = repo.get_commit("f5f9756a1dd52a53820cc54927abb34725377987", commit_files_per_page=3)
             # repo is lazy, so this commit is also lazy, here we test with an eager (fetched) commit
             commit.complete()

--- a/tests/Pickle.py
+++ b/tests/Pickle.py
@@ -59,7 +59,7 @@ class Pickle(Framework.TestCase):
 
     def testPicklePaginatedList(self):
         gh = github.Github()
-        repo = gh.get_repo(REPO_NAME, lazy=True)
+        repo = gh.withLazy(True).get_repo(REPO_NAME)
         branches = repo.get_branches()
         branches2 = pickle.loads(pickle.dumps(branches))
         self.assertIsInstance(branches2, PaginatedList)

--- a/tests/PullRequest.py
+++ b/tests/PullRequest.py
@@ -68,7 +68,7 @@ class PullRequest(Framework.TestCase):
         self.repo = self.g.get_repo("PyGithub/PyGithub")
         self.pull = self.repo.get_pull(31)
 
-        marco_repo = self.g.get_repo("MarcoFalke/PyGithub", lazy=True)
+        marco_repo = self.g.withLazy(True).get_repo("MarcoFalke/PyGithub")
         self.pullIssue256Closed = marco_repo.get_pull(1).complete()
         self.pullIssue256Merged = marco_repo.get_pull(2).complete()
         self.pullIssue256Conflict = marco_repo.get_pull(3).complete()
@@ -533,7 +533,7 @@ class PullRequest(Framework.TestCase):
         self.assertTrue(self.pull.update_branch())
 
     def testConvertToDraft(self):
-        ready_pr = self.g.get_repo("didot/PyGithub", lazy=True).get_pull(1)
+        ready_pr = self.g.withLazy(True).get_repo("didot/PyGithub").get_pull(1)
         self.assertFalse(ready_pr.draft)
         response = ready_pr.convert_to_draft()
         self.assertTrue(ready_pr.draft)
@@ -545,7 +545,7 @@ class PullRequest(Framework.TestCase):
         }
 
     def testMarkReadyForReview(self):
-        draft_pr = self.g.get_repo("didot/PyGithub", lazy=True).get_pull(2)
+        draft_pr = self.g.withLazy(True).get_repo("didot/PyGithub").get_pull(2)
         self.assertTrue(draft_pr.draft)
         response = draft_pr.mark_ready_for_review()
         self.assertFalse(draft_pr.draft)

--- a/tests/PullRequest1169.py
+++ b/tests/PullRequest1169.py
@@ -40,7 +40,7 @@ from . import Framework
 class PullRequest1169(Framework.TestCase):
     def setUp(self):
         super().setUp()
-        ferada_repo = self.g.get_repo("coleslaw-org/coleslaw", lazy=True)
+        ferada_repo = self.g.withLazy(True).get_repo("coleslaw-org/coleslaw")
         self.pull = ferada_repo.get_pull(173)
 
     def testReviewApproveWithoutBody(self):

--- a/tests/PullRequestReview.py
+++ b/tests/PullRequestReview.py
@@ -54,7 +54,7 @@ class PullRequestReview(Framework.TestCase):
     def setUp(self):
         super().setUp()
 
-        self.repo = self.g.get_repo("PyGithub/PyGithub", lazy=True)
+        self.repo = self.g.withLazy(True).get_repo("PyGithub/PyGithub")
         self.pull = self.repo.get_pull(538)
 
         # Test ability to create a review

--- a/tests/PullRequestReview1856.py
+++ b/tests/PullRequestReview1856.py
@@ -27,7 +27,7 @@ from . import Framework
 
 class PullRequestReview1856(Framework.TestCase):
     def testDelete(self):
-        pumpkin_repo = self.g.get_repo("CS481-Team-Pumpkin/PyGithub", lazy=True)
+        pumpkin_repo = self.g.withLazy(True).get_repo("CS481-Team-Pumpkin/PyGithub")
         pumpkin_pull = pumpkin_repo.get_pull(4)
         pullreview = pumpkin_pull.get_review(631460061)
 

--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -2385,10 +2385,10 @@ class LazyRepository(Framework.TestCase):
         self.repository_name = "PyGithub/PyGithub"
 
     def getLazyRepository(self):
-        return self.g.get_repo(self.repository_name, lazy=True)
+        return self.g.withLazy(True).get_repo(self.repository_name)
 
     def getEagerRepository(self):
-        return self.g.get_repo(self.repository_name, lazy=False)
+        return self.g.withLazy(False).get_repo(self.repository_name)
 
     def testLazyAttributes(self):
         repo = self.g.withLazy(True).get_repo("lazy/repo")
@@ -2467,35 +2467,35 @@ class LazyRepository(Framework.TestCase):
         lazy_repo = self.getLazyRepository()
         self.assertTrue(lazy_repo.enable_vulnerability_alert())
 
-        lazy_repo = self.g.get_repo("random", lazy=True)
+        lazy_repo = self.g.withLazy(True).get_repo("random")
         self.assertFalse(lazy_repo.enable_vulnerability_alert())
 
     def testEnableAutomatedSecurityFixes(self):
         lazy_repo = self.getLazyRepository()
         self.assertTrue(lazy_repo.enable_automated_security_fixes())
 
-        lazy_repo = self.g.get_repo("random", lazy=True)
+        lazy_repo = self.g.withLazy(True).get_repo("random")
         self.assertFalse(lazy_repo.enable_automated_security_fixes())
 
     def testDisableAutomatedSecurityFixes(self):
         lazy_repo = self.getLazyRepository()
         self.assertTrue(lazy_repo.disable_automated_security_fixes())
 
-        lazy_repo = self.g.get_repo("random", lazy=True)
+        lazy_repo = self.g.withLazy(True).get_repo("random")
         self.assertFalse(lazy_repo.disable_automated_security_fixes())
 
     def testGetVulnerabilityAlert(self):
         lazy_repo = self.getEagerRepository()
         self.assertTrue(lazy_repo.get_vulnerability_alert())
 
-        lazy_repo = self.g.get_repo("random", lazy=True)
+        lazy_repo = self.g.withLazy(True).get_repo("random")
         self.assertFalse(lazy_repo.get_vulnerability_alert())
 
     def testDisableVulnerabilityAlert(self):
         lazy_repo = self.getLazyRepository()
         self.assertTrue(lazy_repo.disable_vulnerability_alert())
 
-        lazy_repo = self.g.get_repo("random", lazy=True)
+        lazy_repo = self.g.withLazy(True).get_repo("random")
         self.assertFalse(lazy_repo.disable_vulnerability_alert())
 
     def testChangeAutomateFixWhenNoVulnerabilityAlert(self):

--- a/tests/RequiredPullRequestReviews.py
+++ b/tests/RequiredPullRequestReviews.py
@@ -70,7 +70,8 @@ class RequiredPullRequestReviews(Framework.TestCase):
 
     def testOrganizationOwnedTeam(self):
         required_pull_request_reviews = (
-            self.g.get_repo("PyGithub/PyGithub", lazy=True)
+            self.g.withLazy(True)
+            .get_repo("PyGithub/PyGithub")
             .get_branch("integrations")
             .get_required_pull_request_reviews()
         )

--- a/tests/RequiredStatusChecks.py
+++ b/tests/RequiredStatusChecks.py
@@ -44,7 +44,7 @@ class RequiredStatusChecks(Framework.TestCase):
     def setUp(self):
         super().setUp()
         self.required_status_checks = (
-            self.g.get_repo("jacquev6/PyGithub", lazy=True).get_branch("integrations").get_required_status_checks()
+            self.g.withLazy(True).get_repo("jacquev6/PyGithub").get_branch("integrations").get_required_status_checks()
         )
 
     def testAttributes(self):

--- a/tests/SubIssue.py
+++ b/tests/SubIssue.py
@@ -28,7 +28,7 @@ from . import Framework
 class SubIssue(Framework.TestCase):
     def setUp(self):
         super().setUp()
-        self.repo = self.g.get_repo("PyGithub/PyGithub", lazy=True)
+        self.repo = self.g.withLazy(True).get_repo("PyGithub/PyGithub")
         self.issue = self.repo.get_issue(5)
 
     def testListSubIssues(self):


### PR DESCRIPTION
**Description**
This PR resolves 148 deprecation warnings raised during test suite execution. 

It refactors the deprecated usage of `get_repo(..., lazy=True/False)` across 18 test files to use the recommended `withLazy(lazy).get_repo(...)` method on the main `Github` class.

**Changes**
* Replaced `get_repo(..., lazy=True)` and `get_repo(..., lazy=False)` calls with `withLazy(True).get_repo(...)` and `withLazy(False).get_repo(...)` in the test suite.
* Verified that all 1123 tests pass cleanly and warnings are eliminated.