### PR TITLE
Migrate from reqests to niquests

### DIFF
--- a/github/Auth.py
+++ b/github/Auth.py
@@ -40,7 +40,7 @@ from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Union
 
 import jwt
-from requests import utils
+from niquests import utils
 
 from github import Consts
 from github.InstallationAuthorization import InstallationAuthorization

--- a/github/GithubIntegration.py
+++ b/github/GithubIntegration.py
@@ -40,9 +40,8 @@ import urllib.parse
 import warnings
 from typing import Any
 
-import urllib3
+import niquests
 from typing_extensions import deprecated
-from urllib3 import Retry
 
 import github
 from github import Consts
@@ -80,7 +79,7 @@ class GithubIntegration:
         user_agent: str = Consts.DEFAULT_USER_AGENT,
         per_page: int = Consts.DEFAULT_PER_PAGE,
         verify: bool | str = True,
-        retry: int | Retry | None = None,
+        retry: int | niquests.RetryConfiguration | None = None,
         pool_size: int | None = None,
         seconds_between_requests: float | None = Consts.DEFAULT_SECONDS_BETWEEN_REQUESTS,
         seconds_between_writes: float | None = Consts.DEFAULT_SECONDS_BETWEEN_WRITES,
@@ -123,7 +122,7 @@ class GithubIntegration:
         assert user_agent is None or isinstance(user_agent, str), user_agent
         assert isinstance(per_page, int), per_page
         assert isinstance(verify, (bool, str)), verify
-        assert retry is None or isinstance(retry, int) or isinstance(retry, urllib3.util.Retry), retry
+        assert retry is None or isinstance(retry, int) or isinstance(retry, niquests.RetryConfiguration), retry
         assert pool_size is None or isinstance(pool_size, int), pool_size
         assert seconds_between_requests is None or seconds_between_requests >= 0
         assert seconds_between_writes is None or seconds_between_writes >= 0

--- a/github/GithubRetry.py
+++ b/github/GithubRetry.py
@@ -140,7 +140,7 @@ class GithubRetry(RetryConfiguration):
                         try:
                             raise RuntimeError("Failed to inspect response message") from e
                         except RuntimeError as e:
-                            raise GithubException(response.status, content, response.headers) from e  # type: ignore
+                            raise GithubException(response.status, content or response.reason, response.headers) from e  # type: ignore
 
                     try:
                         if Requester.isRateLimitError(message):

--- a/github/GithubRetry.py
+++ b/github/GithubRetry.py
@@ -38,14 +38,13 @@ from logging import Logger
 from types import TracebackType
 from typing import Any
 
-from requests import Response
-from requests.models import CaseInsensitiveDict
-from requests.utils import get_encoding_from_headers
+from niquests import Response, RetryConfiguration
+from niquests.models import CaseInsensitiveDict
+from niquests.packages.urllib3.connectionpool import ConnectionPool
+from niquests.packages.urllib3.exceptions import MaxRetryError
+from niquests.packages.urllib3.response import HTTPResponse
+from niquests.utils import get_encoding_from_headers
 from typing_extensions import Self
-from urllib3 import Retry
-from urllib3.connectionpool import ConnectionPool
-from urllib3.exceptions import MaxRetryError
-from urllib3.response import HTTPResponse
 
 from github.GithubException import GithubException, RateLimitExceededExceedsMaxWait
 from github.Requester import Requester
@@ -53,7 +52,7 @@ from github.Requester import Requester
 DEFAULT_SECONDARY_RATE_WAIT: int = 60
 
 
-class GithubRetry(Retry):
+class GithubRetry(RetryConfiguration):
     """
     A Github-specific implementation of `urllib3.Retry`
 
@@ -95,7 +94,9 @@ class GithubRetry(Retry):
         # we retry 403 and look into the response header via Retry.increment
         # to determine if we really retry that 403
         kwargs["status_forcelist"] = kwargs.get("status_forcelist", list(range(500, 600))) + [403]
-        kwargs["allowed_methods"] = kwargs.get("allowed_methods", Retry.DEFAULT_ALLOWED_METHODS.union({"GET", "POST"}))
+        kwargs["allowed_methods"] = kwargs.get(
+            "allowed_methods", RetryConfiguration.DEFAULT_ALLOWED_METHODS.union({"GET", "POST"})
+        )
         super().__init__(**kwargs)
 
     def new(self, **kw: Any) -> Self:
@@ -110,7 +111,7 @@ class GithubRetry(Retry):
         error: Exception | None = None,
         _pool: ConnectionPool | None = None,
         _stacktrace: TracebackType | None = None,
-    ) -> Retry:
+    ) -> RetryConfiguration:
         if response:
             # we retry 403 only when there is a Retry-After header (indicating it is retry-able)
             # or the body message does imply a rate limit error

--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -106,8 +106,7 @@ import warnings
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, BinaryIO, TypeVar, overload
 
-import urllib3
-from urllib3.util import Retry
+import niquests
 
 import github.ApplicationOAuth
 import github.Auth
@@ -201,7 +200,7 @@ class Github:
         user_agent: str = Consts.DEFAULT_USER_AGENT,
         per_page: int = Consts.DEFAULT_PER_PAGE,
         verify: bool | str = True,
-        retry: int | Retry | None = default_retry,
+        retry: int | niquests.RetryConfiguration | None = default_retry,
         pool_size: int | None = None,
         seconds_between_requests: float | None = Consts.DEFAULT_SECONDS_BETWEEN_REQUESTS,
         seconds_between_writes: float | None = Consts.DEFAULT_SECONDS_BETWEEN_WRITES,
@@ -242,7 +241,7 @@ class Github:
         assert user_agent is None or isinstance(user_agent, str), user_agent
         assert isinstance(per_page, int), per_page
         assert isinstance(verify, (bool, str)), verify
-        assert retry is None or isinstance(retry, int) or isinstance(retry, urllib3.util.Retry), retry
+        assert retry is None or isinstance(retry, int) or isinstance(retry, niquests.RetryConfiguration), retry
         assert pool_size is None or isinstance(pool_size, int), pool_size
         assert seconds_between_requests is None or seconds_between_requests >= 0
         assert seconds_between_writes is None or seconds_between_writes >= 0

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -1433,6 +1433,7 @@ class WithRequester(Generic[T]):
     def requester(self) -> Requester:
         return self.__requester
 
-    def withRequester(self, requester: Any) -> WithRequester[T]:
+    def withRequester(self, requester: Requester) -> WithRequester[T]:
+        assert isinstance(requester, Requester), requester
         self.__requester = requester
         return self

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -98,14 +98,13 @@ import time
 import urllib
 import urllib.parse
 from collections import deque
-from collections.abc import Callable, ItemsView, Iterator
+from collections.abc import Callable, Iterator
 from datetime import datetime, timezone
 from io import IOBase
 from typing import TYPE_CHECKING, Any, BinaryIO, Deque, Generic, TypeVar
 
-import requests
-import requests.adapters
-from urllib3 import Retry
+import niquests
+import niquests.adapters
 
 import github.Consts as Consts
 import github.GithubException
@@ -127,26 +126,26 @@ ACCESS_TOKEN_REFRESH_THRESHOLD_SECONDS = 20
 
 class RequestsResponse:
     # mimic the httplib response object
-    def __init__(self, r: requests.Response):
+    def __init__(self, r: niquests.Response):
         self.status = r.status_code
         self.headers = r.headers
         self.response = r
 
-    def getheaders(self) -> ItemsView[str, str]:
+    def getheaders(self) -> Iterator[tuple[str, str]]:
         return self.headers.items()
 
     def read(self) -> str:
         return self.response.text or ""
 
-    def iter_content(self, chunk_size: int | None = 1) -> Iterator:
-        return self.response.iter_content(chunk_size=chunk_size)
+    def iter_content(self, chunk_size: int | None = -1) -> Iterator:
+        return self.response.iter_content(chunk_size=chunk_size or -1)
 
     def raise_for_status(self) -> None:
         self.response.raise_for_status()
 
 
 class HTTPSRequestsConnectionClass:
-    retry: int | Retry
+    retry: int | niquests.RetryConfiguration
 
     # mimic the httplib connection object
     def __init__(
@@ -155,7 +154,7 @@ class HTTPSRequestsConnectionClass:
         port: int | None = None,
         strict: bool = False,
         timeout: int | None = None,
-        retry: int | Retry | None = None,
+        retry: int | niquests.RetryConfiguration | None = None,
         pool_size: int | None = None,
         **kwargs: Any,
     ) -> None:
@@ -164,28 +163,24 @@ class HTTPSRequestsConnectionClass:
         self.protocol = "https"
         self.timeout = timeout
         self.verify = kwargs.get("verify", True)
-        self.session = requests.Session()
-        # having Session.auth set something other than None disables falling back to .netrc file
-        # https://github.com/psf/requests/blob/d63e94f552ebf77ccf45d97e5863ac46500fa2c7/src/requests/sessions.py#L480-L481
-        # see https://github.com/PyGithub/PyGithub/pull/2703
-        self.session.auth = Requester.noopAuth
 
         if retry is None:
-            self.retry = requests.adapters.DEFAULT_RETRIES
+            self.retry = niquests.adapters.DEFAULT_RETRIES
         else:
             self.retry = retry
 
         if pool_size is None:
-            self.pool_size = requests.adapters.DEFAULT_POOLSIZE
+            self.pool_size = niquests.adapters.DEFAULT_POOLSIZE
         else:
             self.pool_size = pool_size
 
-        self.adapter = requests.adapters.HTTPAdapter(
-            max_retries=self.retry,
-            pool_connections=self.pool_size,
-            pool_maxsize=self.pool_size,
+        self.session = niquests.Session(
+            retries=self.retry, pool_connections=self.pool_size, pool_maxsize=self.pool_size
         )
-        self.session.mount("https://", self.adapter)
+        # having Session.auth set something other than None disables falling back to .netrc file
+        # https://github.com/psf/requests/blob/d63e94f552ebf77ccf45d97e5863ac46500fa2c7/src/requests/sessions.py#L480-L481
+        # see https://github.com/PyGithub/PyGithub/pull/2703
+        self.session.auth = Requester.noopAuth
 
     def request(
         self,
@@ -226,7 +221,7 @@ class HTTPRequestsConnectionClass:
         port: int | None = None,
         strict: bool = False,
         timeout: int | None = None,
-        retry: int | Retry | None = None,
+        retry: int | niquests.RetryConfiguration | None = None,
         pool_size: int | None = None,
         **kwargs: Any,
     ):
@@ -235,28 +230,24 @@ class HTTPRequestsConnectionClass:
         self.protocol = "http"
         self.timeout = timeout
         self.verify = kwargs.get("verify", True)
-        self.session = requests.Session()
-        # having Session.auth set something other than None disables falling back to .netrc file
-        # https://github.com/psf/requests/blob/d63e94f552ebf77ccf45d97e5863ac46500fa2c7/src/requests/sessions.py#L480-L481
-        # see https://github.com/PyGithub/PyGithub/pull/2703
-        self.session.auth = Requester.noopAuth
 
         if retry is None:
-            self.retry = requests.adapters.DEFAULT_RETRIES
+            self.retry = niquests.adapters.DEFAULT_RETRIES
         else:
             self.retry = retry  # type: ignore
 
         if pool_size is None:
-            self.pool_size = requests.adapters.DEFAULT_POOLSIZE
+            self.pool_size = niquests.adapters.DEFAULT_POOLSIZE
         else:
             self.pool_size = pool_size
 
-        self.adapter = requests.adapters.HTTPAdapter(
-            max_retries=self.retry,
-            pool_connections=self.pool_size,
-            pool_maxsize=self.pool_size,
+        self.session = niquests.Session(
+            retries=self.retry, pool_connections=self.pool_size, pool_maxsize=self.pool_size
         )
-        self.session.mount("http://", self.adapter)
+        # having Session.auth set something other than None disables falling back to .netrc file
+        # https://github.com/psf/requests/blob/d63e94f552ebf77ccf45d97e5863ac46500fa2c7/src/requests/sessions.py#L480-L481
+        # see https://github.com/PyGithub/PyGithub/pull/2703
+        self.session.auth = Requester.noopAuth
 
     def request(self, verb: str, url: str, input: None, headers: dict[str, str], stream: bool = False) -> None:
         self.verb = verb
@@ -294,7 +285,7 @@ class Requester:
     _frameBuffer: list[Any]
 
     @staticmethod
-    def noopAuth(request: requests.models.PreparedRequest) -> requests.models.PreparedRequest:
+    def noopAuth(request: niquests.models.PreparedRequest) -> niquests.models.PreparedRequest:
         return request
 
     @classmethod
@@ -397,7 +388,7 @@ class Requester:
         user_agent: str,
         per_page: int,
         verify: bool | str,
-        retry: int | Retry | None,
+        retry: int | niquests.RetryConfiguration | None,
         pool_size: int | None,
         seconds_between_requests: float | None = None,
         seconds_between_writes: float | None = None,
@@ -1325,7 +1316,7 @@ class Requester:
                 return self.__requestRaw(
                     cnx, verb, path, requestHeaders, input, stream=stream, follow_302_redirect=True
                 )
-            return status, responseHeaders, output
+            return status or 0, responseHeaders, output
         finally:
             # we record the time of this request after it finished
             # to defer next request starting from this request's end, not start
@@ -1442,7 +1433,6 @@ class WithRequester(Generic[T]):
     def requester(self) -> Requester:
         return self.__requester
 
-    def withRequester(self, requester: Requester) -> WithRequester[T]:
-        assert isinstance(requester, Requester), requester
+    def withRequester(self, requester: Any) -> WithRequester[T]:
         self.__requester = requester
         return self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,9 @@ dynamic = ["version"]
 
 dependencies = [
   "pynacl>=1.4.0",
-  "requests>=2.14.0",
+  "niquests>=3,<4",
   "pyjwt[crypto]>=2.4.0",
   "typing-extensions>=4.5.0",
-  "urllib3>=1.26.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = ["version"]
 
 dependencies = [
   "pynacl>=1.4.0",
-  "niquests>=3,<4",
+  "niquests>=3.12,<4",
   "pyjwt[crypto]>=2.4.0",
   "typing-extensions>=4.5.0",
 ]

--- a/requirements/types.txt
+++ b/requirements/types.txt
@@ -1,3 +1,2 @@
 mypy >=1.0.0
 types-jwt
-types-requests

--- a/tests/Authentication.py
+++ b/tests/Authentication.py
@@ -51,6 +51,7 @@ from unittest import mock
 from unittest.mock import Mock
 
 import jwt
+import niquests.utils
 
 import github
 from github.Auth import Auth, Login
@@ -268,6 +269,7 @@ class Authentication(Framework.BasicTestCase):
         self.assertEqual(user.login, "EnricoMi")
 
     def testNetrcAuth(self):
+        niquests.utils.get_netrc_auth.cache_clear()
         with NamedTemporaryFile("wt", delete=False) as tmp:
             # write temporary netrc file
             tmp.write("machine api.github.com\n")
@@ -285,6 +287,7 @@ class Authentication(Framework.BasicTestCase):
             self.assertEqual(auth.token_type, "Basic")
 
     def testNetrcAuthFails(self):
+        niquests.utils.get_netrc_auth.cache_clear()
         # provide an empty netrc file to make sure this test does not find one
         with NamedTemporaryFile("wt", delete=False) as tmp:
             tmp.close()

--- a/tests/Framework.py
+++ b/tests/Framework.py
@@ -74,6 +74,7 @@ from urllib.parse import urlsplit
 
 import vcr
 import vcr.cassette
+from niquests.packages.urllib3.util import Url
 from requests.structures import CaseInsensitiveDict
 from vcr.matchers import requests_match
 

--- a/tests/Framework.py
+++ b/tests/Framework.py
@@ -74,7 +74,6 @@ from urllib.parse import urlsplit
 
 import vcr
 import vcr.cassette
-from niquests.packages.urllib3.util import Url
 from requests.structures import CaseInsensitiveDict
 from vcr.matchers import requests_match
 

--- a/tests/GithubIntegration.py
+++ b/tests/GithubIntegration.py
@@ -37,7 +37,8 @@
 
 import time  # NOQA
 
-from urllib3.exceptions import InsecureRequestWarning
+import requests  # NOQA
+from niquests.packages.urllib3.exceptions import InsecureRequestWarning
 
 import github
 from github import Consts

--- a/tests/GithubRetry.py
+++ b/tests/GithubRetry.py
@@ -385,7 +385,7 @@ class GithubRetry(unittest.TestCase):
         response = niquests.packages.urllib3.response.HTTPResponse()
         self.do_test_default_behaviour(retry, response)
 
-    def test_error_in_get_content(self):
+    def test_error_inspecting_response_body(self):
         retry = github.GithubRetry(total=3)
         response = niquests.packages.urllib3.response.HTTPResponse(status=403, reason="NOT GOOD")
 
@@ -402,7 +402,7 @@ class GithubRetry(unittest.TestCase):
 
             self.assertIsInstance(exp.exception.__cause__.__cause__, ValueError)
             self.assertEqual(
-                ("Unable to determine whether fp is closed.",),
+                ("Expecting value: line 1 column 1 (char 0)",),
                 exp.exception.__cause__.__cause__.args,
             )
 

--- a/tests/GithubRetry.py
+++ b/tests/GithubRetry.py
@@ -33,8 +33,7 @@ from datetime import datetime
 from io import BytesIO
 from unittest import mock
 
-import urllib3.response
-from urllib3 import Retry
+import niquests.packages.urllib3.response
 
 import github
 from github.GithubRetry import DEFAULT_SECONDARY_RATE_WAIT
@@ -79,7 +78,7 @@ class GithubRetry(unittest.TestCase):
             orig_retry = retry
             with mock.patch.object(retry, "_GithubRetry__log") as log:
                 if expect_retry_error:
-                    with self.assertRaises(urllib3.exceptions.MaxRetryError):
+                    with self.assertRaises(niquests.packages.urllib3.exceptions.MaxRetryError):
                         retry.increment("TEST", "URL", response)
                     retry = None
                 else:
@@ -115,7 +114,7 @@ class GithubRetry(unittest.TestCase):
     def response_func(content, reset=None):
         def response():
             stream = BytesIO(content.encode("utf8"))
-            return urllib3.response.HTTPResponse(
+            return niquests.packages.urllib3.response.HTTPResponse(
                 body=stream,
                 preload_content=False,
                 headers={"X-RateLimit-Reset": f"{reset}"} if reset else {},
@@ -349,7 +348,7 @@ class GithubRetry(unittest.TestCase):
         test_increment(retry, response(), expect_retry_error=True)
 
     def do_test_default_behaviour(self, retry, response):
-        expected = Retry(total=retry.total, backoff_factor=retry.backoff_factor)
+        expected = niquests.RetryConfiguration(total=retry.total, backoff_factor=retry.backoff_factor)
         self.assertTrue(retry.total > 0)
         for _ in range(retry.total):
             retry = retry.increment("TEST", "URL", response)
@@ -357,14 +356,14 @@ class GithubRetry(unittest.TestCase):
             self.assertEqual(expected.total, retry.total)
             self.assertEqual(expected.get_backoff_time(), retry.get_backoff_time())
 
-        with self.assertRaises(urllib3.exceptions.MaxRetryError):
+        with self.assertRaises(niquests.packages.urllib3.exceptions.MaxRetryError):
             retry.increment("TEST", "URL", response)
-        with self.assertRaises(urllib3.exceptions.MaxRetryError):
+        with self.assertRaises(niquests.packages.urllib3.exceptions.MaxRetryError):
             expected.increment("TEST", "URL", response)
 
     def test_403_with_retry_after(self):
         retry = github.GithubRetry(total=3)
-        response = urllib3.response.HTTPResponse(status=403, headers={"Retry-After": "123"})
+        response = niquests.packages.urllib3.response.HTTPResponse(status=403, headers={"Retry-After": "123"})
         self.do_test_default_behaviour(retry, response)
 
     def test_403_with_non_retryable_error(self):
@@ -378,17 +377,17 @@ class GithubRetry(unittest.TestCase):
 
     def test_misc_response(self):
         retry = github.GithubRetry(total=3)
-        response = urllib3.response.HTTPResponse()
+        response = niquests.packages.urllib3.response.HTTPResponse()
         self.do_test_default_behaviour(retry, response)
 
     def test_misc_response_exponential_backoff(self):
         retry = github.GithubRetry(total=3, backoff_factor=10)
-        response = urllib3.response.HTTPResponse()
+        response = niquests.packages.urllib3.response.HTTPResponse()
         self.do_test_default_behaviour(retry, response)
 
     def test_error_in_get_content(self):
         retry = github.GithubRetry(total=3)
-        response = urllib3.response.HTTPResponse(status=403, reason="NOT GOOD")
+        response = niquests.packages.urllib3.response.HTTPResponse(status=403, reason="NOT GOOD")
 
         with mock.patch.object(retry, "_GithubRetry__log") as log:
             with self.assertRaises(github.GithubException) as exp:

--- a/tests/Installation.py
+++ b/tests/Installation.py
@@ -41,7 +41,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from urllib3.exceptions import InsecureRequestWarning
+from niquests.packages.urllib3.exceptions import InsecureRequestWarning
 
 import github
 from github import Consts

--- a/tests/Retry.py
+++ b/tests/Retry.py
@@ -31,8 +31,8 @@
 #                                                                              #
 ################################################################################
 
+import niquests
 import requests
-import urllib3
 
 import github
 
@@ -45,7 +45,7 @@ class Retry(Framework.TestCase):
     def setUp(self):
         # status codes returned on random github server errors
         status_forcelist = (500, 502, 504)
-        retry = urllib3.Retry(total=3, read=3, connect=3, status_forcelist=status_forcelist)
+        retry = niquests.RetryConfiguration(total=3, read=3, connect=3, status_forcelist=status_forcelist)
         self.setRetry(retry)
         super().setUp()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,21 @@
 #                                                                              #
 ################################################################################
 
-from . import Framework
+from sys import modules
+
+import niquests
+from niquests.packages import urllib3
+
+# module 'responses' is tied to Requests, and Niquests is entirely compatible with it.
+# we can fool it without effort.
+modules["requests"] = niquests
+modules["requests.adapters"] = niquests.adapters
+modules["requests.models"] = niquests.models
+modules["requests.exceptions"] = niquests.exceptions
+modules["requests.packages.urllib3"] = urllib3
+
+
+from . import Framework  # noqa: E402
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
The `requests` package is central to this project to communicate with the Github REST API. That package is under permanent feature freeze, meaning there are only bug and security fixes but no new features enhancing performance or future compatibility:

- https://github.com/psf/requests/issues/6664
- https://3.python-requests.org/dev/todo/#feature-freeze

This migrates to PyGithub to niquests, a fully compatible fork that moved beyond requests feature-wise:
https://github.com/jawah/niquests

This reuses the migration bit from #3464.