### PR TITLE
Apply nullable property types from OpenAPI

### DIFF
--- a/github/AdvisoryVulnerability.py
+++ b/github/AdvisoryVulnerability.py
@@ -78,30 +78,30 @@ class AdvisoryVulnerability(NonCompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._first_patched_version: Attribute[str] = NotSet
-        self._package: Attribute[AdvisoryVulnerabilityPackage] = NotSet
-        self._patched_versions: Attribute[str] = NotSet
-        self._vulnerable_functions: Attribute[list[str]] = NotSet
-        self._vulnerable_version_range: Attribute[str] = NotSet
+        self._first_patched_version: Attribute[str | None] = NotSet
+        self._package: Attribute[AdvisoryVulnerabilityPackage | None] = NotSet
+        self._patched_versions: Attribute[str | None] = NotSet
+        self._vulnerable_functions: Attribute[list[str] | None] = NotSet
+        self._vulnerable_version_range: Attribute[str | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"package": self.package})
 
     @property
-    def first_patched_version(self) -> str:
+    def first_patched_version(self) -> str | None:
         return self._first_patched_version.value
 
     @property
     def package(
         self,
-    ) -> AdvisoryVulnerabilityPackage:
+    ) -> AdvisoryVulnerabilityPackage | None:
         """
         :type: :class:`github.AdvisoryVulnerability.AdvisoryVulnerability`
         """
         return self._package.value
 
     @property
-    def patched_versions(self) -> str:
+    def patched_versions(self) -> str | None:
         """
         :type: string
         """
@@ -165,10 +165,12 @@ class AdvisoryVulnerability(NonCompletableGithubObject):
                 "vulnerable_functions": vulnerability["vulnerable_functions"],
                 "vulnerable_version_range": vulnerability["vulnerable_version_range"],
             }
+        package = vulnerability.package
+        assert package is not None, vulnerability
         return {
             "package": {
-                "ecosystem": vulnerability.package.ecosystem,
-                "name": vulnerability.package.name,
+                "ecosystem": package.ecosystem,
+                "name": package.name,
             },
             "patched_versions": vulnerability.patched_versions,
             "vulnerable_functions": vulnerability.vulnerable_functions,

--- a/github/Artifact.py
+++ b/github/Artifact.py
@@ -67,18 +67,18 @@ class Artifact(NonCompletableGithubObject):
 
     def _initAttributes(self) -> None:
         self._archive_download_url: Attribute[str] = NotSet
-        self._created_at: Attribute[datetime] = NotSet
-        self._digest: Attribute[str] = NotSet
+        self._created_at: Attribute[datetime | None] = NotSet
+        self._digest: Attribute[str | None] = NotSet
         self._expired: Attribute[bool] = NotSet
-        self._expires_at: Attribute[datetime] = NotSet
+        self._expires_at: Attribute[datetime | None] = NotSet
         self._head_sha: Attribute[str] = NotSet
         self._id: Attribute[int] = NotSet
         self._name: Attribute[str] = NotSet
         self._node_id: Attribute[str] = NotSet
         self._size_in_bytes: Attribute[int] = NotSet
-        self._updated_at: Attribute[datetime] = NotSet
+        self._updated_at: Attribute[datetime | None] = NotSet
         self._url: Attribute[str] = NotSet
-        self._workflow_run: Attribute[WorkflowRun] = NotSet
+        self._workflow_run: Attribute[WorkflowRun | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"name": self._name.value, "id": self._id.value})
@@ -88,11 +88,11 @@ class Artifact(NonCompletableGithubObject):
         return self._archive_download_url.value
 
     @property
-    def created_at(self) -> datetime:
+    def created_at(self) -> datetime | None:
         return self._created_at.value
 
     @property
-    def digest(self) -> str:
+    def digest(self) -> str | None:
         return self._digest.value
 
     @property
@@ -100,7 +100,7 @@ class Artifact(NonCompletableGithubObject):
         return self._expired.value
 
     @property
-    def expires_at(self) -> datetime:
+    def expires_at(self) -> datetime | None:
         return self._expires_at.value
 
     @property
@@ -124,7 +124,7 @@ class Artifact(NonCompletableGithubObject):
         return self._size_in_bytes.value
 
     @property
-    def updated_at(self) -> datetime:
+    def updated_at(self) -> datetime | None:
         return self._updated_at.value
 
     @property
@@ -132,7 +132,7 @@ class Artifact(NonCompletableGithubObject):
         return self._url.value
 
     @property
-    def workflow_run(self) -> WorkflowRun:
+    def workflow_run(self) -> WorkflowRun | None:
         return self._workflow_run.value
 
     def delete(self) -> bool:

--- a/github/AuthenticatedUser.py
+++ b/github/AuthenticatedUser.py
@@ -161,30 +161,30 @@ class AuthenticatedUser(CompletableGithubObject):
 
     def _initAttributes(self) -> None:
         self._avatar_url: Attribute[str] = NotSet
-        self._bio: Attribute[str] = NotSet
-        self._blog: Attribute[str] = NotSet
+        self._bio: Attribute[str | None] = NotSet
+        self._blog: Attribute[str | None] = NotSet
         self._business_plus: Attribute[bool] = NotSet
         self._collaborators: Attribute[int] = NotSet
-        self._company: Attribute[str] = NotSet
+        self._company: Attribute[str | None] = NotSet
         self._created_at: Attribute[datetime] = NotSet
         self._disk_usage: Attribute[int] = NotSet
-        self._email: Attribute[str] = NotSet
+        self._email: Attribute[str | None] = NotSet
         self._events_url: Attribute[str] = NotSet
         self._followers: Attribute[int] = NotSet
         self._followers_url: Attribute[str] = NotSet
         self._following: Attribute[int] = NotSet
         self._following_url: Attribute[str] = NotSet
         self._gists_url: Attribute[str] = NotSet
-        self._gravatar_id: Attribute[str] = NotSet
-        self._hireable: Attribute[bool] = NotSet
+        self._gravatar_id: Attribute[str | None] = NotSet
+        self._hireable: Attribute[bool | None] = NotSet
         self._html_url: Attribute[str] = NotSet
         self._id: Attribute[int] = NotSet
         self._ldap_dn: Attribute[str] = NotSet
-        self._location: Attribute[str] = NotSet
+        self._location: Attribute[str | None] = NotSet
         self._login: Attribute[str] = NotSet
-        self._name: Attribute[str] = NotSet
+        self._name: Attribute[str | None] = NotSet
         self._node_id: Attribute[str] = NotSet
-        self._notification_email: Attribute[str] = NotSet
+        self._notification_email: Attribute[str | None] = NotSet
         self._organizations_url: Attribute[str] = NotSet
         self._owned_private_repos: Attribute[int] = NotSet
         self._plan: Attribute[Plan] = NotSet
@@ -197,7 +197,7 @@ class AuthenticatedUser(CompletableGithubObject):
         self._starred_url: Attribute[str] = NotSet
         self._subscriptions_url: Attribute[str] = NotSet
         self._total_private_repos: Attribute[int] = NotSet
-        self._twitter_username: Attribute[str] = NotSet
+        self._twitter_username: Attribute[str | None] = NotSet
         self._two_factor_authentication: Attribute[bool] = NotSet
         self._type: Attribute[str] = NotSet
         self._updated_at: Attribute[datetime] = NotSet
@@ -213,12 +213,12 @@ class AuthenticatedUser(CompletableGithubObject):
         return self._avatar_url.value
 
     @property
-    def bio(self) -> str:
+    def bio(self) -> str | None:
         self._completeIfNotSet(self._bio)
         return self._bio.value
 
     @property
-    def blog(self) -> str:
+    def blog(self) -> str | None:
         self._completeIfNotSet(self._blog)
         return self._blog.value
 
@@ -233,7 +233,7 @@ class AuthenticatedUser(CompletableGithubObject):
         return self._collaborators.value
 
     @property
-    def company(self) -> str:
+    def company(self) -> str | None:
         self._completeIfNotSet(self._company)
         return self._company.value
 
@@ -248,7 +248,7 @@ class AuthenticatedUser(CompletableGithubObject):
         return self._disk_usage.value
 
     @property
-    def email(self) -> str:
+    def email(self) -> str | None:
         self._completeIfNotSet(self._email)
         return self._email.value
 
@@ -283,12 +283,12 @@ class AuthenticatedUser(CompletableGithubObject):
         return self._gists_url.value
 
     @property
-    def gravatar_id(self) -> str:
+    def gravatar_id(self) -> str | None:
         self._completeIfNotSet(self._gravatar_id)
         return self._gravatar_id.value
 
     @property
-    def hireable(self) -> bool:
+    def hireable(self) -> bool | None:
         self._completeIfNotSet(self._hireable)
         return self._hireable.value
 
@@ -308,7 +308,7 @@ class AuthenticatedUser(CompletableGithubObject):
         return self._ldap_dn.value
 
     @property
-    def location(self) -> str:
+    def location(self) -> str | None:
         self._completeIfNotSet(self._location)
         return self._location.value
 
@@ -318,7 +318,7 @@ class AuthenticatedUser(CompletableGithubObject):
         return self._login.value
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         self._completeIfNotSet(self._name)
         return self._name.value
 
@@ -328,7 +328,7 @@ class AuthenticatedUser(CompletableGithubObject):
         return self._node_id.value
 
     @property
-    def notification_email(self) -> str:
+    def notification_email(self) -> str | None:
         self._completeIfNotSet(self._notification_email)
         return self._notification_email.value
 
@@ -393,7 +393,7 @@ class AuthenticatedUser(CompletableGithubObject):
         return self._total_private_repos.value
 
     @property
-    def twitter_username(self) -> str:
+    def twitter_username(self) -> str | None:
         self._completeIfNotSet(self._twitter_username)
         return self._twitter_username.value
 
@@ -783,7 +783,8 @@ class AuthenticatedUser(CompletableGithubObject):
         if is_defined(state):
             url_parameters["state"] = state
         if is_defined(labels):
-            url_parameters["labels"] = ",".join(label.name for label in labels)
+            assert all(label.name is not None for label in labels), labels
+            url_parameters["labels"] = ",".join(label.name for label in labels)  # type: ignore[misc]
         if is_defined(sort):
             url_parameters["sort"] = sort
         if is_defined(direction):
@@ -816,7 +817,8 @@ class AuthenticatedUser(CompletableGithubObject):
         if is_defined(state):
             url_parameters["state"] = state
         if is_defined(labels):
-            url_parameters["labels"] = ",".join(label.name for label in labels)
+            assert all(label.name is not None for label in labels), labels
+            url_parameters["labels"] = ",".join(label.name for label in labels)  # type: ignore[misc]
         if is_defined(sort):
             url_parameters["sort"] = sort
         if is_defined(direction):

--- a/github/Autolink.py
+++ b/github/Autolink.py
@@ -64,7 +64,7 @@ class Autolink(NonCompletableGithubObject):
         self._id: Attribute[int] = NotSet
         self._is_alphanumeric: Attribute[bool] = NotSet
         self._key_prefix: Attribute[str] = NotSet
-        self._updated_at: Attribute[datetime] = NotSet
+        self._updated_at: Attribute[datetime | None] = NotSet
         self._url_template: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
@@ -83,7 +83,7 @@ class Autolink(NonCompletableGithubObject):
         return self._key_prefix.value
 
     @property
-    def updated_at(self) -> datetime:
+    def updated_at(self) -> datetime | None:
         return self._updated_at.value
 
     @property

--- a/github/CheckRun.py
+++ b/github/CheckRun.py
@@ -88,22 +88,22 @@ class CheckRun(CompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._app: Attribute[GithubApp] = NotSet
-        self._check_suite: Attribute[CheckSuite] = NotSet
+        self._app: Attribute[GithubApp | None] = NotSet
+        self._check_suite: Attribute[CheckSuite | None] = NotSet
         self._check_suite_id: Attribute[int] = NotSet
         self._completed_at: Attribute[datetime | None] = NotSet
-        self._conclusion: Attribute[str] = NotSet
+        self._conclusion: Attribute[str | None] = NotSet
         self._deployment: Attribute[Deployment] = NotSet
-        self._details_url: Attribute[str] = NotSet
-        self._external_id: Attribute[str] = NotSet
+        self._details_url: Attribute[str | None] = NotSet
+        self._external_id: Attribute[str | None] = NotSet
         self._head_sha: Attribute[str] = NotSet
-        self._html_url: Attribute[str] = NotSet
+        self._html_url: Attribute[str | None] = NotSet
         self._id: Attribute[int] = NotSet
         self._name: Attribute[str] = NotSet
         self._node_id: Attribute[str] = NotSet
         self._output: Attribute[CheckRunOutput] = NotSet
         self._pull_requests: Attribute[list[PullRequest]] = NotSet
-        self._started_at: Attribute[datetime] = NotSet
+        self._started_at: Attribute[datetime | None] = NotSet
         self._status: Attribute[str] = NotSet
         self._url: Attribute[str] = NotSet
 
@@ -111,12 +111,12 @@ class CheckRun(CompletableGithubObject):
         return self.get__repr__({"id": self._id.value, "conclusion": self._conclusion.value})
 
     @property
-    def app(self) -> GithubApp:
+    def app(self) -> GithubApp | None:
         self._completeIfNotSet(self._app)
         return self._app.value
 
     @property
-    def check_suite(self) -> CheckSuite:
+    def check_suite(self) -> CheckSuite | None:
         self._completeIfNotSet(self._check_suite)
         return self._check_suite.value
 
@@ -132,7 +132,7 @@ class CheckRun(CompletableGithubObject):
         return self._completed_at.value
 
     @property
-    def conclusion(self) -> str:
+    def conclusion(self) -> str | None:
         self._completeIfNotSet(self._conclusion)
         return self._conclusion.value
 
@@ -142,12 +142,12 @@ class CheckRun(CompletableGithubObject):
         return self._deployment.value
 
     @property
-    def details_url(self) -> str:
+    def details_url(self) -> str | None:
         self._completeIfNotSet(self._details_url)
         return self._details_url.value
 
     @property
-    def external_id(self) -> str:
+    def external_id(self) -> str | None:
         self._completeIfNotSet(self._external_id)
         return self._external_id.value
 
@@ -157,7 +157,7 @@ class CheckRun(CompletableGithubObject):
         return self._head_sha.value
 
     @property
-    def html_url(self) -> str:
+    def html_url(self) -> str | None:
         self._completeIfNotSet(self._html_url)
         return self._html_url.value
 
@@ -187,7 +187,7 @@ class CheckRun(CompletableGithubObject):
         return self._pull_requests.value
 
     @property
-    def started_at(self) -> datetime:
+    def started_at(self) -> datetime | None:
         self._completeIfNotSet(self._started_at)
         return self._started_at.value
 

--- a/github/CheckRunAnnotation.py
+++ b/github/CheckRunAnnotation.py
@@ -56,22 +56,22 @@ class CheckRunAnnotation(NonCompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._annotation_level: Attribute[str] = NotSet
+        self._annotation_level: Attribute[str | None] = NotSet
         self._blob_href: Attribute[str] = NotSet
-        self._end_column: Attribute[int] = NotSet
+        self._end_column: Attribute[int | None] = NotSet
         self._end_line: Attribute[int] = NotSet
-        self._message: Attribute[str] = NotSet
+        self._message: Attribute[str | None] = NotSet
         self._path: Attribute[str] = NotSet
-        self._raw_details: Attribute[str] = NotSet
-        self._start_column: Attribute[int] = NotSet
+        self._raw_details: Attribute[str | None] = NotSet
+        self._start_column: Attribute[int | None] = NotSet
         self._start_line: Attribute[int] = NotSet
-        self._title: Attribute[str] = NotSet
+        self._title: Attribute[str | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"title": self._title.value})
 
     @property
-    def annotation_level(self) -> str:
+    def annotation_level(self) -> str | None:
         return self._annotation_level.value
 
     @property
@@ -79,7 +79,7 @@ class CheckRunAnnotation(NonCompletableGithubObject):
         return self._blob_href.value
 
     @property
-    def end_column(self) -> int:
+    def end_column(self) -> int | None:
         return self._end_column.value
 
     @property
@@ -87,7 +87,7 @@ class CheckRunAnnotation(NonCompletableGithubObject):
         return self._end_line.value
 
     @property
-    def message(self) -> str:
+    def message(self) -> str | None:
         return self._message.value
 
     @property
@@ -95,11 +95,11 @@ class CheckRunAnnotation(NonCompletableGithubObject):
         return self._path.value
 
     @property
-    def raw_details(self) -> str:
+    def raw_details(self) -> str | None:
         return self._raw_details.value
 
     @property
-    def start_column(self) -> int:
+    def start_column(self) -> int | None:
         return self._start_column.value
 
     @property
@@ -107,7 +107,7 @@ class CheckRunAnnotation(NonCompletableGithubObject):
         return self._start_line.value
 
     @property
-    def title(self) -> str:
+    def title(self) -> str | None:
         return self._title.value
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:

--- a/github/CheckRunOutput.py
+++ b/github/CheckRunOutput.py
@@ -67,9 +67,9 @@ class CheckRunOutput(NonCompletableGithubObject):
     def _initAttributes(self) -> None:
         self._annotations_count: Attribute[int] = NotSet
         self._annotations_url: Attribute[str] = NotSet
-        self._summary: Attribute[str] = NotSet
-        self._text: Attribute[str] = NotSet
-        self._title: Attribute[str] = NotSet
+        self._summary: Attribute[str | None] = NotSet
+        self._text: Attribute[str | None] = NotSet
+        self._title: Attribute[str | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"title": self._title.value})
@@ -83,15 +83,15 @@ class CheckRunOutput(NonCompletableGithubObject):
         return self._annotations_url.value
 
     @property
-    def summary(self) -> str:
+    def summary(self) -> str | None:
         return self._summary.value
 
     @property
-    def text(self) -> str:
+    def text(self) -> str | None:
         return self._text.value
 
     @property
-    def title(self) -> str:
+    def title(self) -> str | None:
         return self._title.value
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:

--- a/github/CheckSuite.py
+++ b/github/CheckSuite.py
@@ -65,31 +65,31 @@ class CheckSuite(CompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._after: Attribute[str] = NotSet
-        self._app: Attribute[GithubApp] = NotSet
-        self._before: Attribute[str] = NotSet
+        self._after: Attribute[str | None] = NotSet
+        self._app: Attribute[GithubApp | None] = NotSet
+        self._before: Attribute[str | None] = NotSet
         self._check_runs_url: Attribute[str] = NotSet
-        self._conclusion: Attribute[str] = NotSet
-        self._created_at: Attribute[datetime] = NotSet
-        self._head_branch: Attribute[str] = NotSet
+        self._conclusion: Attribute[str | None] = NotSet
+        self._created_at: Attribute[datetime | None] = NotSet
+        self._head_branch: Attribute[str | None] = NotSet
         self._head_commit: Attribute[GitCommit] = NotSet
         self._head_sha: Attribute[str] = NotSet
         self._id: Attribute[int] = NotSet
         self._latest_check_runs_count: Attribute[int] = NotSet
         self._node_id: Attribute[str] = NotSet
-        self._pull_requests: Attribute[list[PullRequest]] = NotSet
+        self._pull_requests: Attribute[list[PullRequest] | None] = NotSet
         self._repository: Attribute[Repository] = NotSet
         self._rerequestable: Attribute[bool] = NotSet
         self._runs_rerequestable: Attribute[bool] = NotSet
-        self._status: Attribute[str] = NotSet
-        self._updated_at: Attribute[datetime] = NotSet
+        self._status: Attribute[str | None] = NotSet
+        self._updated_at: Attribute[datetime | None] = NotSet
         self._url: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"id": self._id.value, "url": self._url.value})
 
     @property
-    def after(self) -> str:
+    def after(self) -> str | None:
         """
         :type: string
         """
@@ -97,7 +97,7 @@ class CheckSuite(CompletableGithubObject):
         return self._after.value
 
     @property
-    def app(self) -> GithubApp:
+    def app(self) -> GithubApp | None:
         """
         :type: :class:`github.GithubApp.GithubApp`
         """
@@ -105,7 +105,7 @@ class CheckSuite(CompletableGithubObject):
         return self._app.value
 
     @property
-    def before(self) -> str:
+    def before(self) -> str | None:
         """
         :type: string
         """
@@ -121,7 +121,7 @@ class CheckSuite(CompletableGithubObject):
         return self._check_runs_url.value
 
     @property
-    def conclusion(self) -> str:
+    def conclusion(self) -> str | None:
         """
         :type: string
         """
@@ -129,7 +129,7 @@ class CheckSuite(CompletableGithubObject):
         return self._conclusion.value
 
     @property
-    def created_at(self) -> datetime:
+    def created_at(self) -> datetime | None:
         """
         :type: datetime.datetime
         """
@@ -137,7 +137,7 @@ class CheckSuite(CompletableGithubObject):
         return self._created_at.value
 
     @property
-    def head_branch(self) -> str:
+    def head_branch(self) -> str | None:
         """
         :type: string
         """
@@ -182,7 +182,7 @@ class CheckSuite(CompletableGithubObject):
         return self._node_id.value
 
     @property
-    def pull_requests(self) -> list[PullRequest]:
+    def pull_requests(self) -> list[PullRequest] | None:
         """
         :type: list of :class:`github.PullRequest.PullRequest`
         """
@@ -208,7 +208,7 @@ class CheckSuite(CompletableGithubObject):
         return self._runs_rerequestable.value
 
     @property
-    def status(self) -> str:
+    def status(self) -> str | None:
         """
         :type: string
         """
@@ -216,7 +216,7 @@ class CheckSuite(CompletableGithubObject):
         return self._status.value
 
     @property
-    def updated_at(self) -> datetime:
+    def updated_at(self) -> datetime | None:
         """
         :type: datetime.datetime
         """

--- a/github/CodeScanAlert.py
+++ b/github/CodeScanAlert.py
@@ -68,7 +68,7 @@ class CodeScanAlert(NonCompletableGithubObject):
     def _initAttributes(self) -> None:
         self._assignees: Attribute[list[NamedUser]] = NotSet
         self._created_at: Attribute[datetime] = NotSet
-        self._dismissal_approved_by: Attribute[NamedUser | Organization] = NotSet
+        self._dismissal_approved_by: Attribute[NamedUser | Organization | None] = NotSet
         self._dismissed_at: Attribute[datetime | None] = NotSet
         self._dismissed_by: Attribute[NamedUser | None] = NotSet
         self._dismissed_comment: Attribute[str | None] = NotSet
@@ -79,7 +79,7 @@ class CodeScanAlert(NonCompletableGithubObject):
         self._most_recent_instance: Attribute[CodeScanAlertInstance] = NotSet
         self._number: Attribute[int] = NotSet
         self._rule: Attribute[CodeScanRule] = NotSet
-        self._state: Attribute[str] = NotSet
+        self._state: Attribute[str | None] = NotSet
         self._tool: Attribute[CodeScanTool] = NotSet
         self._updated_at: Attribute[datetime] = NotSet
         self._url: Attribute[str] = NotSet
@@ -96,7 +96,7 @@ class CodeScanAlert(NonCompletableGithubObject):
         return self._created_at.value
 
     @property
-    def dismissal_approved_by(self) -> NamedUser | Organization:
+    def dismissal_approved_by(self) -> NamedUser | Organization | None:
         return self._dismissal_approved_by.value
 
     @property
@@ -140,7 +140,7 @@ class CodeScanAlert(NonCompletableGithubObject):
         return self._rule.value
 
     @property
-    def state(self) -> str:
+    def state(self) -> str | None:
         return self._state.value
 
     @property
@@ -178,7 +178,7 @@ class CodeScanAlert(NonCompletableGithubObject):
                 attributes["dismissal_approved_by"],
                 (github.NamedUser.NamedUser, "User"),
                 (github.Organization.Organization, "Organization"),
-            )
+            )  # type: ignore
         if "dismissed_at" in attributes:  # pragma no branch
             self._dismissed_at = self._makeDatetimeAttribute(attributes["dismissed_at"])
         if "dismissed_by" in attributes:  # pragma no branch

--- a/github/CodeScanAlertInstance.py
+++ b/github/CodeScanAlertInstance.py
@@ -60,7 +60,7 @@ class CodeScanAlertInstance(NonCompletableGithubObject):
         self._location: Attribute[CodeScanAlertInstanceLocation] = NotSet
         self._message: Attribute[dict[str, Any]] = NotSet
         self._ref: Attribute[str] = NotSet
-        self._state: Attribute[str] = NotSet
+        self._state: Attribute[str | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"ref": self.ref, "analysis_key": self.analysis_key})
@@ -102,7 +102,7 @@ class CodeScanAlertInstance(NonCompletableGithubObject):
         return self._ref.value
 
     @property
-    def state(self) -> str:
+    def state(self) -> str | None:
         return self._state.value
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:

--- a/github/CodeScanRule.py
+++ b/github/CodeScanRule.py
@@ -65,13 +65,13 @@ class CodeScanRule(NonCompletableGithubObject):
     def _initAttributes(self) -> None:
         self._description: Attribute[str] = NotSet
         self._full_description: Attribute[str] = NotSet
-        self._help: Attribute[str] = NotSet
-        self._help_uri: Attribute[str] = NotSet
-        self._id: Attribute[str] = NotSet
+        self._help: Attribute[str | None] = NotSet
+        self._help_uri: Attribute[str | None] = NotSet
+        self._id: Attribute[str | None] = NotSet
         self._name: Attribute[str] = NotSet
-        self._security_severity_level: Attribute[str] = NotSet
-        self._severity: Attribute[str] = NotSet
-        self._tags: Attribute[list[str]] = NotSet
+        self._security_severity_level: Attribute[str | None] = NotSet
+        self._severity: Attribute[str | None] = NotSet
+        self._tags: Attribute[list[str] | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"id": self.id, "name": self.name})
@@ -85,15 +85,15 @@ class CodeScanRule(NonCompletableGithubObject):
         return self._full_description.value
 
     @property
-    def help(self) -> str:
+    def help(self) -> str | None:
         return self._help.value
 
     @property
-    def help_uri(self) -> str:
+    def help_uri(self) -> str | None:
         return self._help_uri.value
 
     @property
-    def id(self) -> str:
+    def id(self) -> str | None:
         return self._id.value
 
     @property
@@ -101,15 +101,15 @@ class CodeScanRule(NonCompletableGithubObject):
         return self._name.value
 
     @property
-    def security_severity_level(self) -> str:
+    def security_severity_level(self) -> str | None:
         return self._security_severity_level.value
 
     @property
-    def severity(self) -> str:
+    def severity(self) -> str | None:
         return self._severity.value
 
     @property
-    def tags(self) -> list[str]:
+    def tags(self) -> list[str] | None:
         return self._tags.value
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:

--- a/github/CodeScanTool.py
+++ b/github/CodeScanTool.py
@@ -59,9 +59,9 @@ class CodeScanTool(NonCompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._guid: Attribute[str] = NotSet
+        self._guid: Attribute[str | None] = NotSet
         self._name: Attribute[str] = NotSet
-        self._version: Attribute[str] = NotSet
+        self._version: Attribute[str | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__(
@@ -73,7 +73,7 @@ class CodeScanTool(NonCompletableGithubObject):
         )
 
     @property
-    def guid(self) -> str:
+    def guid(self) -> str | None:
         return self._guid.value
 
     @property
@@ -81,7 +81,7 @@ class CodeScanTool(NonCompletableGithubObject):
         return self._name.value
 
     @property
-    def version(self) -> str:
+    def version(self) -> str | None:
         return self._version.value
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:

--- a/github/Commit.py
+++ b/github/Commit.py
@@ -104,10 +104,10 @@ class Commit(CompletableGithubObjectWithPaginatedProperty):
 
     def _initAttributes(self) -> None:
         super()._initAttributes()
-        self._author: Attribute[NamedUser] = NotSet
+        self._author: Attribute[NamedUser | None] = NotSet
         self._comments_url: Attribute[str] = NotSet
         self._commit: Attribute[GitCommit] = NotSet
-        self._committer: Attribute[NamedUser] = NotSet
+        self._committer: Attribute[NamedUser | None] = NotSet
         self._files: Attribute[list[File]] = NotSet
         self._html_url: Attribute[str] = NotSet
         self._node_id: Attribute[str] = NotSet
@@ -125,7 +125,7 @@ class Commit(CompletableGithubObjectWithPaginatedProperty):
         return self.sha
 
     @property
-    def author(self) -> NamedUser:
+    def author(self) -> NamedUser | None:
         self._completeIfNotSet(self._author)
         return self._author.value
 
@@ -140,7 +140,7 @@ class Commit(CompletableGithubObjectWithPaginatedProperty):
         return self._commit.value
 
     @property
-    def committer(self) -> NamedUser:
+    def committer(self) -> NamedUser | None:
         self._completeIfNotSet(self._committer)
         return self._committer.value
 

--- a/github/CommitComment.py
+++ b/github/CommitComment.py
@@ -80,14 +80,14 @@ class CommitComment(CompletableGithubObject):
         self._created_at: Attribute[datetime] = NotSet
         self._html_url: Attribute[str] = NotSet
         self._id: Attribute[int] = NotSet
-        self._line: Attribute[int] = NotSet
+        self._line: Attribute[int | None] = NotSet
         self._node_id: Attribute[str] = NotSet
-        self._path: Attribute[str] = NotSet
-        self._position: Attribute[int] = NotSet
+        self._path: Attribute[str | None] = NotSet
+        self._position: Attribute[int | None] = NotSet
         self._reactions: Attribute[dict[str, Any]] = NotSet
         self._updated_at: Attribute[datetime] = NotSet
         self._url: Attribute[str] = NotSet
-        self._user: Attribute[NamedUser | Organization] = NotSet
+        self._user: Attribute[NamedUser | Organization | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"id": self._id.value, "user": self._user.value})
@@ -123,7 +123,7 @@ class CommitComment(CompletableGithubObject):
         return self._id.value
 
     @property
-    def line(self) -> int:
+    def line(self) -> int | None:
         self._completeIfNotSet(self._line)
         return self._line.value
 
@@ -133,12 +133,12 @@ class CommitComment(CompletableGithubObject):
         return self._node_id.value
 
     @property
-    def path(self) -> str:
+    def path(self) -> str | None:
         self._completeIfNotSet(self._path)
         return self._path.value
 
     @property
-    def position(self) -> int:
+    def position(self) -> int | None:
         self._completeIfNotSet(self._position)
         return self._position.value
 
@@ -158,7 +158,7 @@ class CommitComment(CompletableGithubObject):
         return self._url.value
 
     @property
-    def user(self) -> NamedUser | Organization:
+    def user(self) -> NamedUser | Organization | None:
         self._completeIfNotSet(self._user)
         return self._user.value
 
@@ -265,4 +265,4 @@ class CommitComment(CompletableGithubObject):
                 attributes["user"],
                 (github.NamedUser.NamedUser, "User"),
                 (github.Organization.Organization, "Organization"),
-            )
+            )  # type: ignore

--- a/github/CommitStatus.py
+++ b/github/CommitStatus.py
@@ -65,16 +65,16 @@ class CommitStatus(NonCompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._avatar_url: Attribute[str] = NotSet
+        self._avatar_url: Attribute[str | None] = NotSet
         self._context: Attribute[str] = NotSet
         self._created_at: Attribute[datetime] = NotSet
-        self._creator: Attribute[NamedUser | Organization] = NotSet
-        self._description: Attribute[str] = NotSet
+        self._creator: Attribute[NamedUser | Organization | None] = NotSet
+        self._description: Attribute[str | None] = NotSet
         self._id: Attribute[int] = NotSet
         self._node_id: Attribute[str] = NotSet
-        self._required: Attribute[bool] = NotSet
+        self._required: Attribute[bool | None] = NotSet
         self._state: Attribute[str] = NotSet
-        self._target_url: Attribute[str] = NotSet
+        self._target_url: Attribute[str | None] = NotSet
         self._updated_at: Attribute[datetime] = NotSet
         self._url: Attribute[str] = NotSet
 
@@ -88,7 +88,7 @@ class CommitStatus(NonCompletableGithubObject):
         )
 
     @property
-    def avatar_url(self) -> str:
+    def avatar_url(self) -> str | None:
         return self._avatar_url.value
 
     @property
@@ -100,11 +100,11 @@ class CommitStatus(NonCompletableGithubObject):
         return self._created_at.value
 
     @property
-    def creator(self) -> NamedUser | Organization:
+    def creator(self) -> NamedUser | Organization | None:
         return self._creator.value
 
     @property
-    def description(self) -> str:
+    def description(self) -> str | None:
         return self._description.value
 
     @property
@@ -116,7 +116,7 @@ class CommitStatus(NonCompletableGithubObject):
         return self._node_id.value
 
     @property
-    def required(self) -> bool:
+    def required(self) -> bool | None:
         return self._required.value
 
     @property
@@ -124,7 +124,7 @@ class CommitStatus(NonCompletableGithubObject):
         return self._state.value
 
     @property
-    def target_url(self) -> str:
+    def target_url(self) -> str | None:
         return self._target_url.value
 
     @property
@@ -149,7 +149,7 @@ class CommitStatus(NonCompletableGithubObject):
                 attributes["creator"],
                 (github.NamedUser.NamedUser, "User"),
                 (github.Organization.Organization, "Organization"),
-            )
+            )  # type: ignore
         if "description" in attributes:  # pragma no branch
             self._description = self._makeStringAttribute(attributes["description"])
         if "id" in attributes:  # pragma no branch

--- a/github/ContentFile.py
+++ b/github/ContentFile.py
@@ -81,15 +81,15 @@ class ContentFile(CompletableGithubObject):
     def _initAttributes(self) -> None:
         self.__links: Attribute[dict[str, Any]] = NotSet
         self._commit: Attribute[GitCommit] = NotSet
-        self._content: Attribute[str] = NotSet
-        self._download_url: Attribute[str] = NotSet
+        self._content: Attribute[str | None] = NotSet
+        self._download_url: Attribute[str | None] = NotSet
         self._encoding: Attribute[str] = NotSet
         self._file_size: Attribute[int] = NotSet
-        self._git_url: Attribute[str] = NotSet
-        self._html_url: Attribute[str] = NotSet
+        self._git_url: Attribute[str | None] = NotSet
+        self._html_url: Attribute[str | None] = NotSet
         self._language: Attribute[str] = NotSet
         self._last_modified_at: Attribute[datetime] = NotSet
-        self._license: Attribute[License] = NotSet
+        self._license: Attribute[License | None] = NotSet
         self._line_numbers: Attribute[list[str]] = NotSet
         self._name: Attribute[str] = NotSet
         self._path: Attribute[str] = NotSet
@@ -116,17 +116,19 @@ class ContentFile(CompletableGithubObject):
         return self._commit.value
 
     @property
-    def content(self) -> str:
+    def content(self) -> str | None:
         self._completeIfNotSet(self._content)
         return self._content.value
 
     @property
     def decoded_content(self) -> bytes:
         assert self.encoding == "base64", f"unsupported encoding: {self.encoding}"
-        return base64.b64decode(bytearray(self.content, "utf-8"))
+        content = self.content
+        assert content is not None, "content is not set"
+        return base64.b64decode(bytearray(content, "utf-8"))
 
     @property
-    def download_url(self) -> str:
+    def download_url(self) -> str | None:
         self._completeIfNotSet(self._download_url)
         return self._download_url.value
 
@@ -141,12 +143,12 @@ class ContentFile(CompletableGithubObject):
         return self._file_size.value
 
     @property
-    def git_url(self) -> str:
+    def git_url(self) -> str | None:
         self._completeIfNotSet(self._git_url)
         return self._git_url.value
 
     @property
-    def html_url(self) -> str:
+    def html_url(self) -> str | None:
         self._completeIfNotSet(self._html_url)
         return self._html_url.value
 
@@ -161,7 +163,7 @@ class ContentFile(CompletableGithubObject):
         return self._last_modified_at.value
 
     @property
-    def license(self) -> License:
+    def license(self) -> License | None:
         self._completeIfNotSet(self._license)
         return self._license.value
 

--- a/github/CopilotSeat.py
+++ b/github/CopilotSeat.py
@@ -57,8 +57,8 @@ class CopilotSeat(NonCompletableGithubObject):
         self._created_at: Attribute[datetime] | _NotSetType = NotSet
         self._last_activity_at: Attribute[datetime] | _NotSetType = NotSet
         self._last_activity_editor: Attribute[str] | _NotSetType = NotSet
-        self._last_authenticated_at: Attribute[datetime] = NotSet
-        self._organization: Attribute[Organization] = NotSet
+        self._last_authenticated_at: Attribute[datetime | None] = NotSet
+        self._organization: Attribute[Organization | None] = NotSet
         self._pending_cancellation_date: Attribute[datetime] | _NotSetType = NotSet
         self._plan_type: Attribute[str] | _NotSetType = NotSet
         self._updated_at: Attribute[datetime] | _NotSetType = NotSet
@@ -67,11 +67,11 @@ class CopilotSeat(NonCompletableGithubObject):
         return self.get__repr__({"assignee": self._assignee.value})
 
     @property
-    def assignee(self) -> NamedUser:
+    def assignee(self) -> NamedUser | None:
         return self._assignee.value
 
     @property
-    def assigning_team(self) -> Team:
+    def assigning_team(self) -> Team | None:
         return self._assigning_team.value
 
     @property
@@ -79,23 +79,23 @@ class CopilotSeat(NonCompletableGithubObject):
         return self._created_at.value
 
     @property
-    def last_activity_at(self) -> datetime:
+    def last_activity_at(self) -> datetime | None:
         return self._last_activity_at.value
 
     @property
-    def last_activity_editor(self) -> str:
+    def last_activity_editor(self) -> str | None:
         return self._last_activity_editor.value
 
     @property
-    def last_authenticated_at(self) -> datetime:
+    def last_authenticated_at(self) -> datetime | None:
         return self._last_authenticated_at.value
 
     @property
-    def organization(self) -> Organization:
+    def organization(self) -> Organization | None:
         return self._organization.value
 
     @property
-    def pending_cancellation_date(self) -> datetime:
+    def pending_cancellation_date(self) -> datetime | None:
         return self._pending_cancellation_date.value
 
     @property

--- a/github/DependabotAlert.py
+++ b/github/DependabotAlert.py
@@ -58,14 +58,14 @@ class DependabotAlert(NonCompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._auto_dismissed_at: Attribute[datetime] = NotSet
+        self._auto_dismissed_at: Attribute[datetime | None] = NotSet
         self._created_at: Attribute[datetime] = NotSet
         self._dependency: Attribute[DependabotAlertDependency] = NotSet
         self._dismissed_at: Attribute[datetime | None] = NotSet
         self._dismissed_by: Attribute[NamedUser | Organization | None] = NotSet
         self._dismissed_comment: Attribute[str | None] = NotSet
         self._dismissed_reason: Attribute[str | None] = NotSet
-        self._fixed_at: Attribute[str] = NotSet
+        self._fixed_at: Attribute[str | None] = NotSet
         self._html_url: Attribute[str] = NotSet
         self._number: Attribute[int] = NotSet
         self._security_advisory: Attribute[DependabotAlertAdvisory] = NotSet
@@ -78,7 +78,7 @@ class DependabotAlert(NonCompletableGithubObject):
         return self.get__repr__({"number": self.number, "ghsa_id": self.security_advisory.ghsa_id})
 
     @property
-    def auto_dismissed_at(self) -> datetime:
+    def auto_dismissed_at(self) -> datetime | None:
         return self._auto_dismissed_at.value
 
     @property

--- a/github/DependabotAlertDependency.py
+++ b/github/DependabotAlertDependency.py
@@ -51,8 +51,8 @@ class DependabotAlertDependency(NonCompletableGithubObject):
     def _initAttributes(self) -> None:
         self._manifest_path: Attribute[str] = NotSet
         self._package: Attribute[AdvisoryVulnerabilityPackage] = NotSet
-        self._relationship: Attribute[str] = NotSet
-        self._scope: Attribute[str] = NotSet
+        self._relationship: Attribute[str | None] = NotSet
+        self._scope: Attribute[str | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__(
@@ -71,11 +71,11 @@ class DependabotAlertDependency(NonCompletableGithubObject):
         return self._package.value
 
     @property
-    def relationship(self) -> str:
+    def relationship(self) -> str | None:
         return self._relationship.value
 
     @property
-    def scope(self) -> str:
+    def scope(self) -> str | None:
         return self._scope.value
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:

--- a/github/DependabotAlertVulnerability.py
+++ b/github/DependabotAlertVulnerability.py
@@ -44,7 +44,7 @@ class DependabotAlertVulnerability(NonCompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._first_patched_version: Attribute[dict] = NotSet
+        self._first_patched_version: Attribute[dict | None] = NotSet
         self._package: Attribute[AdvisoryVulnerabilityPackage] = NotSet
         self._severity: Attribute[str] = NotSet
         self._vulnerable_version_range: Attribute[str | None] = NotSet
@@ -53,7 +53,7 @@ class DependabotAlertVulnerability(NonCompletableGithubObject):
         return self.get__repr__({"package": self.package, "severity": self.severity})
 
     @property
-    def first_patched_version(self) -> dict:
+    def first_patched_version(self) -> dict | None:
         return self._first_patched_version.value
 
     @property

--- a/github/Deployment.py
+++ b/github/Deployment.py
@@ -80,14 +80,14 @@ class Deployment(CompletableGithubObject):
 
     def _initAttributes(self) -> None:
         self._created_at: Attribute[datetime] = NotSet
-        self._creator: Attribute[NamedUser | Organization] = NotSet
-        self._description: Attribute[str] = NotSet
+        self._creator: Attribute[NamedUser | Organization | None] = NotSet
+        self._description: Attribute[str | None] = NotSet
         self._environment: Attribute[str] = NotSet
         self._id: Attribute[int] = NotSet
         self._node_id: Attribute[str] = NotSet
         self._original_environment: Attribute[str] = NotSet
         self._payload: Attribute[dict[str, Any]] = NotSet
-        self._performed_via_github_app: Attribute[GithubApp] = NotSet
+        self._performed_via_github_app: Attribute[GithubApp | None] = NotSet
         self._production_environment: Attribute[bool] = NotSet
         self._ref: Attribute[str] = NotSet
         self._repository_url: Attribute[str] = NotSet
@@ -107,12 +107,12 @@ class Deployment(CompletableGithubObject):
         return self._created_at.value
 
     @property
-    def creator(self) -> NamedUser | Organization:
+    def creator(self) -> NamedUser | Organization | None:
         self._completeIfNotSet(self._creator)
         return self._creator.value
 
     @property
-    def description(self) -> str:
+    def description(self) -> str | None:
         self._completeIfNotSet(self._description)
         return self._description.value
 
@@ -142,7 +142,7 @@ class Deployment(CompletableGithubObject):
         return self._payload.value
 
     @property
-    def performed_via_github_app(self) -> GithubApp:
+    def performed_via_github_app(self) -> GithubApp | None:
         self._completeIfNotSet(self._performed_via_github_app)
         return self._performed_via_github_app.value
 
@@ -272,7 +272,7 @@ class Deployment(CompletableGithubObject):
                 attributes["creator"],
                 (github.NamedUser.NamedUser, "User"),
                 (github.Organization.Organization, "Organization"),
-            )
+            )  # type: ignore
         if "description" in attributes:  # pragma no branch
             self._description = self._makeStringAttribute(attributes["description"])
         if "environment" in attributes:  # pragma no branch

--- a/github/DeploymentStatus.py
+++ b/github/DeploymentStatus.py
@@ -72,7 +72,7 @@ class DeploymentStatus(CompletableGithubObject):
 
     def _initAttributes(self) -> None:
         self._created_at: Attribute[datetime] = NotSet
-        self._creator: Attribute[NamedUser] = NotSet
+        self._creator: Attribute[NamedUser | None] = NotSet
         self._deployment_url: Attribute[str] = NotSet
         self._description: Attribute[str] = NotSet
         self._environment: Attribute[str] = NotSet
@@ -80,7 +80,7 @@ class DeploymentStatus(CompletableGithubObject):
         self._id: Attribute[int] = NotSet
         self._log_url: Attribute[str] = NotSet
         self._node_id: Attribute[str] = NotSet
-        self._performed_via_github_app: Attribute[GithubApp] = NotSet
+        self._performed_via_github_app: Attribute[GithubApp | None] = NotSet
         self._repository_url: Attribute[str] = NotSet
         self._state: Attribute[str] = NotSet
         self._target_url: Attribute[str] = NotSet
@@ -96,7 +96,7 @@ class DeploymentStatus(CompletableGithubObject):
         return self._created_at.value
 
     @property
-    def creator(self) -> NamedUser:
+    def creator(self) -> NamedUser | None:
         self._completeIfNotSet(self._creator)
         return self._creator.value
 
@@ -136,7 +136,7 @@ class DeploymentStatus(CompletableGithubObject):
         return self._node_id.value
 
     @property
-    def performed_via_github_app(self) -> GithubApp:
+    def performed_via_github_app(self) -> GithubApp | None:
         self._completeIfNotSet(self._performed_via_github_app)
         return self._performed_via_github_app.value
 

--- a/github/Enterprise.py
+++ b/github/Enterprise.py
@@ -70,16 +70,16 @@ class Enterprise(NonCompletableGithubObject):
 
     def _initAttributes(self) -> None:
         self._avatar_url: Attribute[str] = NotSet
-        self._created_at: Attribute[datetime] = NotSet
-        self._description: Attribute[str] = NotSet
+        self._created_at: Attribute[datetime | None] = NotSet
+        self._description: Attribute[str | None] = NotSet
         self._html_url: Attribute[str] = NotSet
         self._id: Attribute[int] = NotSet
         self._name: Attribute[str] = NotSet
         self._node_id: Attribute[str] = NotSet
         self._slug: Attribute[str] = NotSet
-        self._updated_at: Attribute[datetime] = NotSet
+        self._updated_at: Attribute[datetime | None] = NotSet
         self._url: Attribute[str] = NotSet
-        self._website_url: Attribute[str] = NotSet
+        self._website_url: Attribute[str | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"slug": self._slug.value})
@@ -89,11 +89,11 @@ class Enterprise(NonCompletableGithubObject):
         return self._avatar_url.value
 
     @property
-    def created_at(self) -> datetime:
+    def created_at(self) -> datetime | None:
         return self._created_at.value
 
     @property
-    def description(self) -> str:
+    def description(self) -> str | None:
         return self._description.value
 
     @property
@@ -123,7 +123,7 @@ class Enterprise(NonCompletableGithubObject):
         return self._slug.value
 
     @property
-    def updated_at(self) -> datetime:
+    def updated_at(self) -> datetime | None:
         return self._updated_at.value
 
     @property
@@ -133,7 +133,7 @@ class Enterprise(NonCompletableGithubObject):
         return self._url.value
 
     @property
-    def website_url(self) -> str:
+    def website_url(self) -> str | None:
         return self._website_url.value
 
     @staticmethod

--- a/github/Environment.py
+++ b/github/Environment.py
@@ -77,7 +77,7 @@ class Environment(CompletableGithubObject):
 
     def _initAttributes(self) -> None:
         self._created_at: Attribute[datetime] = NotSet
-        self._deployment_branch_policy: Attribute[EnvironmentDeploymentBranchPolicy] = NotSet
+        self._deployment_branch_policy: Attribute[EnvironmentDeploymentBranchPolicy | None] = NotSet
         self._environments_url: Attribute[str] = NotSet
         self._html_url: Attribute[str] = NotSet
         self._id: Attribute[int] = NotSet
@@ -98,7 +98,7 @@ class Environment(CompletableGithubObject):
     @property
     def deployment_branch_policy(
         self,
-    ) -> EnvironmentDeploymentBranchPolicy:
+    ) -> EnvironmentDeploymentBranchPolicy | None:
         self._completeIfNotSet(self._deployment_branch_policy)
         return self._deployment_branch_policy.value
 

--- a/github/Event.py
+++ b/github/Event.py
@@ -71,13 +71,13 @@ class Event(NonCompletableGithubObject):
 
     def _initAttributes(self) -> None:
         self._actor: Attribute[NamedUser] = NotSet
-        self._created_at: Attribute[datetime] = NotSet
+        self._created_at: Attribute[datetime | None] = NotSet
         self._id: Attribute[str] = NotSet
         self._org: Attribute[Organization] = NotSet
         self._payload: Attribute[dict[str, Any]] = NotSet
         self._public: Attribute[bool] = NotSet
         self._repo: Attribute[Repository] = NotSet
-        self._type: Attribute[str] = NotSet
+        self._type: Attribute[str | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"id": self._id.value, "type": self._type.value})
@@ -87,7 +87,7 @@ class Event(NonCompletableGithubObject):
         return self._actor.value
 
     @property
-    def created_at(self) -> datetime:
+    def created_at(self) -> datetime | None:
         return self._created_at.value
 
     @property
@@ -111,7 +111,7 @@ class Event(NonCompletableGithubObject):
         return self._repo.value
 
     @property
-    def type(self) -> str:
+    def type(self) -> str | None:
         return self._type.value
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:

--- a/github/File.py
+++ b/github/File.py
@@ -66,7 +66,7 @@ class File(NonCompletableGithubObject):
         self._patch: Attribute[str] = NotSet
         self._previous_filename: Attribute[str] = NotSet
         self._raw_url: Attribute[str] = NotSet
-        self._sha: Attribute[str] = NotSet
+        self._sha: Attribute[str | None] = NotSet
         self._status: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
@@ -109,7 +109,7 @@ class File(NonCompletableGithubObject):
         return self._raw_url.value
 
     @property
-    def sha(self) -> str:
+    def sha(self) -> str | None:
         return self._sha.value
 
     @property

--- a/github/Gist.py
+++ b/github/Gist.py
@@ -91,23 +91,23 @@ class Gist(CompletableGithubObject):
         self._comments_url: Attribute[str] = NotSet
         self._commits_url: Attribute[str] = NotSet
         self._created_at: Attribute[datetime] = NotSet
-        self._description: Attribute[str] = NotSet
+        self._description: Attribute[str | None] = NotSet
         self._files: Attribute[dict[str, GistFile]] = NotSet
-        self._fork_of: Attribute[Gist] = NotSet
-        self._forks: Attribute[list[Gist]] = NotSet
+        self._fork_of: Attribute[Gist | None] = NotSet
+        self._forks: Attribute[list[Gist] | None] = NotSet
         self._forks_url: Attribute[str] = NotSet
         self._git_pull_url: Attribute[str] = NotSet
         self._git_push_url: Attribute[str] = NotSet
-        self._history: Attribute[list[GistHistoryState]] = NotSet
+        self._history: Attribute[list[GistHistoryState] | None] = NotSet
         self._html_url: Attribute[str] = NotSet
         self._id: Attribute[str] = NotSet
         self._node_id: Attribute[str] = NotSet
-        self._owner: Attribute[NamedUser] = NotSet
+        self._owner: Attribute[NamedUser | None] = NotSet
         self._public: Attribute[bool] = NotSet
         self._truncated: Attribute[bool] = NotSet
         self._updated_at: Attribute[datetime] = NotSet
         self._url: Attribute[str] = NotSet
-        self._user: Attribute[NamedUser] = NotSet
+        self._user: Attribute[NamedUser | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"id": self._id.value})
@@ -138,7 +138,7 @@ class Gist(CompletableGithubObject):
         return self._created_at.value
 
     @property
-    def description(self) -> str:
+    def description(self) -> str | None:
         self._completeIfNotSet(self._description)
         return self._description.value
 
@@ -148,12 +148,12 @@ class Gist(CompletableGithubObject):
         return self._files.value
 
     @property
-    def fork_of(self) -> Gist:
+    def fork_of(self) -> Gist | None:
         self._completeIfNotSet(self._fork_of)
         return self._fork_of.value
 
     @property
-    def forks(self) -> list[Gist]:
+    def forks(self) -> list[Gist] | None:
         self._completeIfNotSet(self._forks)
         return self._forks.value
 
@@ -173,7 +173,7 @@ class Gist(CompletableGithubObject):
         return self._git_push_url.value
 
     @property
-    def history(self) -> list[GistHistoryState]:
+    def history(self) -> list[GistHistoryState] | None:
         self._completeIfNotSet(self._history)
         return self._history.value
 
@@ -193,7 +193,7 @@ class Gist(CompletableGithubObject):
         return self._node_id.value
 
     @property
-    def owner(self) -> NamedUser:
+    def owner(self) -> NamedUser | None:
         self._completeIfNotSet(self._owner)
         return self._owner.value
 
@@ -218,7 +218,7 @@ class Gist(CompletableGithubObject):
         return self._url.value
 
     @property
-    def user(self) -> NamedUser:
+    def user(self) -> NamedUser | None:
         self._completeIfNotSet(self._user)
         return self._user.value
 

--- a/github/GistComment.py
+++ b/github/GistComment.py
@@ -75,7 +75,7 @@ class GistComment(CompletableGithubObject):
         self._node_id: Attribute[str] = NotSet
         self._updated_at: Attribute[datetime] = NotSet
         self._url: Attribute[str] = NotSet
-        self._user: Attribute[NamedUser] = NotSet
+        self._user: Attribute[NamedUser | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"id": self._id.value, "user": self._user.value})
@@ -116,7 +116,7 @@ class GistComment(CompletableGithubObject):
         return self._url.value
 
     @property
-    def user(self) -> NamedUser:
+    def user(self) -> NamedUser | None:
         self._completeIfNotSet(self._user)
         return self._user.value
 

--- a/github/GistHistoryState.py
+++ b/github/GistHistoryState.py
@@ -87,7 +87,7 @@ class GistHistoryState(CompletableGithubObject):
         self._public: Attribute[bool] = NotSet
         self._updated_at: Attribute[datetime] = NotSet
         self._url: Attribute[str] = NotSet
-        self._user: Attribute[NamedUser] = NotSet
+        self._user: Attribute[NamedUser | None] = NotSet
         self._version: Attribute[str] = NotSet
 
     @property
@@ -186,7 +186,7 @@ class GistHistoryState(CompletableGithubObject):
         return self._url.value
 
     @property
-    def user(self) -> NamedUser:
+    def user(self) -> NamedUser | None:
         self._completeIfNotSet(self._user)
         return self._user.value
 

--- a/github/GitBlob.py
+++ b/github/GitBlob.py
@@ -64,7 +64,7 @@ class GitBlob(CompletableGithubObject):
         self._highlighted_content: Attribute[str] = NotSet
         self._node_id: Attribute[str] = NotSet
         self._sha: Attribute[str] = NotSet
-        self._size: Attribute[int] = NotSet
+        self._size: Attribute[int | None] = NotSet
         self._url: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
@@ -96,7 +96,7 @@ class GitBlob(CompletableGithubObject):
         return self._sha.value
 
     @property
-    def size(self) -> int:
+    def size(self) -> int | None:
         self._completeIfNotSet(self._size)
         return self._size.value
 

--- a/github/GitCommit.py
+++ b/github/GitCommit.py
@@ -76,9 +76,9 @@ class GitCommit(CompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._author: Attribute[GitAuthor] = NotSet
+        self._author: Attribute[GitAuthor | None] = NotSet
         self._comment_count: Attribute[int] = NotSet
-        self._committer: Attribute[GitAuthor] = NotSet
+        self._committer: Attribute[GitAuthor | None] = NotSet
         self._html_url: Attribute[str] = NotSet
         self._id: Attribute[str] = NotSet
         self._message: Attribute[str] = NotSet
@@ -99,7 +99,7 @@ class GitCommit(CompletableGithubObject):
         return self.sha
 
     @property
-    def author(self) -> GitAuthor:
+    def author(self) -> GitAuthor | None:
         self._completeIfNotSet(self._author)
         return self._author.value
 
@@ -109,7 +109,7 @@ class GitCommit(CompletableGithubObject):
         return self._comment_count.value
 
     @property
-    def committer(self) -> GitAuthor:
+    def committer(self) -> GitAuthor | None:
         self._completeIfNotSet(self._committer)
         return self._committer.value
 

--- a/github/GitCommitVerification.py
+++ b/github/GitCommitVerification.py
@@ -63,14 +63,14 @@ class GitCommitVerification(NonCompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._payload: Attribute[str] = NotSet
+        self._payload: Attribute[str | None] = NotSet
         self._reason: Attribute[str] = NotSet
-        self._signature: Attribute[str] = NotSet
+        self._signature: Attribute[str | None] = NotSet
         self._verified: Attribute[bool] = NotSet
-        self._verified_at: Attribute[datetime] = NotSet
+        self._verified_at: Attribute[datetime | None] = NotSet
 
     @property
-    def payload(self) -> str:
+    def payload(self) -> str | None:
         return self._payload.value
 
     @property
@@ -78,7 +78,7 @@ class GitCommitVerification(NonCompletableGithubObject):
         return self._reason.value
 
     @property
-    def signature(self) -> str:
+    def signature(self) -> str | None:
         return self._signature.value
 
     @property
@@ -86,7 +86,7 @@ class GitCommitVerification(NonCompletableGithubObject):
         return self._verified.value
 
     @property
-    def verified_at(self) -> datetime:
+    def verified_at(self) -> datetime | None:
         return self._verified_at.value
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:

--- a/github/GitRelease.py
+++ b/github/GitRelease.py
@@ -97,7 +97,7 @@ class GitRelease(CompletableGithubObject):
         self._assets: Attribute[list[GitReleaseAsset]] = NotSet
         self._assets_url: Attribute[str] = NotSet
         self._author: Attribute[NamedUser] = NotSet
-        self._body: Attribute[str] = NotSet
+        self._body: Attribute[str | None] = NotSet
         self._body_html: Attribute[str] = NotSet
         self._body_text: Attribute[str] = NotSet
         self._created_at: Attribute[datetime] = NotSet
@@ -110,19 +110,19 @@ class GitRelease(CompletableGithubObject):
         self._immutable: Attribute[bool] = NotSet
         self._mentions_count: Attribute[int] = NotSet
         self._message: Attribute[str] = NotSet
-        self._name: Attribute[str] = NotSet
+        self._name: Attribute[str | None] = NotSet
         self._node_id: Attribute[str] = NotSet
         self._prerelease: Attribute[bool] = NotSet
-        self._published_at: Attribute[datetime] = NotSet
+        self._published_at: Attribute[datetime | None] = NotSet
         self._reactions: Attribute[dict[str, Any]] = NotSet
         self._status: Attribute[str] = NotSet
         self._tag_name: Attribute[str] = NotSet
-        self._tarball_url: Attribute[str] = NotSet
+        self._tarball_url: Attribute[str | None] = NotSet
         self._target_commitish: Attribute[str] = NotSet
-        self._updated_at: Attribute[datetime] = NotSet
+        self._updated_at: Attribute[datetime | None] = NotSet
         self._upload_url: Attribute[str] = NotSet
         self._url: Attribute[str] = NotSet
-        self._zipball_url: Attribute[str] = NotSet
+        self._zipball_url: Attribute[str | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"name": self._name.value})
@@ -143,7 +143,7 @@ class GitRelease(CompletableGithubObject):
         return self._author.value
 
     @property
-    def body(self) -> str:
+    def body(self) -> str | None:
         self._completeIfNotSet(self._body)
         return self._body.value
 
@@ -203,7 +203,7 @@ class GitRelease(CompletableGithubObject):
         return self._message.value
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         self._completeIfNotSet(self._name)
         return self._name.value
 
@@ -218,7 +218,7 @@ class GitRelease(CompletableGithubObject):
         return self._prerelease.value
 
     @property
-    def published_at(self) -> datetime:
+    def published_at(self) -> datetime | None:
         self._completeIfNotSet(self._published_at)
         return self._published_at.value
 
@@ -238,7 +238,7 @@ class GitRelease(CompletableGithubObject):
         return self._tag_name.value
 
     @property
-    def tarball_url(self) -> str:
+    def tarball_url(self) -> str | None:
         self._completeIfNotSet(self._tarball_url)
         return self._tarball_url.value
 
@@ -249,12 +249,12 @@ class GitRelease(CompletableGithubObject):
 
     @property
     @deprecated("Use name instead")
-    def title(self) -> str:
+    def title(self) -> str | None:
         # alias for name
         return self.name
 
     @property
-    def updated_at(self) -> datetime:
+    def updated_at(self) -> datetime | None:
         self._completeIfNotSet(self._updated_at)
         return self._updated_at.value
 
@@ -269,7 +269,7 @@ class GitRelease(CompletableGithubObject):
         return self._url.value
 
     @property
-    def zipball_url(self) -> str:
+    def zipball_url(self) -> str | None:
         self._completeIfNotSet(self._zipball_url)
         return self._zipball_url.value
 

--- a/github/GitReleaseAsset.py
+++ b/github/GitReleaseAsset.py
@@ -78,13 +78,13 @@ class GitReleaseAsset(CompletableGithubObject):
         self._digest: Attribute[str | None] = NotSet
         self._download_count: Attribute[int] = NotSet
         self._id: Attribute[int] = NotSet
-        self._label: Attribute[str] = NotSet
+        self._label: Attribute[str | None] = NotSet
         self._name: Attribute[str] = NotSet
         self._node_id: Attribute[str] = NotSet
         self._size: Attribute[int] = NotSet
         self._state: Attribute[str] = NotSet
         self._updated_at: Attribute[datetime] = NotSet
-        self._uploader: Attribute[NamedUser] = NotSet
+        self._uploader: Attribute[NamedUser | None] = NotSet
         self._url: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
@@ -121,7 +121,7 @@ class GitReleaseAsset(CompletableGithubObject):
         return self._id.value
 
     @property
-    def label(self) -> str:
+    def label(self) -> str | None:
         self._completeIfNotSet(self._label)
         return self._label.value
 
@@ -151,7 +151,7 @@ class GitReleaseAsset(CompletableGithubObject):
         return self._updated_at.value
 
     @property
-    def uploader(self) -> NamedUser:
+    def uploader(self) -> NamedUser | None:
         self._completeIfNotSet(self._uploader)
         return self._uploader.value
 

--- a/github/GithubApp.py
+++ b/github/GithubApp.py
@@ -78,7 +78,7 @@ class GithubApp(CompletableGithubObject):
         self._client_id: Attribute[str] = NotSet
         self._client_secret: Attribute[str] = NotSet
         self._created_at: Attribute[datetime] = NotSet
-        self._description: Attribute[str] = NotSet
+        self._description: Attribute[str | None] = NotSet
         self._events: Attribute[list[str]] = NotSet
         self._external_url: Attribute[str] = NotSet
         self._html_url: Attribute[str] = NotSet
@@ -113,7 +113,7 @@ class GithubApp(CompletableGithubObject):
         return self._created_at.value
 
     @property
-    def description(self) -> str:
+    def description(self) -> str | None:
         self._completeIfNotSet(self._description)
         return self._description.value
 

--- a/github/GlobalAdvisory.py
+++ b/github/GlobalAdvisory.py
@@ -55,15 +55,15 @@ class GlobalAdvisory(AdvisoryBase):
 
     def _initAttributes(self) -> None:
         super()._initAttributes()
-        self._credits: Attribute[list[AdvisoryCreditDetailed]] = NotSet
-        self._epss: Attribute[dict[str, Any]] = NotSet
-        self._github_reviewed_at: Attribute[datetime] = NotSet
-        self._nvd_published_at: Attribute[datetime] = NotSet
-        self._references: Attribute[list[str]] = NotSet
-        self._repository_advisory_url: Attribute[str] = NotSet
-        self._source_code_location: Attribute[str] = NotSet
+        self._credits: Attribute[list[AdvisoryCreditDetailed] | None] = NotSet
+        self._epss: Attribute[dict[str, Any] | None] = NotSet
+        self._github_reviewed_at: Attribute[datetime | None] = NotSet
+        self._nvd_published_at: Attribute[datetime | None] = NotSet
+        self._references: Attribute[list[str] | None] = NotSet
+        self._repository_advisory_url: Attribute[str | None] = NotSet
+        self._source_code_location: Attribute[str | None] = NotSet
         self._type: Attribute[str] = NotSet
-        self._vulnerabilities: Attribute[list[AdvisoryVulnerability]] = NotSet
+        self._vulnerabilities: Attribute[list[AdvisoryVulnerability] | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"ghsa_id": self.ghsa_id, "summary": self.summary})
@@ -71,31 +71,31 @@ class GlobalAdvisory(AdvisoryBase):
     @property
     def credits(
         self,
-    ) -> list[AdvisoryCreditDetailed]:
+    ) -> list[AdvisoryCreditDetailed] | None:
         return self._credits.value
 
     @property
-    def epss(self) -> dict[str, Any]:
+    def epss(self) -> dict[str, Any] | None:
         return self._epss.value
 
     @property
-    def github_reviewed_at(self) -> datetime:
+    def github_reviewed_at(self) -> datetime | None:
         return self._github_reviewed_at.value
 
     @property
-    def nvd_published_at(self) -> datetime:
+    def nvd_published_at(self) -> datetime | None:
         return self._nvd_published_at.value
 
     @property
-    def references(self) -> list[str]:
+    def references(self) -> list[str] | None:
         return self._references.value
 
     @property
-    def repository_advisory_url(self) -> str:
+    def repository_advisory_url(self) -> str | None:
         return self._repository_advisory_url.value
 
     @property
-    def source_code_location(self) -> str:
+    def source_code_location(self) -> str | None:
         return self._source_code_location.value
 
     @property
@@ -103,7 +103,7 @@ class GlobalAdvisory(AdvisoryBase):
         return self._type.value
 
     @property
-    def vulnerabilities(self) -> list[AdvisoryVulnerability]:
+    def vulnerabilities(self) -> list[AdvisoryVulnerability] | None:
         return self._vulnerabilities.value
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:

--- a/github/HookDelivery.py
+++ b/github/HookDelivery.py
@@ -45,18 +45,18 @@ class HookDeliverySummary(NonCompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._action: Attribute[str] = NotSet
+        self._action: Attribute[str | None] = NotSet
         self._delivered_at: Attribute[datetime] = NotSet
         self._duration: Attribute[float] = NotSet
         self._event: Attribute[str] = NotSet
         self._guid: Attribute[str] = NotSet
         self._id: Attribute[int] = NotSet
-        self._installation_id: Attribute[int] = NotSet
+        self._installation_id: Attribute[int | None] = NotSet
         self._redelivery: Attribute[bool] = NotSet
-        self._repository_id: Attribute[int] = NotSet
+        self._repository_id: Attribute[int | None] = NotSet
         self._status: Attribute[str] = NotSet
         self._status_code: Attribute[int] = NotSet
-        self._throttled_at: Attribute[datetime] = NotSet
+        self._throttled_at: Attribute[datetime | None] = NotSet
         self._url: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
@@ -107,7 +107,7 @@ class HookDeliverySummary(NonCompletableGithubObject):
         return self._status_code.value
 
     @property
-    def throttled_at(self) -> datetime:
+    def throttled_at(self) -> datetime | None:
         return self._throttled_at.value
 
     @property
@@ -154,8 +154,8 @@ class HookDeliveryRequest(NonCompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self.__headers: Attribute[dict] = NotSet
-        self._payload: Attribute[dict] = NotSet
+        self.__headers: Attribute[dict | None] = NotSet
+        self._payload: Attribute[dict | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"payload": self._payload.value})
@@ -186,8 +186,8 @@ class HookDeliveryResponse(NonCompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self.__headers: Attribute[dict] = NotSet
-        self._payload: Attribute[str] = NotSet
+        self.__headers: Attribute[dict | None] = NotSet
+        self._payload: Attribute[str | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"payload": self._payload.value})

--- a/github/HookResponse.py
+++ b/github/HookResponse.py
@@ -54,23 +54,23 @@ class HookResponse(NonCompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._code: Attribute[int] = NotSet
-        self._message: Attribute[str] = NotSet
-        self._status: Attribute[str] = NotSet
+        self._code: Attribute[int | None] = NotSet
+        self._message: Attribute[str | None] = NotSet
+        self._status: Attribute[str | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"status": self._status.value})
 
     @property
-    def code(self) -> int:
+    def code(self) -> int | None:
         return self._code.value
 
     @property
-    def message(self) -> str:
+    def message(self) -> str | None:
         return self._message.value
 
     @property
-    def status(self) -> str:
+    def status(self) -> str | None:
         return self._status.value
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:

--- a/github/Installation.py
+++ b/github/Installation.py
@@ -105,11 +105,11 @@ class Installation(NonCompletableGithubObject):
 
     def _initAttributes(self) -> None:
         self._access_tokens_url: Attribute[str] = NotSet
-        self._account: Attribute[NamedUser | Organization] = NotSet
+        self._account: Attribute[NamedUser | Organization | None] = NotSet
         self._app_id: Attribute[int] = NotSet
         self._app_slug: Attribute[str] = NotSet
         self._client_id: Attribute[str] = NotSet
-        self._contact_email: Attribute[str] = NotSet
+        self._contact_email: Attribute[str | None] = NotSet
         self._created_at: Attribute[datetime] = NotSet
         self._events: Attribute[list[str]] = NotSet
         self._has_multiple_single_files: Attribute[bool] = NotSet
@@ -118,10 +118,10 @@ class Installation(NonCompletableGithubObject):
         self._permissions: Attribute[dict[str, Any]] = NotSet
         self._repositories_url: Attribute[str] = NotSet
         self._repository_selection: Attribute[str] = NotSet
-        self._single_file_name: Attribute[str] = NotSet
+        self._single_file_name: Attribute[str | None] = NotSet
         self._single_file_paths: Attribute[list[str]] = NotSet
-        self._suspended_at: Attribute[datetime] = NotSet
-        self._suspended_by: Attribute[NamedUser] = NotSet
+        self._suspended_at: Attribute[datetime | None] = NotSet
+        self._suspended_by: Attribute[NamedUser | None] = NotSet
         self._target_id: Attribute[int] = NotSet
         self._target_type: Attribute[str] = NotSet
         self._updated_at: Attribute[datetime] = NotSet
@@ -134,7 +134,7 @@ class Installation(NonCompletableGithubObject):
         return self._access_tokens_url.value
 
     @property
-    def account(self) -> NamedUser | Organization:
+    def account(self) -> NamedUser | Organization | None:
         return self._account.value
 
     @property
@@ -150,7 +150,7 @@ class Installation(NonCompletableGithubObject):
         return self._client_id.value
 
     @property
-    def contact_email(self) -> str:
+    def contact_email(self) -> str | None:
         return self._contact_email.value
 
     @property
@@ -196,7 +196,7 @@ class Installation(NonCompletableGithubObject):
         return self._requester
 
     @property
-    def single_file_name(self) -> str:
+    def single_file_name(self) -> str | None:
         return self._single_file_name.value
 
     @property
@@ -204,11 +204,11 @@ class Installation(NonCompletableGithubObject):
         return self._single_file_paths.value
 
     @property
-    def suspended_at(self) -> datetime:
+    def suspended_at(self) -> datetime | None:
         return self._suspended_at.value
 
     @property
-    def suspended_by(self) -> NamedUser:
+    def suspended_by(self) -> NamedUser | None:
         return self._suspended_by.value
 
     @property
@@ -252,7 +252,7 @@ class Installation(NonCompletableGithubObject):
                 attributes,
                 (github.NamedUser.NamedUser, "User"),
                 (github.Organization.Organization, "Organization"),
-            )
+            )  # type: ignore
         if "app_id" in attributes:  # pragma no branch
             self._app_id = self._makeIntAttribute(attributes["app_id"])
         if "app_slug" in attributes:  # pragma no branch

--- a/github/Invitation.py
+++ b/github/Invitation.py
@@ -74,8 +74,8 @@ class Invitation(CompletableGithubObject):
         self._expired: Attribute[bool] = NotSet
         self._html_url: Attribute[str] = NotSet
         self._id: Attribute[int] = NotSet
-        self._invitee: Attribute[NamedUser | Organization] = NotSet
-        self._inviter: Attribute[NamedUser | Organization] = NotSet
+        self._invitee: Attribute[NamedUser | Organization | None] = NotSet
+        self._inviter: Attribute[NamedUser | Organization | None] = NotSet
         self._node_id: Attribute[str] = NotSet
         self._permissions: Attribute[str] = NotSet
         self._repository: Attribute[Repository] = NotSet
@@ -105,12 +105,12 @@ class Invitation(CompletableGithubObject):
         return self._id.value
 
     @property
-    def invitee(self) -> NamedUser | Organization:
+    def invitee(self) -> NamedUser | Organization | None:
         self._completeIfNotSet(self._invitee)
         return self._invitee.value
 
     @property
-    def inviter(self) -> NamedUser | Organization:
+    def inviter(self) -> NamedUser | Organization | None:
         self._completeIfNotSet(self._inviter)
         return self._inviter.value
 
@@ -150,7 +150,7 @@ class Invitation(CompletableGithubObject):
                 attributes["invitee"],
                 (github.NamedUser.NamedUser, "User"),
                 (github.Organization.Organization, "Organization"),
-            )
+            )  # type: ignore
         if "inviter" in attributes:  # pragma no branch
             self._inviter = self._makeUnionClassAttributeFromTypeKey(
                 "type",
@@ -158,7 +158,7 @@ class Invitation(CompletableGithubObject):
                 attributes["inviter"],
                 (github.NamedUser.NamedUser, "User"),
                 (github.Organization.Organization, "Organization"),
-            )
+            )  # type: ignore
         if "node_id" in attributes:  # pragma no branch
             self._node_id = self._makeStringAttribute(attributes["node_id"])
 

--- a/github/Issue.py
+++ b/github/Issue.py
@@ -134,11 +134,11 @@ class Issue(CompletableGithubObject):
         self._assignee: Attribute[NamedUser | None] = NotSet
         self._assignees: Attribute[list[NamedUser]] = NotSet
         self._author_association: Attribute[str] = NotSet
-        self._body: Attribute[str] = NotSet
+        self._body: Attribute[str | None] = NotSet
         self._body_html: Attribute[str] = NotSet
         self._body_text: Attribute[str] = NotSet
-        self._closed_at: Attribute[datetime] = NotSet
-        self._closed_by: Attribute[NamedUser] = NotSet
+        self._closed_at: Attribute[datetime | None] = NotSet
+        self._closed_by: Attribute[NamedUser | None] = NotSet
         self._comments: Attribute[int] = NotSet
         self._comments_url: Attribute[str] = NotSet
         self._created_at: Attribute[datetime] = NotSet
@@ -150,11 +150,11 @@ class Issue(CompletableGithubObject):
         self._labels: Attribute[list[Label]] = NotSet
         self._labels_url: Attribute[str] = NotSet
         self._locked: Attribute[bool] = NotSet
-        self._milestone: Attribute[Milestone] = NotSet
+        self._milestone: Attribute[Milestone | None] = NotSet
         self._node_id: Attribute[str] = NotSet
         self._number: Attribute[int] = NotSet
-        self._parent_issue_url: Attribute[str] = NotSet
-        self._performed_via_github_app: Attribute[GithubApp] = NotSet
+        self._parent_issue_url: Attribute[str | None] = NotSet
+        self._performed_via_github_app: Attribute[GithubApp | None] = NotSet
         self._pull_request: Attribute[IssuePullRequest] = NotSet
         self._reactions: Attribute[dict] = NotSet
         self._repository: Attribute[Repository] = NotSet
@@ -165,10 +165,10 @@ class Issue(CompletableGithubObject):
         self._text_matches: Attribute[dict[str, Any]] = NotSet
         self._timeline_url: Attribute[str] = NotSet
         self._title: Attribute[str] = NotSet
-        self._type: Attribute[IssueType] = NotSet
+        self._type: Attribute[IssueType | None] = NotSet
         self._updated_at: Attribute[datetime] = NotSet
         self._url: Attribute[str] = NotSet
-        self._user: Attribute[NamedUser] = NotSet
+        self._user: Attribute[NamedUser | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"number": self._number.value, "title": self._title.value})
@@ -199,7 +199,7 @@ class Issue(CompletableGithubObject):
         return self._author_association.value
 
     @property
-    def body(self) -> str:
+    def body(self) -> str | None:
         self._completeIfNotSet(self._body)
         return self._body.value
 
@@ -214,7 +214,7 @@ class Issue(CompletableGithubObject):
         return self._body_text.value
 
     @property
-    def closed_at(self) -> datetime:
+    def closed_at(self) -> datetime | None:
         self._completeIfNotSet(self._closed_at)
         return self._closed_at.value
 
@@ -279,7 +279,7 @@ class Issue(CompletableGithubObject):
         return self._locked.value
 
     @property
-    def milestone(self) -> Milestone:
+    def milestone(self) -> Milestone | None:
         self._completeIfNotSet(self._milestone)
         return self._milestone.value
 
@@ -294,12 +294,12 @@ class Issue(CompletableGithubObject):
         return self._number.value
 
     @property
-    def parent_issue_url(self) -> str:
+    def parent_issue_url(self) -> str | None:
         self._completeIfNotSet(self._parent_issue_url)
         return self._parent_issue_url.value
 
     @property
-    def performed_via_github_app(self) -> GithubApp:
+    def performed_via_github_app(self) -> GithubApp | None:
         self._completeIfNotSet(self._performed_via_github_app)
         return self._performed_via_github_app.value
 
@@ -360,7 +360,7 @@ class Issue(CompletableGithubObject):
         return self._title.value
 
     @property
-    def type(self) -> IssueType:
+    def type(self) -> IssueType | None:
         self._completeIfNotSet(self._type)
         return self._type.value
 
@@ -375,7 +375,7 @@ class Issue(CompletableGithubObject):
         return self._url.value
 
     @property
-    def user(self) -> NamedUser:
+    def user(self) -> NamedUser | None:
         self._completeIfNotSet(self._user)
         return self._user.value
 

--- a/github/IssueComment.py
+++ b/github/IssueComment.py
@@ -90,11 +90,11 @@ class IssueComment(CompletableGithubObject):
         self._id: Attribute[int] = NotSet
         self._issue_url: Attribute[str] = NotSet
         self._node_id: Attribute[str] = NotSet
-        self._performed_via_github_app: Attribute[GithubApp] = NotSet
+        self._performed_via_github_app: Attribute[GithubApp | None] = NotSet
         self._reactions: Attribute[dict] = NotSet
         self._updated_at: Attribute[datetime] = NotSet
         self._url: Attribute[str] = NotSet
-        self._user: Attribute[NamedUser | Organization] = NotSet
+        self._user: Attribute[NamedUser | Organization | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"id": self._id.value, "user": self._user.value})
@@ -145,7 +145,7 @@ class IssueComment(CompletableGithubObject):
         return self._node_id.value
 
     @property
-    def performed_via_github_app(self) -> GithubApp:
+    def performed_via_github_app(self) -> GithubApp | None:
         self._completeIfNotSet(self._performed_via_github_app)
         return self._performed_via_github_app.value
 
@@ -165,7 +165,7 @@ class IssueComment(CompletableGithubObject):
         return self._url.value
 
     @property
-    def user(self) -> NamedUser | Organization:
+    def user(self) -> NamedUser | Organization | None:
         self._completeIfNotSet(self._user)
         return self._user.value
 
@@ -302,4 +302,4 @@ class IssueComment(CompletableGithubObject):
                 attributes["user"],
                 (github.NamedUser.NamedUser, "User"),
                 (github.Organization.Organization, "Organization"),
-            )
+            )  # type: ignore

--- a/github/IssueEvent.py
+++ b/github/IssueEvent.py
@@ -80,44 +80,44 @@ class IssueEvent(CompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._actor: Attribute[NamedUser | Organization] = NotSet
-        self._assignee: Attribute[NamedUser | Organization] = NotSet
-        self._assigner: Attribute[NamedUser | Organization] = NotSet
+        self._actor: Attribute[NamedUser | Organization | None] = NotSet
+        self._assignee: Attribute[NamedUser | Organization | None] = NotSet
+        self._assigner: Attribute[NamedUser | Organization | None] = NotSet
         self._author_association: Attribute[dict[str, Any]] = NotSet
-        self._commit_id: Attribute[str] = NotSet
-        self._commit_url: Attribute[str] = NotSet
+        self._commit_id: Attribute[str | None] = NotSet
+        self._commit_url: Attribute[str | None] = NotSet
         self._created_at: Attribute[datetime] = NotSet
         self._dismissed_review: Attribute[dict] = NotSet
         self._event: Attribute[str] = NotSet
         self._id: Attribute[int] = NotSet
-        self._issue: Attribute[Issue] = NotSet
+        self._issue: Attribute[Issue | None] = NotSet
         self._label: Attribute[Label] = NotSet
-        self._lock_reason: Attribute[str] = NotSet
+        self._lock_reason: Attribute[str | None] = NotSet
         self._milestone: Attribute[Milestone] = NotSet
         self._node_id: Attribute[str] = NotSet
-        self._performed_via_github_app: Attribute[GithubApp] = NotSet
+        self._performed_via_github_app: Attribute[GithubApp | None] = NotSet
         self._project_card: Attribute[dict[str, Any]] = NotSet
         self._rename: Attribute[dict] = NotSet
-        self._requested_reviewer: Attribute[NamedUser | Organization] = NotSet
+        self._requested_reviewer: Attribute[NamedUser | Organization | None] = NotSet
         self._requested_team: Attribute[Team] = NotSet
-        self._review_requester: Attribute[NamedUser | Organization] = NotSet
+        self._review_requester: Attribute[NamedUser | Organization | None] = NotSet
         self._url: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"id": self._id.value})
 
     @property
-    def actor(self) -> NamedUser | Organization:
+    def actor(self) -> NamedUser | Organization | None:
         self._completeIfNotSet(self._actor)
         return self._actor.value
 
     @property
-    def assignee(self) -> NamedUser | Organization:
+    def assignee(self) -> NamedUser | Organization | None:
         self._completeIfNotSet(self._assignee)
         return self._assignee.value
 
     @property
-    def assigner(self) -> NamedUser | Organization:
+    def assigner(self) -> NamedUser | Organization | None:
         self._completeIfNotSet(self._assigner)
         return self._assigner.value
 
@@ -127,12 +127,12 @@ class IssueEvent(CompletableGithubObject):
         return self._author_association.value
 
     @property
-    def commit_id(self) -> str:
+    def commit_id(self) -> str | None:
         self._completeIfNotSet(self._commit_id)
         return self._commit_id.value
 
     @property
-    def commit_url(self) -> str:
+    def commit_url(self) -> str | None:
         self._completeIfNotSet(self._commit_url)
         return self._commit_url.value
 
@@ -157,7 +157,7 @@ class IssueEvent(CompletableGithubObject):
         return self._id.value
 
     @property
-    def issue(self) -> Issue:
+    def issue(self) -> Issue | None:
         self._completeIfNotSet(self._issue)
         return self._issue.value
 
@@ -167,7 +167,7 @@ class IssueEvent(CompletableGithubObject):
         return self._label.value
 
     @property
-    def lock_reason(self) -> str:
+    def lock_reason(self) -> str | None:
         self._completeIfNotSet(self._lock_reason)
         return self._lock_reason.value
 
@@ -182,7 +182,7 @@ class IssueEvent(CompletableGithubObject):
         return self._node_id.value
 
     @property
-    def performed_via_github_app(self) -> GithubApp:
+    def performed_via_github_app(self) -> GithubApp | None:
         self._completeIfNotSet(self._performed_via_github_app)
         return self._performed_via_github_app.value
 
@@ -197,7 +197,7 @@ class IssueEvent(CompletableGithubObject):
         return self._rename.value
 
     @property
-    def requested_reviewer(self) -> NamedUser | Organization:
+    def requested_reviewer(self) -> NamedUser | Organization | None:
         self._completeIfNotSet(self._requested_reviewer)
         return self._requested_reviewer.value
 
@@ -207,7 +207,7 @@ class IssueEvent(CompletableGithubObject):
         return self._requested_team.value
 
     @property
-    def review_requester(self) -> NamedUser | Organization:
+    def review_requester(self) -> NamedUser | Organization | None:
         self._completeIfNotSet(self._review_requester)
         return self._review_requester.value
 
@@ -224,7 +224,7 @@ class IssueEvent(CompletableGithubObject):
                 attributes["actor"],
                 (github.NamedUser.NamedUser, "User"),
                 (github.Organization.Organization, "Organization"),
-            )
+            )  # type: ignore
         if "assignee" in attributes:  # pragma no branch
             self._assignee = self._makeUnionClassAttributeFromTypeKey(
                 "type",
@@ -232,7 +232,7 @@ class IssueEvent(CompletableGithubObject):
                 attributes["assignee"],
                 (github.NamedUser.NamedUser, "User"),
                 (github.Organization.Organization, "Organization"),
-            )
+            )  # type: ignore
         if "assigner" in attributes:  # pragma no branch
             self._assigner = self._makeUnionClassAttributeFromTypeKey(
                 "type",
@@ -240,7 +240,7 @@ class IssueEvent(CompletableGithubObject):
                 attributes["assigner"],
                 (github.NamedUser.NamedUser, "User"),
                 (github.Organization.Organization, "Organization"),
-            )
+            )  # type: ignore
         if "author_association" in attributes:  # pragma no branch
             self._author_association = self._makeDictAttribute(attributes["author_association"])
         if "commit_id" in attributes:  # pragma no branch
@@ -280,7 +280,7 @@ class IssueEvent(CompletableGithubObject):
                 attributes["requested_reviewer"],
                 (github.NamedUser.NamedUser, "User"),
                 (github.Organization.Organization, "Organization"),
-            )
+            )  # type: ignore
         if "requested_team" in attributes:  # pragma no branch
             self._requested_team = self._makeClassAttribute(github.Team.Team, attributes["requested_team"])
         if "review_requester" in attributes:  # pragma no branch
@@ -290,6 +290,6 @@ class IssueEvent(CompletableGithubObject):
                 attributes["review_requester"],
                 (github.NamedUser.NamedUser, "User"),
                 (github.Organization.Organization, "Organization"),
-            )
+            )  # type: ignore
         if "url" in attributes:  # pragma no branch
             self._url = self._makeStringAttribute(attributes["url"])

--- a/github/IssuePullRequest.py
+++ b/github/IssuePullRequest.py
@@ -57,26 +57,26 @@ class IssuePullRequest(NonCompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._diff_url: Attribute[str] = NotSet
-        self._html_url: Attribute[str] = NotSet
-        self._merged_at: Attribute[datetime] = NotSet
-        self._patch_url: Attribute[str] = NotSet
+        self._diff_url: Attribute[str | None] = NotSet
+        self._html_url: Attribute[str | None] = NotSet
+        self._merged_at: Attribute[datetime | None] = NotSet
+        self._patch_url: Attribute[str | None] = NotSet
         self._url: Attribute[str] = NotSet
 
     @property
-    def diff_url(self) -> str:
+    def diff_url(self) -> str | None:
         return self._diff_url.value
 
     @property
-    def html_url(self) -> str:
+    def html_url(self) -> str | None:
         return self._html_url.value
 
     @property
-    def merged_at(self) -> datetime:
+    def merged_at(self) -> datetime | None:
         return self._merged_at.value
 
     @property
-    def patch_url(self) -> str:
+    def patch_url(self) -> str | None:
         return self._patch_url.value
 
     @property

--- a/github/IssueType.py
+++ b/github/IssueType.py
@@ -59,9 +59,9 @@ class IssueType(NonCompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._color: Attribute[str] = NotSet
+        self._color: Attribute[str | None] = NotSet
         self._created_at: Attribute[datetime] = NotSet
-        self._description: Attribute[str] = NotSet
+        self._description: Attribute[str | None] = NotSet
         self._id: Attribute[int] = NotSet
         self._is_enabled: Attribute[bool] = NotSet
         self._name: Attribute[str] = NotSet
@@ -72,7 +72,7 @@ class IssueType(NonCompletableGithubObject):
         return self.get__repr__({"name": self._name.value})
 
     @property
-    def color(self) -> str:
+    def color(self) -> str | None:
         return self._color.value
 
     @property
@@ -80,7 +80,7 @@ class IssueType(NonCompletableGithubObject):
         return self._created_at.value
 
     @property
-    def description(self) -> str:
+    def description(self) -> str | None:
         return self._description.value
 
     @property

--- a/github/Label.py
+++ b/github/Label.py
@@ -70,11 +70,11 @@ class Label(CompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._color: Attribute[str] = NotSet
+        self._color: Attribute[str | None] = NotSet
         self._default: Attribute[bool] = NotSet
-        self._description: Attribute[str] = NotSet
+        self._description: Attribute[str | None] = NotSet
         self._id: Attribute[int] = NotSet
-        self._name: Attribute[str] = NotSet
+        self._name: Attribute[str | None] = NotSet
         self._node_id: Attribute[str] = NotSet
         self._url: Attribute[str] = NotSet
 
@@ -83,10 +83,12 @@ class Label(CompletableGithubObject):
 
     @property
     def _identity(self) -> str:
-        return urllib.parse.quote(self.name)
+        name = self.name
+        assert name is not None, "name is not set"
+        return urllib.parse.quote(name)
 
     @property
-    def color(self) -> str:
+    def color(self) -> str | None:
         self._completeIfNotSet(self._color)
         return self._color.value
 
@@ -96,7 +98,7 @@ class Label(CompletableGithubObject):
         return self._default.value
 
     @property
-    def description(self) -> str:
+    def description(self) -> str | None:
         self._completeIfNotSet(self._description)
         return self._description.value
 
@@ -106,7 +108,7 @@ class Label(CompletableGithubObject):
         return self._id.value
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         self._completeIfNotSet(self._name)
         return self._name.value
 

--- a/github/License.py
+++ b/github/License.py
@@ -75,7 +75,7 @@ class License(CompletableGithubObject):
         self._name: Attribute[str] = NotSet
         self._node_id: Attribute[str] = NotSet
         self._permissions: Attribute[list[str]] = NotSet
-        self._spdx_id: Attribute[str] = NotSet
+        self._spdx_id: Attribute[str | None] = NotSet
         self._url: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
@@ -132,7 +132,7 @@ class License(CompletableGithubObject):
         return self._permissions.value
 
     @property
-    def spdx_id(self) -> str:
+    def spdx_id(self) -> str | None:
         self._completeIfNotSet(self._spdx_id)
         return self._spdx_id.value
 

--- a/github/Membership.py
+++ b/github/Membership.py
@@ -78,7 +78,7 @@ class Membership(CompletableGithubObject):
         self._role: Attribute[str] = NotSet
         self._state: Attribute[str] = NotSet
         self._url: Attribute[str] = NotSet
-        self._user: Attribute[NamedUser] = NotSet
+        self._user: Attribute[NamedUser | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"url": self._url.value})
@@ -124,7 +124,7 @@ class Membership(CompletableGithubObject):
         return self._url.value
 
     @property
-    def user(self) -> NamedUser:
+    def user(self) -> NamedUser | None:
         self._completeIfNotSet(self._user)
         return self._user.value
 

--- a/github/Migration.py
+++ b/github/Migration.py
@@ -92,7 +92,7 @@ class Migration(CompletableGithubObject):
         self._lock_repositories: Attribute[bool] = NotSet
         self._node_id: Attribute[str] = NotSet
         self._org_metadata_only: Attribute[bool] = NotSet
-        self._owner: Attribute[NamedUser | Organization] = NotSet
+        self._owner: Attribute[NamedUser | Organization | None] = NotSet
         self._repositories: Attribute[list[Repository]] = NotSet
         self._state: Attribute[str] = NotSet
         self._updated_at: Attribute[datetime] = NotSet
@@ -166,7 +166,7 @@ class Migration(CompletableGithubObject):
         return self._org_metadata_only.value
 
     @property
-    def owner(self) -> NamedUser | Organization:
+    def owner(self) -> NamedUser | Organization | None:
         self._completeIfNotSet(self._owner)
         return self._owner.value
 
@@ -267,7 +267,7 @@ class Migration(CompletableGithubObject):
                 attributes["owner"],
                 (github.NamedUser.NamedUser, "User"),
                 (github.Organization.Organization, "Organization"),
-            )
+            )  # type: ignore
         if "repositories" in attributes:
             self._repositories = self._makeListOfClassesAttribute(
                 github.Repository.Repository, attributes["repositories"]

--- a/github/Milestone.py
+++ b/github/Milestone.py
@@ -75,12 +75,12 @@ class Milestone(CompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._closed_at: Attribute[datetime] = NotSet
+        self._closed_at: Attribute[datetime | None] = NotSet
         self._closed_issues: Attribute[int] = NotSet
         self._created_at: Attribute[datetime] = NotSet
-        self._creator: Attribute[NamedUser] = NotSet
-        self._description: Attribute[str] = NotSet
-        self._due_on: Attribute[datetime] = NotSet
+        self._creator: Attribute[NamedUser | None] = NotSet
+        self._description: Attribute[str | None] = NotSet
+        self._due_on: Attribute[datetime | None] = NotSet
         self._html_url: Attribute[str] = NotSet
         self._id: Attribute[int] = NotSet
         self._labels_url: Attribute[str] = NotSet
@@ -100,7 +100,7 @@ class Milestone(CompletableGithubObject):
         return self._number.value
 
     @property
-    def closed_at(self) -> datetime:
+    def closed_at(self) -> datetime | None:
         self._completeIfNotSet(self._closed_at)
         return self._closed_at.value
 
@@ -115,12 +115,12 @@ class Milestone(CompletableGithubObject):
         return self._created_at.value
 
     @property
-    def creator(self) -> NamedUser:
+    def creator(self) -> NamedUser | None:
         self._completeIfNotSet(self._creator)
         return self._creator.value
 
     @property
-    def description(self) -> str:
+    def description(self) -> str | None:
         self._completeIfNotSet(self._description)
         return self._description.value
 

--- a/github/NamedUser.py
+++ b/github/NamedUser.py
@@ -129,9 +129,9 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
         self._ldap_dn: Attribute[str] = NotSet
         self._location: Attribute[str | None] = NotSet
         self._login: Attribute[str] = NotSet
-        self._name: Attribute[str] = NotSet
+        self._name: Attribute[str | None] = NotSet
         self._node_id: Attribute[str] = NotSet
-        self._notification_email: Attribute[str] = NotSet
+        self._notification_email: Attribute[str | None] = NotSet
         self._organizations_url: Attribute[str] = NotSet
         self._owned_private_repos: Attribute[int] = NotSet
         self._permissions: Attribute[Permissions] = NotSet
@@ -309,7 +309,7 @@ class NamedUser(github.GithubObject.CompletableGithubObject):
         return self._node_id.value
 
     @property
-    def notification_email(self) -> str:
+    def notification_email(self) -> str | None:
         return self._notification_email.value
 
     @property
@@ -773,19 +773,19 @@ class OrganizationInvitation(NamedUser):
 
     def _initAttributes(self) -> None:
         super()._initAttributes()
-        self._failed_at: Attribute[str] = NotSet
-        self._failed_reason: Attribute[str] = NotSet
+        self._failed_at: Attribute[str | None] = NotSet
+        self._failed_reason: Attribute[str | None] = NotSet
         self._invitation_source: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"id": self._id.value})
 
     @property
-    def failed_at(self) -> str:
+    def failed_at(self) -> str | None:
         return self._failed_at.value
 
     @property
-    def failed_reason(self) -> str:
+    def failed_reason(self) -> str | None:
         return self._failed_reason.value
 
     @property

--- a/github/Notification.py
+++ b/github/Notification.py
@@ -77,7 +77,7 @@ class Notification(CompletableGithubObject):
 
     def _initAttributes(self) -> None:
         self._id: Attribute[str] = NotSet
-        self._last_read_at: Attribute[datetime] = NotSet
+        self._last_read_at: Attribute[datetime | None] = NotSet
         self._reason: Attribute[str] = NotSet
         self._repository: Attribute[Repository] = NotSet
         self._subject: Attribute[NotificationSubject] = NotSet
@@ -95,7 +95,7 @@ class Notification(CompletableGithubObject):
         return self._id.value
 
     @property
-    def last_read_at(self) -> datetime:
+    def last_read_at(self) -> datetime | None:
         self._completeIfNotSet(self._last_read_at)
         return self._last_read_at.value
 

--- a/github/Organization.py
+++ b/github/Organization.py
@@ -188,31 +188,31 @@ class Organization(CompletableGithubObject):
 
     def _initAttributes(self) -> None:
         self._advanced_security_enabled_for_new_repositories: Attribute[bool] = NotSet
-        self._archived_at: Attribute[datetime] = NotSet
+        self._archived_at: Attribute[datetime | None] = NotSet
         self._avatar_url: Attribute[str] = NotSet
-        self._billing_email: Attribute[str] = NotSet
+        self._billing_email: Attribute[str | None] = NotSet
         self._blog: Attribute[str | None] = NotSet
-        self._collaborators: Attribute[int] = NotSet
+        self._collaborators: Attribute[int | None] = NotSet
         self._company: Attribute[str] = NotSet
         self._created_at: Attribute[datetime] = NotSet
-        self._default_repository_branch: Attribute[str] = NotSet
-        self._default_repository_permission: Attribute[str] = NotSet
+        self._default_repository_branch: Attribute[str | None] = NotSet
+        self._default_repository_permission: Attribute[str | None] = NotSet
         self._dependabot_alerts_enabled_for_new_repositories: Attribute[bool] = NotSet
         self._dependabot_security_updates_enabled_for_new_repositories: Attribute[bool] = NotSet
         self._dependency_graph_enabled_for_new_repositories: Attribute[bool] = NotSet
         self._deploy_keys_enabled_for_repositories: Attribute[bool] = NotSet
-        self._description: Attribute[str] = NotSet
-        self._disk_usage: Attribute[int] = NotSet
+        self._description: Attribute[str | None] = NotSet
+        self._disk_usage: Attribute[int | None] = NotSet
         self._display_commenter_full_name_setting_enabled: Attribute[bool] = NotSet
         self._display_login: Attribute[str] = NotSet
-        self._email: Attribute[str] = NotSet
+        self._email: Attribute[str | None] = NotSet
         self._events_url: Attribute[str] = NotSet
         self._followers: Attribute[int] = NotSet
         self._followers_url: Attribute[str] = NotSet
         self._following: Attribute[int] = NotSet
         self._following_url: Attribute[str] = NotSet
         self._gists_url: Attribute[str] = NotSet
-        self._gravatar_id: Attribute[str] = NotSet
+        self._gravatar_id: Attribute[str | None] = NotSet
         self._has_organization_projects: Attribute[bool] = NotSet
         self._has_repository_projects: Attribute[bool] = NotSet
         self._hooks_url: Attribute[str] = NotSet
@@ -230,20 +230,20 @@ class Organization(CompletableGithubObject):
         self._members_can_create_private_repositories: Attribute[bool] = NotSet
         self._members_can_create_public_pages: Attribute[bool] = NotSet
         self._members_can_create_public_repositories: Attribute[bool] = NotSet
-        self._members_can_create_repositories: Attribute[bool] = NotSet
+        self._members_can_create_repositories: Attribute[bool | None] = NotSet
         self._members_can_create_teams: Attribute[bool] = NotSet
         self._members_can_delete_issues: Attribute[bool] = NotSet
         self._members_can_delete_repositories: Attribute[bool] = NotSet
-        self._members_can_fork_private_repositories: Attribute[bool] = NotSet
+        self._members_can_fork_private_repositories: Attribute[bool | None] = NotSet
         self._members_can_invite_outside_collaborators: Attribute[bool] = NotSet
         self._members_can_view_dependency_insights: Attribute[bool] = NotSet
         self._members_url: Attribute[str] = NotSet
-        self._name: Attribute[str] = NotSet
+        self._name: Attribute[str | None] = NotSet
         self._node_id: Attribute[str] = NotSet
         self._organizations_url: Attribute[str] = NotSet
         self._owned_private_repos: Attribute[int] = NotSet
         self._plan: Attribute[Plan] = NotSet
-        self._private_gists: Attribute[int] = NotSet
+        self._private_gists: Attribute[int | None] = NotSet
         self._public_gists: Attribute[int] = NotSet
         self._public_members_url: Attribute[str] = NotSet
         self._public_repos: Attribute[int] = NotSet
@@ -251,7 +251,7 @@ class Organization(CompletableGithubObject):
         self._received_events_url: Attribute[str] = NotSet
         self._repos_url: Attribute[str] = NotSet
         self._secret_scanning_enabled_for_new_repositories: Attribute[bool] = NotSet
-        self._secret_scanning_push_protection_custom_link: Attribute[str] = NotSet
+        self._secret_scanning_push_protection_custom_link: Attribute[str | None] = NotSet
         self._secret_scanning_push_protection_custom_link_enabled: Attribute[bool] = NotSet
         self._secret_scanning_push_protection_enabled_for_new_repositories: Attribute[bool] = NotSet
         self._site_admin: Attribute[bool] = NotSet
@@ -259,8 +259,8 @@ class Organization(CompletableGithubObject):
         self._starred_url: Attribute[str] = NotSet
         self._subscriptions_url: Attribute[str] = NotSet
         self._total_private_repos: Attribute[int] = NotSet
-        self._twitter_username: Attribute[str] = NotSet
-        self._two_factor_requirement_enabled: Attribute[bool] = NotSet
+        self._twitter_username: Attribute[str | None] = NotSet
+        self._two_factor_requirement_enabled: Attribute[bool | None] = NotSet
         self._type: Attribute[str] = NotSet
         self._updated_at: Attribute[datetime] = NotSet
         self._url: Attribute[str] = NotSet
@@ -276,7 +276,7 @@ class Organization(CompletableGithubObject):
         return self._advanced_security_enabled_for_new_repositories.value
 
     @property
-    def archived_at(self) -> datetime:
+    def archived_at(self) -> datetime | None:
         self._completeIfNotSet(self._archived_at)
         return self._archived_at.value
 
@@ -286,7 +286,7 @@ class Organization(CompletableGithubObject):
         return self._avatar_url.value
 
     @property
-    def billing_email(self) -> str:
+    def billing_email(self) -> str | None:
         self._completeIfNotSet(self._billing_email)
         return self._billing_email.value
 
@@ -296,7 +296,7 @@ class Organization(CompletableGithubObject):
         return self._blog.value
 
     @property
-    def collaborators(self) -> int:
+    def collaborators(self) -> int | None:
         self._completeIfNotSet(self._collaborators)
         return self._collaborators.value
 
@@ -311,12 +311,12 @@ class Organization(CompletableGithubObject):
         return self._created_at.value
 
     @property
-    def default_repository_branch(self) -> str:
+    def default_repository_branch(self) -> str | None:
         self._completeIfNotSet(self._default_repository_branch)
         return self._default_repository_branch.value
 
     @property
-    def default_repository_permission(self) -> str:
+    def default_repository_permission(self) -> str | None:
         self._completeIfNotSet(self._default_repository_permission)
         return self._default_repository_permission.value
 
@@ -341,12 +341,12 @@ class Organization(CompletableGithubObject):
         return self._deploy_keys_enabled_for_repositories.value
 
     @property
-    def description(self) -> str:
+    def description(self) -> str | None:
         self._completeIfNotSet(self._description)
         return self._description.value
 
     @property
-    def disk_usage(self) -> int:
+    def disk_usage(self) -> int | None:
         self._completeIfNotSet(self._disk_usage)
         return self._disk_usage.value
 
@@ -396,7 +396,7 @@ class Organization(CompletableGithubObject):
         return self._gists_url.value
 
     @property
-    def gravatar_id(self) -> str:
+    def gravatar_id(self) -> str | None:
         self._completeIfNotSet(self._gravatar_id)
         return self._gravatar_id.value
 
@@ -486,7 +486,7 @@ class Organization(CompletableGithubObject):
         return self._members_can_create_public_repositories.value
 
     @property
-    def members_can_create_repositories(self) -> bool:
+    def members_can_create_repositories(self) -> bool | None:
         self._completeIfNotSet(self._members_can_create_repositories)
         return self._members_can_create_repositories.value
 
@@ -506,7 +506,7 @@ class Organization(CompletableGithubObject):
         return self._members_can_delete_repositories.value
 
     @property
-    def members_can_fork_private_repositories(self) -> bool:
+    def members_can_fork_private_repositories(self) -> bool | None:
         self._completeIfNotSet(self._members_can_fork_private_repositories)
         return self._members_can_fork_private_repositories.value
 
@@ -551,7 +551,7 @@ class Organization(CompletableGithubObject):
         return self._plan.value
 
     @property
-    def private_gists(self) -> int:
+    def private_gists(self) -> int | None:
         self._completeIfNotSet(self._private_gists)
         return self._private_gists.value
 
@@ -591,7 +591,7 @@ class Organization(CompletableGithubObject):
         return self._secret_scanning_enabled_for_new_repositories.value
 
     @property
-    def secret_scanning_push_protection_custom_link(self) -> str:
+    def secret_scanning_push_protection_custom_link(self) -> str | None:
         self._completeIfNotSet(self._secret_scanning_push_protection_custom_link)
         return self._secret_scanning_push_protection_custom_link.value
 
@@ -631,12 +631,12 @@ class Organization(CompletableGithubObject):
         return self._total_private_repos.value
 
     @property
-    def twitter_username(self) -> str:
+    def twitter_username(self) -> str | None:
         self._completeIfNotSet(self._twitter_username)
         return self._twitter_username.value
 
     @property
-    def two_factor_requirement_enabled(self) -> bool:
+    def two_factor_requirement_enabled(self) -> bool | None:
         self._completeIfNotSet(self._two_factor_requirement_enabled)
         return self._two_factor_requirement_enabled.value
 
@@ -1246,7 +1246,8 @@ class Organization(CompletableGithubObject):
             {"filter": filter, "state": state, "sort": sort, "direction": direction}
         )
         if is_defined(labels):
-            url_parameters["labels"] = ",".join(label.name for label in labels)
+            assert all(label.name is not None for label in labels), labels
+            url_parameters["labels"] = ",".join(label.name for label in labels)  # type: ignore[misc]
         if is_defined(since):
             url_parameters["since"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
         return PaginatedList(github.Issue.Issue, self._requester, f"{self.url}/issues", url_parameters)

--- a/github/OrganizationCustomProperty.py
+++ b/github/OrganizationCustomProperty.py
@@ -86,26 +86,26 @@ class OrganizationCustomProperty(NonCompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._allowed_values: Attribute[list[str]] = NotSet
-        self._default_value: Attribute[str | list[str]] = NotSet
-        self._description: Attribute[str] = NotSet
+        self._allowed_values: Attribute[list[str] | None] = NotSet
+        self._default_value: Attribute[str | list[str] | None] = NotSet
+        self._description: Attribute[str | None] = NotSet
         self._property_name: Attribute[str] = NotSet
         self._required: Attribute[bool] = NotSet
         self._source_type: Attribute[str] = NotSet
         self._url: Attribute[str] = NotSet
         self._value_type: Attribute[str] = NotSet
-        self._values_editable_by: Attribute[str] = NotSet
+        self._values_editable_by: Attribute[str | None] = NotSet
 
     @property
-    def allowed_values(self) -> Opt[list[str] | None]:
+    def allowed_values(self) -> Opt[list[str] | None] | None:
         return self._allowed_values.value
 
     @property
-    def default_value(self) -> Opt[str | list[str] | None]:
+    def default_value(self) -> Opt[str | list[str] | None] | None:
         return self._default_value.value
 
     @property
-    def description(self) -> Opt[str | None]:
+    def description(self) -> Opt[str | None] | None:
         return self._description.value
 
     @property
@@ -129,7 +129,7 @@ class OrganizationCustomProperty(NonCompletableGithubObject):
         return self._value_type.value
 
     @property
-    def values_editable_by(self) -> Opt[str | None]:
+    def values_editable_by(self) -> Opt[str | None] | None:
         return self._values_editable_by.value
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:

--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -159,14 +159,14 @@ class PullRequest(CompletableGithubObject):
 
     def _initAttributes(self) -> None:
         self.__links: Attribute[dict[str, Any]] = NotSet
-        self._active_lock_reason: Attribute[str] = NotSet
+        self._active_lock_reason: Attribute[str | None] = NotSet
         self._additions: Attribute[int] = NotSet
-        self._assignee: Attribute[NamedUser] = NotSet
+        self._assignee: Attribute[NamedUser | None] = NotSet
         self._assignees: Attribute[list[NamedUser]] = NotSet
         self._author_association: Attribute[str] = NotSet
-        self._auto_merge: Attribute[dict[str, Any]] = NotSet
+        self._auto_merge: Attribute[dict[str, Any] | None] = NotSet
         self._base: Attribute[PullRequestPart] = NotSet
-        self._body: Attribute[str] = NotSet
+        self._body: Attribute[str | None] = NotSet
         self._changed_files: Attribute[int] = NotSet
         self._closed_at: Attribute[datetime | None] = NotSet
         self._comments: Attribute[int] = NotSet
@@ -184,17 +184,17 @@ class PullRequest(CompletableGithubObject):
         self._labels: Attribute[list[Label]] = NotSet
         self._locked: Attribute[bool] = NotSet
         self._maintainer_can_modify: Attribute[bool] = NotSet
-        self._merge_commit_sha: Attribute[str] = NotSet
-        self._mergeable: Attribute[bool] = NotSet
+        self._merge_commit_sha: Attribute[str | None] = NotSet
+        self._mergeable: Attribute[bool | None] = NotSet
         self._mergeable_state: Attribute[str] = NotSet
         self._merged: Attribute[bool] = NotSet
         self._merged_at: Attribute[datetime | None] = NotSet
         self._merged_by: Attribute[NamedUser | None] = NotSet
-        self._milestone: Attribute[Milestone] = NotSet
+        self._milestone: Attribute[Milestone | None] = NotSet
         self._node_id: Attribute[str] = NotSet
         self._number: Attribute[int] = NotSet
         self._patch_url: Attribute[str] = NotSet
-        self._rebaseable: Attribute[bool] = NotSet
+        self._rebaseable: Attribute[bool | None] = NotSet
         self._requested_reviewers: Attribute[list[NamedUser]] = NotSet
         self._requested_teams: Attribute[list[Team]] = NotSet
         self._review_comment_url: Attribute[str] = NotSet
@@ -205,7 +205,7 @@ class PullRequest(CompletableGithubObject):
         self._title: Attribute[str] = NotSet
         self._updated_at: Attribute[datetime | None] = NotSet
         self._url: Attribute[str] = NotSet
-        self._user: Attribute[NamedUser] = NotSet
+        self._user: Attribute[NamedUser | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"number": self._number.value, "title": self._title.value})
@@ -216,7 +216,7 @@ class PullRequest(CompletableGithubObject):
         return self.__links.value
 
     @property
-    def active_lock_reason(self) -> str:
+    def active_lock_reason(self) -> str | None:
         self._completeIfNotSet(self._active_lock_reason)
         return self._active_lock_reason.value
 
@@ -226,7 +226,7 @@ class PullRequest(CompletableGithubObject):
         return self._additions.value
 
     @property
-    def assignee(self) -> NamedUser:
+    def assignee(self) -> NamedUser | None:
         self._completeIfNotSet(self._assignee)
         return self._assignee.value
 
@@ -241,7 +241,7 @@ class PullRequest(CompletableGithubObject):
         return self._author_association.value
 
     @property
-    def auto_merge(self) -> dict[str, Any]:
+    def auto_merge(self) -> dict[str, Any] | None:
         self._completeIfNotSet(self._auto_merge)
         return self._auto_merge.value
 
@@ -251,7 +251,7 @@ class PullRequest(CompletableGithubObject):
         return self._base.value
 
     @property
-    def body(self) -> str:
+    def body(self) -> str | None:
         self._completeIfNotSet(self._body)
         return self._body.value
 
@@ -341,12 +341,12 @@ class PullRequest(CompletableGithubObject):
         return self._maintainer_can_modify.value
 
     @property
-    def merge_commit_sha(self) -> str:
+    def merge_commit_sha(self) -> str | None:
         self._completeIfNotSet(self._merge_commit_sha)
         return self._merge_commit_sha.value
 
     @property
-    def mergeable(self) -> bool:
+    def mergeable(self) -> bool | None:
         self._completeIfNotSet(self._mergeable)
         return self._mergeable.value
 
@@ -371,7 +371,7 @@ class PullRequest(CompletableGithubObject):
         return self._merged_by.value
 
     @property
-    def milestone(self) -> Milestone:
+    def milestone(self) -> Milestone | None:
         self._completeIfNotSet(self._milestone)
         return self._milestone.value
 
@@ -391,7 +391,7 @@ class PullRequest(CompletableGithubObject):
         return self._patch_url.value
 
     @property
-    def rebaseable(self) -> bool:
+    def rebaseable(self) -> bool | None:
         self._completeIfNotSet(self._rebaseable)
         return self._rebaseable.value
 
@@ -446,7 +446,7 @@ class PullRequest(CompletableGithubObject):
         return self._url.value
 
     @property
-    def user(self) -> NamedUser:
+    def user(self) -> NamedUser | None:
         self._completeIfNotSet(self._user)
         return self._user.value
 

--- a/github/PullRequest.py
+++ b/github/PullRequest.py
@@ -189,7 +189,7 @@ class PullRequest(CompletableGithubObject):
         self._mergeable_state: Attribute[str] = NotSet
         self._merged: Attribute[bool] = NotSet
         self._merged_at: Attribute[datetime | None] = NotSet
-        self._merged_by: Attribute[NamedUser] = NotSet
+        self._merged_by: Attribute[NamedUser | None] = NotSet
         self._milestone: Attribute[Milestone] = NotSet
         self._node_id: Attribute[str] = NotSet
         self._number: Attribute[int] = NotSet
@@ -366,7 +366,7 @@ class PullRequest(CompletableGithubObject):
         return self._merged_at.value
 
     @property
-    def merged_by(self) -> NamedUser:
+    def merged_by(self) -> NamedUser | None:
         self._completeIfNotSet(self._merged_by)
         return self._merged_by.value
 

--- a/github/PullRequestComment.py
+++ b/github/PullRequestComment.py
@@ -96,19 +96,19 @@ class PullRequestComment(CompletableGithubObject):
         self._original_commit_id: Attribute[str] = NotSet
         self._original_line: Attribute[int] = NotSet
         self._original_position: Attribute[int] = NotSet
-        self._original_start_line: Attribute[int] = NotSet
+        self._original_start_line: Attribute[int | None] = NotSet
         self._path: Attribute[str] = NotSet
-        self._position: Attribute[int] = NotSet
-        self._pull_request_review_id: Attribute[int] = NotSet
+        self._position: Attribute[int | None] = NotSet
+        self._pull_request_review_id: Attribute[int | None] = NotSet
         self._pull_request_url: Attribute[str] = NotSet
         self._reactions: Attribute[dict[str, Any]] = NotSet
         self._side: Attribute[str] = NotSet
-        self._start_line: Attribute[int] = NotSet
-        self._start_side: Attribute[str] = NotSet
+        self._start_line: Attribute[int | None] = NotSet
+        self._start_side: Attribute[str | None] = NotSet
         self._subject_type: Attribute[str] = NotSet
         self._updated_at: Attribute[datetime] = NotSet
         self._url: Attribute[str] = NotSet
-        self._user: Attribute[NamedUser] = NotSet
+        self._user: Attribute[NamedUser | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"id": self._id.value, "user": self._user.value})
@@ -194,7 +194,7 @@ class PullRequestComment(CompletableGithubObject):
         return self._original_position.value
 
     @property
-    def original_start_line(self) -> int:
+    def original_start_line(self) -> int | None:
         self._completeIfNotSet(self._original_start_line)
         return self._original_start_line.value
 
@@ -204,12 +204,12 @@ class PullRequestComment(CompletableGithubObject):
         return self._path.value
 
     @property
-    def position(self) -> int:
+    def position(self) -> int | None:
         self._completeIfNotSet(self._position)
         return self._position.value
 
     @property
-    def pull_request_review_id(self) -> int:
+    def pull_request_review_id(self) -> int | None:
         self._completeIfNotSet(self._pull_request_review_id)
         return self._pull_request_review_id.value
 
@@ -229,12 +229,12 @@ class PullRequestComment(CompletableGithubObject):
         return self._side.value
 
     @property
-    def start_line(self) -> int:
+    def start_line(self) -> int | None:
         self._completeIfNotSet(self._start_line)
         return self._start_line.value
 
     @property
-    def start_side(self) -> str:
+    def start_side(self) -> str | None:
         self._completeIfNotSet(self._start_side)
         return self._start_side.value
 
@@ -254,7 +254,7 @@ class PullRequestComment(CompletableGithubObject):
         return self._url.value
 
     @property
-    def user(self) -> NamedUser:
+    def user(self) -> NamedUser | None:
         self._completeIfNotSet(self._user)
         return self._user.value
 

--- a/github/PullRequestPart.py
+++ b/github/PullRequestPart.py
@@ -71,7 +71,7 @@ class PullRequestPart(NonCompletableGithubObject):
         self._ref: Attribute[str] = NotSet
         self._repo: Attribute[Repository] = NotSet
         self._sha: Attribute[str] = NotSet
-        self._user: Attribute[NamedUser] = NotSet
+        self._user: Attribute[NamedUser | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"sha": self._sha.value})
@@ -93,7 +93,7 @@ class PullRequestPart(NonCompletableGithubObject):
         return self._sha.value
 
     @property
-    def user(self) -> NamedUser:
+    def user(self) -> NamedUser | None:
         return self._user.value
 
     def _useAttributes(self, attributes: dict[str, Any]) -> None:

--- a/github/PullRequestReview.py
+++ b/github/PullRequestReview.py
@@ -76,14 +76,14 @@ class PullRequestReview(NonCompletableGithubObject):
         self._body: Attribute[str] = NotSet
         self._body_html: Attribute[str] = NotSet
         self._body_text: Attribute[str] = NotSet
-        self._commit_id: Attribute[str] = NotSet
+        self._commit_id: Attribute[str | None] = NotSet
         self._html_url: Attribute[str] = NotSet
         self._id: Attribute[int] = NotSet
         self._node_id: Attribute[str] = NotSet
         self._pull_request_url: Attribute[str] = NotSet
         self._state: Attribute[str] = NotSet
         self._submitted_at: Attribute[datetime] = NotSet
-        self._user: Attribute[NamedUser] = NotSet
+        self._user: Attribute[NamedUser | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"id": self._id.value, "user": self._user.value})
@@ -105,7 +105,7 @@ class PullRequestReview(NonCompletableGithubObject):
         return self._body_text.value
 
     @property
-    def commit_id(self) -> str:
+    def commit_id(self) -> str | None:
         return self._commit_id.value
 
     @property
@@ -133,7 +133,7 @@ class PullRequestReview(NonCompletableGithubObject):
         return self._submitted_at.value
 
     @property
-    def user(self) -> NamedUser:
+    def user(self) -> NamedUser | None:
         return self._user.value
 
     def dismiss(self, message: str) -> None:

--- a/github/Reaction.py
+++ b/github/Reaction.py
@@ -76,7 +76,7 @@ class Reaction(NonCompletableGithubObject):
         self._created_at: Attribute[datetime] = NotSet
         self._id: Attribute[int] = NotSet
         self._node_id: Attribute[str] = NotSet
-        self._user: Attribute[NamedUser] = NotSet
+        self._user: Attribute[NamedUser | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"id": self._id.value, "user": self._user.value})
@@ -98,7 +98,7 @@ class Reaction(NonCompletableGithubObject):
         return self._node_id.value
 
     @property
-    def user(self) -> NamedUser:
+    def user(self) -> NamedUser | None:
         return self._user.value
 
     @deprecated(

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -391,12 +391,12 @@ class Repository(CompletableGithubObject):
         self._compare_url: Attribute[str] = NotSet
         self._contents_url: Attribute[str] = NotSet
         self._contributors_url: Attribute[str] = NotSet
-        self._created_at: Attribute[datetime] = NotSet
+        self._created_at: Attribute[datetime | None] = NotSet
         self._custom_properties: Attribute[dict[str, None | str | list]] = NotSet  # type: ignore
         self._default_branch: Attribute[str] = NotSet
         self._delete_branch_on_merge: Attribute[bool] = NotSet
         self._deployments_url: Attribute[str] = NotSet
-        self._description: Attribute[str] = NotSet
+        self._description: Attribute[str | None] = NotSet
         self._disabled: Attribute[bool] = NotSet
         self._downloads_url: Attribute[str] = NotSet
         self._events_url: Attribute[str] = NotSet
@@ -415,7 +415,7 @@ class Repository(CompletableGithubObject):
         self._has_pages: Attribute[bool] = NotSet
         self._has_projects: Attribute[bool] = NotSet
         self._has_wiki: Attribute[bool] = NotSet
-        self._homepage: Attribute[str] = NotSet
+        self._homepage: Attribute[str | None] = NotSet
         self._hooks_url: Attribute[str] = NotSet
         self._html_url: Attribute[str] = NotSet
         self._id: Attribute[int] = NotSet
@@ -425,31 +425,31 @@ class Repository(CompletableGithubObject):
         self._issues_url: Attribute[str] = NotSet
         self._keys_url: Attribute[str] = NotSet
         self._labels_url: Attribute[str] = NotSet
-        self._language: Attribute[str] = NotSet
+        self._language: Attribute[str | None] = NotSet
         self._languages_url: Attribute[str] = NotSet
-        self._license: Attribute[License] = NotSet
+        self._license: Attribute[License | None] = NotSet
         self._master_branch: Attribute[str] = NotSet
         self._merge_commit_message: Attribute[str] = NotSet
         self._merge_commit_title: Attribute[str] = NotSet
         self._merges_url: Attribute[str] = NotSet
         self._milestones_url: Attribute[str] = NotSet
-        self._mirror_url: Attribute[str] = NotSet
+        self._mirror_url: Attribute[str | None] = NotSet
         self._name: Attribute[str] = NotSet
         self._network_count: Attribute[int] = NotSet
         self._node_id: Attribute[str] = NotSet
         self._notifications_url: Attribute[str] = NotSet
         self._open_issues: Attribute[int] = NotSet
         self._open_issues_count: Attribute[int] = NotSet
-        self._organization: Attribute[Organization] = NotSet
+        self._organization: Attribute[Organization | None] = NotSet
         self._owner: Attribute[NamedUser] = NotSet
         self._parent: Attribute[Repository] = NotSet
         self._permissions: Attribute[Permissions] = NotSet
         self._private: Attribute[bool] = NotSet
         self._pulls_url: Attribute[str] = NotSet
-        self._pushed_at: Attribute[datetime] = NotSet
+        self._pushed_at: Attribute[datetime | None] = NotSet
         self._releases_url: Attribute[str] = NotSet
         self._role_name: Attribute[str] = NotSet
-        self._security_and_analysis: Attribute[SecurityAndAnalysis] = NotSet
+        self._security_and_analysis: Attribute[SecurityAndAnalysis | None] = NotSet
         self._size: Attribute[int] = NotSet
         self._source: Attribute[Repository] = NotSet
         self._squash_merge_commit_message: Attribute[str] = NotSet
@@ -465,11 +465,11 @@ class Repository(CompletableGithubObject):
         self._svn_url: Attribute[str] = NotSet
         self._tags_url: Attribute[str] = NotSet
         self._teams_url: Attribute[str] = NotSet
-        self._temp_clone_token: Attribute[str] = NotSet
-        self._template_repository: Attribute[Repository] = NotSet
+        self._temp_clone_token: Attribute[str | None] = NotSet
+        self._template_repository: Attribute[Repository | None] = NotSet
         self._topics: Attribute[list[str]] = NotSet
         self._trees_url: Attribute[str] = NotSet
-        self._updated_at: Attribute[datetime] = NotSet
+        self._updated_at: Attribute[datetime | None] = NotSet
         self._url: Attribute[str] = NotSet
         self._use_squash_pr_title_as_default: Attribute[bool] = NotSet
         self._visibility: Attribute[str] = NotSet
@@ -645,7 +645,7 @@ class Repository(CompletableGithubObject):
         return self._contributors_url.value
 
     @property
-    def created_at(self) -> datetime:
+    def created_at(self) -> datetime | None:
         """
         :type: datetime
         """
@@ -685,7 +685,7 @@ class Repository(CompletableGithubObject):
         return self._deployments_url.value
 
     @property
-    def description(self) -> str:
+    def description(self) -> str | None:
         """
         :type: string
         """
@@ -834,7 +834,7 @@ class Repository(CompletableGithubObject):
         return self._has_wiki.value
 
     @property
-    def homepage(self) -> str:
+    def homepage(self) -> str | None:
         """
         :type: string
         """
@@ -914,7 +914,7 @@ class Repository(CompletableGithubObject):
         return self._labels_url.value
 
     @property
-    def language(self) -> str:
+    def language(self) -> str | None:
         """
         :type: string
         """
@@ -930,7 +930,7 @@ class Repository(CompletableGithubObject):
         return self._languages_url.value
 
     @property
-    def license(self) -> License:
+    def license(self) -> License | None:
         self._completeIfNotSet(self._license)
         return self._license.value
 
@@ -972,7 +972,7 @@ class Repository(CompletableGithubObject):
         return self._milestones_url.value
 
     @property
-    def mirror_url(self) -> str:
+    def mirror_url(self) -> str | None:
         """
         :type: string
         """
@@ -1025,7 +1025,7 @@ class Repository(CompletableGithubObject):
         return self._open_issues_count.value
 
     @property
-    def organization(self) -> Organization:
+    def organization(self) -> Organization | None:
         """
         :type: :class:`github.Organization.Organization`
         """
@@ -1073,7 +1073,7 @@ class Repository(CompletableGithubObject):
         return self._pulls_url.value
 
     @property
-    def pushed_at(self) -> datetime:
+    def pushed_at(self) -> datetime | None:
         """
         :type: datetime
         """
@@ -1094,7 +1094,7 @@ class Repository(CompletableGithubObject):
         return self._role_name.value
 
     @property
-    def security_and_analysis(self) -> SecurityAndAnalysis:
+    def security_and_analysis(self) -> SecurityAndAnalysis | None:
         """
         :type: :class:`github.SecurityAndAnalysis.SecurityAndAnalysis`
         """
@@ -1219,12 +1219,12 @@ class Repository(CompletableGithubObject):
         return self._teams_url.value
 
     @property
-    def temp_clone_token(self) -> str:
+    def temp_clone_token(self) -> str | None:
         self._completeIfNotSet(self._temp_clone_token)
         return self._temp_clone_token.value
 
     @property
-    def template_repository(self) -> Repository:
+    def template_repository(self) -> Repository | None:
         self._completeIfNotSet(self._template_repository)
         return self._template_repository.value
 
@@ -1245,7 +1245,7 @@ class Repository(CompletableGithubObject):
         return self._trees_url.value
 
     @property
-    def updated_at(self) -> datetime:
+    def updated_at(self) -> datetime | None:
         """
         :type: datetime
         """
@@ -4664,15 +4664,17 @@ class Repository(CompletableGithubObject):
         """
         :calls: `POST /orgs/{org}/code-security/configurations/{configuration_id}/attach <https://docs.github.com/en/rest/code-security/configurations#attach-a-configuration-to-repositories>`_
         """
-        self.organization.attach_security_config_to_repositories(
-            id=id, scope="selected", selected_repository_ids=[self.id]
-        )
+        organization = self.organization
+        assert organization is not None, "organization is not set"
+        organization.attach_security_config_to_repositories(id=id, scope="selected", selected_repository_ids=[self.id])
 
     def detach_security_config(self) -> None:
         """
         :calls: `DELETE /orgs/{org}/code-security/configurations/detach <https://docs.github.com/en/rest/code-security/configurations#detach-configurations-from-repositories>`_
         """
-        self.organization.detach_security_config_from_repositories(selected_repository_ids=[self.id])
+        organization = self.organization
+        assert organization is not None, "organization is not set"
+        organization.detach_security_config_from_repositories(selected_repository_ids=[self.id])
 
     def get_security_config(self) -> RepoCodeSecurityConfig | None:
         """

--- a/github/RepositoryAdvisory.py
+++ b/github/RepositoryAdvisory.py
@@ -69,63 +69,63 @@ class RepositoryAdvisory(AdvisoryBase):
 
     def _initAttributes(self) -> None:
         super()._initAttributes()
-        self._author: Attribute[NamedUser] = NotSet
-        self._closed_at: Attribute[datetime] = NotSet
-        self._collaborating_teams: Attribute[list[Team]] = NotSet
-        self._collaborating_users: Attribute[list[NamedUser]] = NotSet
-        self._created_at: Attribute[datetime] = NotSet
-        self._credits: Attribute[list[AdvisoryCredit]] = NotSet
-        self._credits_detailed: Attribute[list[AdvisoryCreditDetailed]] = NotSet
-        self._cwe_ids: Attribute[list[str]] = NotSet
-        self._private_fork: Attribute[Repository] = NotSet
-        self._publisher: Attribute[NamedUser] = NotSet
+        self._author: Attribute[NamedUser | None] = NotSet
+        self._closed_at: Attribute[datetime | None] = NotSet
+        self._collaborating_teams: Attribute[list[Team] | None] = NotSet
+        self._collaborating_users: Attribute[list[NamedUser] | None] = NotSet
+        self._created_at: Attribute[datetime | None] = NotSet
+        self._credits: Attribute[list[AdvisoryCredit] | None] = NotSet
+        self._credits_detailed: Attribute[list[AdvisoryCreditDetailed] | None] = NotSet
+        self._cwe_ids: Attribute[list[str] | None] = NotSet
+        self._private_fork: Attribute[Repository | None] = NotSet
+        self._publisher: Attribute[NamedUser | None] = NotSet
         self._state: Attribute[str] = NotSet
-        self._submission: Attribute[dict[str, Any]] = NotSet
-        self._vulnerabilities: Attribute[list[AdvisoryVulnerability]] = NotSet
+        self._submission: Attribute[dict[str, Any] | None] = NotSet
+        self._vulnerabilities: Attribute[list[AdvisoryVulnerability] | None] = NotSet
         super()._initAttributes()
 
     @property
-    def author(self) -> NamedUser:
+    def author(self) -> NamedUser | None:
         return self._author.value
 
     @property
-    def closed_at(self) -> datetime:
+    def closed_at(self) -> datetime | None:
         return self._closed_at.value
 
     @property
-    def collaborating_teams(self) -> list[Team]:
+    def collaborating_teams(self) -> list[Team] | None:
         return self._collaborating_teams.value
 
     @property
-    def collaborating_users(self) -> list[NamedUser]:
+    def collaborating_users(self) -> list[NamedUser] | None:
         return self._collaborating_users.value
 
     @property
-    def created_at(self) -> datetime:
+    def created_at(self) -> datetime | None:
         return self._created_at.value
 
     @property
     def credits(
         self,
-    ) -> list[AdvisoryCredit]:
+    ) -> list[AdvisoryCredit] | None:
         return self._credits.value
 
     @property
     def credits_detailed(
         self,
-    ) -> list[AdvisoryCreditDetailed]:
+    ) -> list[AdvisoryCreditDetailed] | None:
         return self._credits_detailed.value
 
     @property
-    def cwe_ids(self) -> list[str]:
+    def cwe_ids(self) -> list[str] | None:
         return self._cwe_ids.value
 
     @property
-    def private_fork(self) -> Repository:
+    def private_fork(self) -> Repository | None:
         return self._private_fork.value
 
     @property
-    def publisher(self) -> NamedUser:
+    def publisher(self) -> NamedUser | None:
         return self._publisher.value
 
     @property
@@ -133,11 +133,11 @@ class RepositoryAdvisory(AdvisoryBase):
         return self._state.value
 
     @property
-    def submission(self) -> dict[str, Any]:
+    def submission(self) -> dict[str, Any] | None:
         return self._submission.value
 
     @property
-    def vulnerabilities(self) -> list[AdvisoryVulnerability]:
+    def vulnerabilities(self) -> list[AdvisoryVulnerability] | None:
         return self._vulnerabilities.value
 
     def add_vulnerability(
@@ -176,7 +176,7 @@ class RepositoryAdvisory(AdvisoryBase):
         post_parameters = {
             "vulnerabilities": [
                 github.AdvisoryVulnerability.AdvisoryVulnerability._to_github_dict(vulnerability)
-                for vulnerability in (self.vulnerabilities + list(vulnerabilities))
+                for vulnerability in ((self.vulnerabilities or []) + list(vulnerabilities))
             ]
         }
         headers, data = self._requester.requestJsonAndCheck(
@@ -219,7 +219,7 @@ class RepositoryAdvisory(AdvisoryBase):
         patch_parameters = {
             "credits": [
                 github.AdvisoryCredit.AdvisoryCredit._to_github_dict(credit)
-                for credit in (self.credits + list(credited))
+                for credit in ((self.credits or []) + list(credited))
             ]
         }
         headers, data = self._requester.requestJsonAndCheck(
@@ -238,7 +238,9 @@ class RepositoryAdvisory(AdvisoryBase):
             login_or_user = login_or_user.login
         patch_parameters = {
             "credits": [
-                dict(login=credit.login, type=credit.type) for credit in self.credits if credit.login != login_or_user
+                dict(login=credit.login, type=credit.type)
+                for credit in (self.credits or [])
+                if credit.login != login_or_user
             ]
         }
         headers, data = self._requester.requestJsonAndCheck(

--- a/github/RepositoryKey.py
+++ b/github/RepositoryKey.py
@@ -67,12 +67,12 @@ class RepositoryKey(CompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._added_by: Attribute[str] = NotSet
+        self._added_by: Attribute[str | None] = NotSet
         self._created_at: Attribute[datetime] = NotSet
         self._enabled: Attribute[bool] = NotSet
         self._id: Attribute[int] = NotSet
         self._key: Attribute[str] = NotSet
-        self._last_used: Attribute[datetime] = NotSet
+        self._last_used: Attribute[datetime | None] = NotSet
         self._read_only: Attribute[bool] = NotSet
         self._title: Attribute[str] = NotSet
         self._url: Attribute[str] = NotSet
@@ -82,7 +82,7 @@ class RepositoryKey(CompletableGithubObject):
         return self.get__repr__({"id": self._id.value, "title": self._title.value})
 
     @property
-    def added_by(self) -> str:
+    def added_by(self) -> str | None:
         self._completeIfNotSet(self._added_by)
         return self._added_by.value
 
@@ -107,7 +107,7 @@ class RepositoryKey(CompletableGithubObject):
         return self._key.value
 
     @property
-    def last_used(self) -> datetime:
+    def last_used(self) -> datetime | None:
         self._completeIfNotSet(self._last_used)
         return self._last_used.value
 

--- a/github/RequiredStatusChecks.py
+++ b/github/RequiredStatusChecks.py
@@ -61,14 +61,14 @@ class Check(NonCompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._app_id: Attribute[int] = NotSet
+        self._app_id: Attribute[int | None] = NotSet
         self._context: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"app_id": self._app_id.value, "context": self._context.value})
 
     @property
-    def app_id(self) -> int:
+    def app_id(self) -> int | None:
         return self._app_id.value
 
     @property

--- a/github/SecretScanAlert.py
+++ b/github/SecretScanAlert.py
@@ -50,19 +50,19 @@ class SecretScanAlert(NonCompletableGithubObject):
 
     def _initAttributes(self) -> None:
         self._created_at: Attribute[datetime] = NotSet
-        self._first_location_detected: Attribute[SecretScanAlertInstance] = NotSet
+        self._first_location_detected: Attribute[SecretScanAlertInstance | None] = NotSet
         self._has_more_locations: Attribute[bool] = NotSet
         self._html_url: Attribute[str] = NotSet
-        self._is_base64_encoded: Attribute[bool] = NotSet
+        self._is_base64_encoded: Attribute[bool | None] = NotSet
         self._locations_url: Attribute[str] = NotSet
-        self._multi_repo: Attribute[bool] = NotSet
+        self._multi_repo: Attribute[bool | None] = NotSet
         self._number: Attribute[int] = NotSet
-        self._publicly_leaked: Attribute[bool] = NotSet
+        self._publicly_leaked: Attribute[bool | None] = NotSet
         self._push_protection_bypass_request_comment: Attribute[str | None] = NotSet
         self._push_protection_bypass_request_html_url: Attribute[str | None] = NotSet
         self._push_protection_bypass_request_reviewer: Attribute[NamedUser | None] = NotSet
         self._push_protection_bypass_request_reviewer_comment: Attribute[str | None] = NotSet
-        self._push_protection_bypassed: Attribute[bool] = NotSet
+        self._push_protection_bypassed: Attribute[bool | None] = NotSet
         self._push_protection_bypassed_at: Attribute[datetime | None] = NotSet
         self._push_protection_bypassed_by: Attribute[NamedUser | None] = NotSet
         self._resolution: Attribute[str | None] = NotSet
@@ -73,7 +73,7 @@ class SecretScanAlert(NonCompletableGithubObject):
         self._secret_type: Attribute[str] = NotSet
         self._secret_type_display_name: Attribute[str] = NotSet
         self._state: Attribute[str] = NotSet
-        self._updated_at: Attribute[datetime] = NotSet
+        self._updated_at: Attribute[datetime | None] = NotSet
         self._url: Attribute[str] = NotSet
         self._validity: Attribute[str] = NotSet
 
@@ -85,7 +85,7 @@ class SecretScanAlert(NonCompletableGithubObject):
         return self._created_at.value
 
     @property
-    def first_location_detected(self) -> SecretScanAlertInstance:
+    def first_location_detected(self) -> SecretScanAlertInstance | None:
         return self._first_location_detected.value
 
     @property
@@ -97,7 +97,7 @@ class SecretScanAlert(NonCompletableGithubObject):
         return self._html_url.value
 
     @property
-    def is_base64_encoded(self) -> bool:
+    def is_base64_encoded(self) -> bool | None:
         return self._is_base64_encoded.value
 
     @property
@@ -105,7 +105,7 @@ class SecretScanAlert(NonCompletableGithubObject):
         return self._locations_url.value
 
     @property
-    def multi_repo(self) -> bool:
+    def multi_repo(self) -> bool | None:
         return self._multi_repo.value
 
     @property
@@ -113,7 +113,7 @@ class SecretScanAlert(NonCompletableGithubObject):
         return self._number.value
 
     @property
-    def publicly_leaked(self) -> bool:
+    def publicly_leaked(self) -> bool | None:
         return self._publicly_leaked.value
 
     @property
@@ -133,7 +133,7 @@ class SecretScanAlert(NonCompletableGithubObject):
         return self._push_protection_bypass_request_reviewer_comment.value
 
     @property
-    def push_protection_bypassed(self) -> bool:
+    def push_protection_bypassed(self) -> bool | None:
         return self._push_protection_bypassed.value
 
     @property
@@ -177,7 +177,7 @@ class SecretScanAlert(NonCompletableGithubObject):
         return self._state.value
 
     @property
-    def updated_at(self) -> datetime:
+    def updated_at(self) -> datetime | None:
         return self._updated_at.value
 
     @property

--- a/github/SelfHostedActionsRunnerToken.py
+++ b/github/SelfHostedActionsRunnerToken.py
@@ -70,7 +70,7 @@ class SelfHostedActionsRunnerToken(NonCompletableGithubObject):
         self._permissions: Attribute[dict[str, Any]] = NotSet
         self._repositories: Attribute[list[Repository]] = NotSet
         self._repository_selection: Attribute[str] = NotSet
-        self._single_file: Attribute[str] = NotSet
+        self._single_file: Attribute[str | None] = NotSet
         self._token: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
@@ -93,7 +93,7 @@ class SelfHostedActionsRunnerToken(NonCompletableGithubObject):
         return self._repository_selection.value
 
     @property
-    def single_file(self) -> str:
+    def single_file(self) -> str | None:
         return self._single_file.value
 
     @property

--- a/github/SourceImport.py
+++ b/github/SourceImport.py
@@ -55,28 +55,28 @@ class SourceImport(CompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._authors_count: Attribute[int] = NotSet
+        self._authors_count: Attribute[int | None] = NotSet
         self._authors_url: Attribute[str] = NotSet
-        self._commit_count: Attribute[int] = NotSet
-        self._error_message: Attribute[str] = NotSet
-        self._failed_step: Attribute[str] = NotSet
+        self._commit_count: Attribute[int | None] = NotSet
+        self._error_message: Attribute[str | None] = NotSet
+        self._failed_step: Attribute[str | None] = NotSet
         self._has_large_files: Attribute[bool] = NotSet
         self._html_url: Attribute[str] = NotSet
-        self._import_percent: Attribute[int] = NotSet
+        self._import_percent: Attribute[int | None] = NotSet
         self._large_files_count: Attribute[int] = NotSet
         self._large_files_size: Attribute[int] = NotSet
         self._message: Attribute[str] = NotSet
         self._project_choices: Attribute[list[dict[str, Any]]] = NotSet
-        self._push_percent: Attribute[int] = NotSet
+        self._push_percent: Attribute[int | None] = NotSet
         self._repository_url: Attribute[str] = NotSet
         self._status: Attribute[str] = NotSet
-        self._status_text: Attribute[str] = NotSet
+        self._status_text: Attribute[str | None] = NotSet
         self._svc_root: Attribute[str] = NotSet
         self._svn_root: Attribute[str] = NotSet
         self._tfvc_project: Attribute[str] = NotSet
         self._url: Attribute[str] = NotSet
         self._use_lfs: Attribute[str] = NotSet
-        self._vcs: Attribute[str] = NotSet
+        self._vcs: Attribute[str | None] = NotSet
         self._vcs_url: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
@@ -90,7 +90,7 @@ class SourceImport(CompletableGithubObject):
         )
 
     @property
-    def authors_count(self) -> int:
+    def authors_count(self) -> int | None:
         self._completeIfNotSet(self._authors_count)
         return self._authors_count.value
 
@@ -100,17 +100,17 @@ class SourceImport(CompletableGithubObject):
         return self._authors_url.value
 
     @property
-    def commit_count(self) -> int:
+    def commit_count(self) -> int | None:
         self._completeIfNotSet(self._commit_count)
         return self._commit_count.value
 
     @property
-    def error_message(self) -> str:
+    def error_message(self) -> str | None:
         self._completeIfNotSet(self._error_message)
         return self._error_message.value
 
     @property
-    def failed_step(self) -> str:
+    def failed_step(self) -> str | None:
         self._completeIfNotSet(self._failed_step)
         return self._failed_step.value
 
@@ -125,7 +125,7 @@ class SourceImport(CompletableGithubObject):
         return self._html_url.value
 
     @property
-    def import_percent(self) -> int:
+    def import_percent(self) -> int | None:
         self._completeIfNotSet(self._import_percent)
         return self._import_percent.value
 
@@ -150,7 +150,7 @@ class SourceImport(CompletableGithubObject):
         return self._project_choices.value
 
     @property
-    def push_percent(self) -> int:
+    def push_percent(self) -> int | None:
         self._completeIfNotSet(self._push_percent)
         return self._push_percent.value
 
@@ -165,7 +165,7 @@ class SourceImport(CompletableGithubObject):
         return self._status.value
 
     @property
-    def status_text(self) -> str:
+    def status_text(self) -> str | None:
         self._completeIfNotSet(self._status_text)
         return self._status_text.value
 
@@ -195,7 +195,7 @@ class SourceImport(CompletableGithubObject):
         return self._use_lfs.value
 
     @property
-    def vcs(self) -> str:
+    def vcs(self) -> str | None:
         self._completeIfNotSet(self._vcs)
         return self._vcs.value
 

--- a/github/Team.py
+++ b/github/Team.py
@@ -111,10 +111,10 @@ class Team(CompletableGithubObject):
 
     def _initAttributes(self) -> None:
         self._created_at: Attribute[datetime] = NotSet
-        self._description: Attribute[str] = NotSet
+        self._description: Attribute[str | None] = NotSet
         self._enterprise_id: Attribute[int] = NotSet
-        self._group_id: Attribute[int] = NotSet
-        self._group_name: Attribute[str] = NotSet
+        self._group_id: Attribute[int | None] = NotSet
+        self._group_name: Attribute[str | None] = NotSet
         self._html_url: Attribute[str] = NotSet
         self._id: Attribute[int] = NotSet
         self._ldap_dn: Attribute[str] = NotSet
@@ -126,7 +126,7 @@ class Team(CompletableGithubObject):
         self._organization: Attribute[Organization] = NotSet
         self._organization_id: Attribute[int] = NotSet
         self._organization_selection_type: Attribute[str] = NotSet
-        self._parent: Attribute[Team] = NotSet
+        self._parent: Attribute[Team | None] = NotSet
         self._permission: Attribute[str] = NotSet
         self._permissions: Attribute[Permissions] = NotSet
         self._privacy: Attribute[str] = NotSet
@@ -151,7 +151,7 @@ class Team(CompletableGithubObject):
         return self._created_at.value
 
     @property
-    def description(self) -> str:
+    def description(self) -> str | None:
         self._completeIfNotSet(self._description)
         return self._description.value
 
@@ -161,12 +161,12 @@ class Team(CompletableGithubObject):
         return self._enterprise_id.value
 
     @property
-    def group_id(self) -> int:
+    def group_id(self) -> int | None:
         self._completeIfNotSet(self._group_id)
         return self._group_id.value
 
     @property
-    def group_name(self) -> str:
+    def group_name(self) -> str | None:
         self._completeIfNotSet(self._group_name)
         return self._group_name.value
 
@@ -226,7 +226,7 @@ class Team(CompletableGithubObject):
         return self._organization_selection_type.value
 
     @property
-    def parent(self) -> Team:
+    def parent(self) -> Team | None:
         self._completeIfNotSet(self._parent)
         return self._parent.value
 

--- a/github/Topic.py
+++ b/github/Topic.py
@@ -57,20 +57,20 @@ class Topic(NonCompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._aliases: Attribute[list[dict[str, Any]]] = NotSet
+        self._aliases: Attribute[list[dict[str, Any]] | None] = NotSet
         self._created_at: Attribute[datetime] = NotSet
-        self._created_by: Attribute[str] = NotSet
+        self._created_by: Attribute[str | None] = NotSet
         self._curated: Attribute[bool] = NotSet
-        self._description: Attribute[str] = NotSet
-        self._display_name: Attribute[str] = NotSet
+        self._description: Attribute[str | None] = NotSet
+        self._display_name: Attribute[str | None] = NotSet
         self._featured: Attribute[bool] = NotSet
-        self._logo_url: Attribute[str] = NotSet
+        self._logo_url: Attribute[str | None] = NotSet
         self._name: Attribute[str] = NotSet
-        self._related: Attribute[list[dict[str, Any]]] = NotSet
-        self._released: Attribute[str] = NotSet
-        self._repository_count: Attribute[int] = NotSet
+        self._related: Attribute[list[dict[str, Any]] | None] = NotSet
+        self._released: Attribute[str | None] = NotSet
+        self._repository_count: Attribute[int | None] = NotSet
         self._score: Attribute[float] = NotSet
-        self._short_description: Attribute[str] = NotSet
+        self._short_description: Attribute[str | None] = NotSet
         self._text_matches: Attribute[dict[str, Any]] = NotSet
         self._updated_at: Attribute[datetime] = NotSet
 
@@ -78,7 +78,7 @@ class Topic(NonCompletableGithubObject):
         return self.get__repr__({"name": self._name.value})
 
     @property
-    def aliases(self) -> list[dict[str, Any]]:
+    def aliases(self) -> list[dict[str, Any]] | None:
         return self._aliases.value
 
     @property
@@ -86,7 +86,7 @@ class Topic(NonCompletableGithubObject):
         return self._created_at.value
 
     @property
-    def created_by(self) -> str:
+    def created_by(self) -> str | None:
         return self._created_by.value
 
     @property
@@ -94,11 +94,11 @@ class Topic(NonCompletableGithubObject):
         return self._curated.value
 
     @property
-    def description(self) -> str:
+    def description(self) -> str | None:
         return self._description.value
 
     @property
-    def display_name(self) -> str:
+    def display_name(self) -> str | None:
         return self._display_name.value
 
     @property
@@ -106,7 +106,7 @@ class Topic(NonCompletableGithubObject):
         return self._featured.value
 
     @property
-    def logo_url(self) -> str:
+    def logo_url(self) -> str | None:
         return self._logo_url.value
 
     @property
@@ -114,15 +114,15 @@ class Topic(NonCompletableGithubObject):
         return self._name.value
 
     @property
-    def related(self) -> list[dict[str, Any]]:
+    def related(self) -> list[dict[str, Any]] | None:
         return self._related.value
 
     @property
-    def released(self) -> str:
+    def released(self) -> str | None:
         return self._released.value
 
     @property
-    def repository_count(self) -> int:
+    def repository_count(self) -> int | None:
         return self._repository_count.value
 
     @property
@@ -130,7 +130,7 @@ class Topic(NonCompletableGithubObject):
         return self._score.value
 
     @property
-    def short_description(self) -> str:
+    def short_description(self) -> str | None:
         return self._short_description.value
 
     @property

--- a/github/UserKey.py
+++ b/github/UserKey.py
@@ -65,7 +65,7 @@ class UserKey(CompletableGithubObject):
         self._created_at: Attribute[datetime] = NotSet
         self._id: Attribute[int] = NotSet
         self._key: Attribute[str] = NotSet
-        self._last_used: Attribute[datetime] = NotSet
+        self._last_used: Attribute[datetime | None] = NotSet
         self._read_only: Attribute[bool] = NotSet
         self._title: Attribute[str] = NotSet
         self._url: Attribute[str] = NotSet
@@ -90,7 +90,7 @@ class UserKey(CompletableGithubObject):
         return self._key.value
 
     @property
-    def last_used(self) -> datetime:
+    def last_used(self) -> datetime | None:
         self._completeIfNotSet(self._last_used)
         return self._last_used.value
 

--- a/github/WorkflowJob.py
+++ b/github/WorkflowJob.py
@@ -58,12 +58,12 @@ class WorkflowJob(CompletableGithubObject):
 
     def _initAttributes(self) -> None:
         self._check_run_url: Attribute[str] = NotSet
-        self._completed_at: Attribute[datetime] = NotSet
+        self._completed_at: Attribute[datetime | None] = NotSet
         self._conclusion: Attribute[str | None] = NotSet
         self._created_at: Attribute[datetime] = NotSet
-        self._head_branch: Attribute[str] = NotSet
+        self._head_branch: Attribute[str | None] = NotSet
         self._head_sha: Attribute[str] = NotSet
-        self._html_url: Attribute[str] = NotSet
+        self._html_url: Attribute[str | None] = NotSet
         self._id: Attribute[int] = NotSet
         self._labels: Attribute[list[str]] = NotSet
         self._name: Attribute[str] = NotSet
@@ -71,15 +71,15 @@ class WorkflowJob(CompletableGithubObject):
         self._run_attempt: Attribute[int] = NotSet
         self._run_id: Attribute[int] = NotSet
         self._run_url: Attribute[str] = NotSet
-        self._runner_group_id: Attribute[int] = NotSet
-        self._runner_group_name: Attribute[str] = NotSet
-        self._runner_id: Attribute[int] = NotSet
-        self._runner_name: Attribute[str] = NotSet
+        self._runner_group_id: Attribute[int | None] = NotSet
+        self._runner_group_name: Attribute[str | None] = NotSet
+        self._runner_id: Attribute[int | None] = NotSet
+        self._runner_name: Attribute[str | None] = NotSet
         self._started_at: Attribute[datetime] = NotSet
         self._status: Attribute[str] = NotSet
         self._steps: Attribute[list[WorkflowStep]] = NotSet
         self._url: Attribute[str] = NotSet
-        self._workflow_name: Attribute[str] = NotSet
+        self._workflow_name: Attribute[str | None] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"id": self._id.value, "url": self._url.value})
@@ -90,7 +90,7 @@ class WorkflowJob(CompletableGithubObject):
         return self._check_run_url.value
 
     @property
-    def completed_at(self) -> datetime:
+    def completed_at(self) -> datetime | None:
         self._completeIfNotSet(self._completed_at)
         return self._completed_at.value
 
@@ -105,7 +105,7 @@ class WorkflowJob(CompletableGithubObject):
         return self._created_at.value
 
     @property
-    def head_branch(self) -> str:
+    def head_branch(self) -> str | None:
         self._completeIfNotSet(self._head_branch)
         return self._head_branch.value
 
@@ -115,7 +115,7 @@ class WorkflowJob(CompletableGithubObject):
         return self._head_sha.value
 
     @property
-    def html_url(self) -> str:
+    def html_url(self) -> str | None:
         self._completeIfNotSet(self._html_url)
         return self._html_url.value
 
@@ -155,22 +155,22 @@ class WorkflowJob(CompletableGithubObject):
         return self._run_url.value
 
     @property
-    def runner_group_id(self) -> int:
+    def runner_group_id(self) -> int | None:
         self._completeIfNotSet(self._runner_group_id)
         return self._runner_group_id.value
 
     @property
-    def runner_group_name(self) -> str:
+    def runner_group_name(self) -> str | None:
         self._completeIfNotSet(self._runner_group_name)
         return self._runner_group_name.value
 
     @property
-    def runner_id(self) -> int:
+    def runner_id(self) -> int | None:
         self._completeIfNotSet(self._runner_id)
         return self._runner_id.value
 
     @property
-    def runner_name(self) -> str:
+    def runner_name(self) -> str | None:
         self._completeIfNotSet(self._runner_name)
         return self._runner_name.value
 
@@ -195,7 +195,7 @@ class WorkflowJob(CompletableGithubObject):
         return self._url.value
 
     @property
-    def workflow_name(self) -> str:
+    def workflow_name(self) -> str | None:
         self._completeIfNotSet(self._workflow_name)
         return self._workflow_name.value
 

--- a/github/WorkflowRun.py
+++ b/github/WorkflowRun.py
@@ -97,12 +97,12 @@ class WorkflowRun(CompletableGithubObject):
         self._check_suite_id: Attribute[int] = NotSet
         self._check_suite_node_id: Attribute[str] = NotSet
         self._check_suite_url: Attribute[str] = NotSet
-        self._conclusion: Attribute[str] = NotSet
+        self._conclusion: Attribute[str | None] = NotSet
         self._created_at: Attribute[datetime] = NotSet
         self._display_title: Attribute[str] = NotSet
         self._event: Attribute[str] = NotSet
-        self._head_branch: Attribute[str] = NotSet
-        self._head_commit: Attribute[GitCommit] = NotSet
+        self._head_branch: Attribute[str | None] = NotSet
+        self._head_commit: Attribute[GitCommit | None] = NotSet
         self._head_repository: Attribute[Repository] = NotSet
         self._head_repository_id: Attribute[int] = NotSet
         self._head_sha: Attribute[str] = NotSet
@@ -110,19 +110,19 @@ class WorkflowRun(CompletableGithubObject):
         self._id: Attribute[int] = NotSet
         self._jobs_url: Attribute[str] = NotSet
         self._logs_url: Attribute[str] = NotSet
-        self._name: Attribute[str] = NotSet
+        self._name: Attribute[str | None] = NotSet
         self._node_id: Attribute[str] = NotSet
         self._path: Attribute[str] = NotSet
-        self._previous_attempt_url: Attribute[str] = NotSet
-        self._pull_requests: Attribute[list[PullRequest]] = NotSet
-        self._referenced_workflows: Attribute[list[dict[str, Any]]] = NotSet
+        self._previous_attempt_url: Attribute[str | None] = NotSet
+        self._pull_requests: Attribute[list[PullRequest] | None] = NotSet
+        self._referenced_workflows: Attribute[list[dict[str, Any]] | None] = NotSet
         self._repository: Attribute[Repository] = NotSet
         self._repository_id: Attribute[int] = NotSet
         self._rerun_url: Attribute[str] = NotSet
         self._run_attempt: Attribute[int] = NotSet
         self._run_number: Attribute[int] = NotSet
         self._run_started_at: Attribute[datetime] = NotSet
-        self._status: Attribute[str] = NotSet
+        self._status: Attribute[str | None] = NotSet
         self._triggering_actor: Attribute[NamedUser] = NotSet
         self._updated_at: Attribute[datetime] = NotSet
         self._url: Attribute[str] = NotSet
@@ -163,7 +163,7 @@ class WorkflowRun(CompletableGithubObject):
         return self._check_suite_url.value
 
     @property
-    def conclusion(self) -> str:
+    def conclusion(self) -> str | None:
         self._completeIfNotSet(self._conclusion)
         return self._conclusion.value
 
@@ -183,12 +183,12 @@ class WorkflowRun(CompletableGithubObject):
         return self._event.value
 
     @property
-    def head_branch(self) -> str:
+    def head_branch(self) -> str | None:
         self._completeIfNotSet(self._head_branch)
         return self._head_branch.value
 
     @property
-    def head_commit(self) -> GitCommit:
+    def head_commit(self) -> GitCommit | None:
         self._completeIfNotSet(self._head_commit)
         return self._head_commit.value
 
@@ -228,7 +228,7 @@ class WorkflowRun(CompletableGithubObject):
         return self._logs_url.value
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         self._completeIfNotSet(self._name)
         return self._name.value
 
@@ -243,17 +243,17 @@ class WorkflowRun(CompletableGithubObject):
         return self._path.value
 
     @property
-    def previous_attempt_url(self) -> str:
+    def previous_attempt_url(self) -> str | None:
         self._completeIfNotSet(self._previous_attempt_url)
         return self._previous_attempt_url.value
 
     @property
-    def pull_requests(self) -> list[PullRequest]:
+    def pull_requests(self) -> list[PullRequest] | None:
         self._completeIfNotSet(self._pull_requests)
         return self._pull_requests.value
 
     @property
-    def referenced_workflows(self) -> list[dict[str, Any]]:
+    def referenced_workflows(self) -> list[dict[str, Any]] | None:
         self._completeIfNotSet(self._referenced_workflows)
         return self._referenced_workflows.value
 
@@ -288,7 +288,7 @@ class WorkflowRun(CompletableGithubObject):
         return self._run_started_at.value
 
     @property
-    def status(self) -> str:
+    def status(self) -> str | None:
         self._completeIfNotSet(self._status)
         return self._status.value
 

--- a/github/WorkflowStep.py
+++ b/github/WorkflowStep.py
@@ -62,23 +62,23 @@ class WorkflowStep(CompletableGithubObject):
     """
 
     def _initAttributes(self) -> None:
-        self._completed_at: Attribute[datetime] = NotSet
-        self._conclusion: Attribute[str] = NotSet
+        self._completed_at: Attribute[datetime | None] = NotSet
+        self._conclusion: Attribute[str | None] = NotSet
         self._name: Attribute[str] = NotSet
         self._number: Attribute[int] = NotSet
-        self._started_at: Attribute[datetime] = NotSet
+        self._started_at: Attribute[datetime | None] = NotSet
         self._status: Attribute[str] = NotSet
 
     def __repr__(self) -> str:
         return self.get__repr__({"number": self._number.value, "name": self._name.value})
 
     @property
-    def completed_at(self) -> datetime:
+    def completed_at(self) -> datetime | None:
         self._completeIfNotSet(self._completed_at)
         return self._completed_at.value
 
     @property
-    def conclusion(self) -> str:
+    def conclusion(self) -> str | None:
         self._completeIfNotSet(self._conclusion)
         return self._conclusion.value
 
@@ -93,7 +93,7 @@ class WorkflowStep(CompletableGithubObject):
         return self._number.value
 
     @property
-    def started_at(self) -> datetime:
+    def started_at(self) -> datetime | None:
         self._completeIfNotSet(self._started_at)
         return self._started_at.value
 

--- a/tests/PullRequest.py
+++ b/tests/PullRequest.py
@@ -57,8 +57,11 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 import pytest
+from typing_extensions import assert_type
 
 import github
+from github.NamedUser import NamedUser
+from github.PullRequest import PullRequest as PullRequestObject
 
 from . import Framework
 
@@ -112,6 +115,16 @@ class PullRequest(Framework.TestCase):
         self.assertEqual(self.pullIssue256Merged.mergeable_state, "unknown")
         self.assertEqual(self.pullIssue256Conflict.mergeable_state, "clean")
         self.assertEqual(self.pullIssue256Uncached.mergeable_state, "unknown")
+
+    def testMergedBy(self) -> None:
+        pull: PullRequestObject = self.pull
+        merged_by = pull.merged_by
+        assert_type(merged_by, NamedUser | None)
+        assert merged_by is not None
+        self.assertEqual(merged_by.login, "jacquev6")
+
+        closed_pull: PullRequestObject = self.pullIssue256Closed
+        self.assertIsNone(closed_pull.merged_by)
 
     def testAttributes(self):
         self.assertEqual(


### PR DESCRIPTION
## Problem

GitHub's REST API marks many object properties as nullable, but PyGithub still exposes those properties as non-null types. `PullRequest.merged_by` is one concrete failure: implicitly merged pull requests can return `null`, while type checkers currently allow callers to dereference it without a guard.

## Solution

- Apply the OpenAPI nullable information across the existing PyGithub object model, following the repository generator output demonstrated in `9b3aefb`.
- Preserve the focused `PullRequest.merged_by` regression for both populated and null replay payloads.
- Pin that public property as `NamedUser | None` with `typing_extensions.assert_type`.

The OpenAPI-generated commit updates 72 existing classes. Runtime deserialization behavior is unchanged; this aligns the public types with values GitHub already returns.

## Validation

- `pytest -q` — 1131 passed, 649 subtests passed
- `pytest tests/PullRequest.py -q` — 42 passed
- `mypy github` — 176 source files clean
- `pre-commit run --all-files` — all hooks passed

Fixes #3553