### PR TITLE
Fix `WorkflowRun` schema suggestion

### DIFF
--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -843,7 +843,7 @@ def openapi_parameter(
 
 
 # decorator to annotate methods with OpenAPI mapping information
-def ignore_return_types(types: list[type]) -> Callable[[Callable[Param, RetType]], Callable[Param, RetType]]:
+def ignore_return_type(*, ignore_type: str) -> Callable[[Callable[Param, RetType]], Callable[Param, RetType]]:
     def ignore_return_types_decorator(fn: Callable[Param, RetType]) -> Callable[Param, RetType]:
         return fn
 

--- a/github/GithubObject.py
+++ b/github/GithubObject.py
@@ -840,3 +840,11 @@ def openapi_parameter(
         return fn
 
     return openapi_parameter_decorator
+
+
+# decorator to annotate methods with OpenAPI mapping information
+def ignore_return_types(types: list[type]) -> Callable[[Callable[Param, RetType]], Callable[Param, RetType]]:
+    def ignore_return_types_decorator(fn: Callable[Param, RetType]) -> Callable[Param, RetType]:
+        return fn
+
+    return ignore_return_types_decorator

--- a/github/Workflow.py
+++ b/github/Workflow.py
@@ -56,7 +56,7 @@ import github.GithubObject
 import github.NamedUser
 import github.Tag
 import github.WorkflowRun
-from github.GithubObject import Attribute, CompletableGithubObject, NotSet, Opt
+from github.GithubObject import Attribute, CompletableGithubObject, NotSet, Opt, ignore_return_types
 from github.PaginatedList import PaginatedList
 
 if TYPE_CHECKING:
@@ -77,7 +77,6 @@ class Workflow(CompletableGithubObject):
     The OpenAPI schema can be found at
 
     - /components/schemas/workflow
-    - /components/schemas/workflow-dispatch-response
 
     """
 
@@ -158,7 +157,7 @@ class Workflow(CompletableGithubObject):
         ref: Branch | Tag | Commit | str,
         inputs: Opt[dict] = NotSet,
         throw: bool = False,
-        return_run_details: Literal[False] = False,
+        return_run_details: Literal[False] = ...,
     ) -> bool:
         ...
 
@@ -168,18 +167,19 @@ class Workflow(CompletableGithubObject):
         ref: github.Branch.Branch | github.Tag.Tag | github.Commit.Commit | str,
         inputs: Opt[dict] = NotSet,
         throw: bool = False,
-        return_run_details: Literal[True] = True,
-    ) -> github.WorkflowRun.WorkflowRun:
+        return_run_details: Literal[True] = ...,
+    ) -> WorkflowRun:
         ...
 
     # v3: default throw to True
+    @ignore_return_types(types=[github.WorkflowRun.WorkflowRun])
     def create_dispatch(
         self,
         ref: github.Branch.Branch | github.Tag.Tag | github.Commit.Commit | str,
         inputs: Opt[dict] = NotSet,
         throw: bool = False,
         return_run_details: bool = False,
-    ) -> bool | github.WorkflowRun.WorkflowRun:
+    ) -> bool | WorkflowRun:
         """
         :calls: `POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches <https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event>`_
         Note: raises or return False without details on error, depending on the ``throw`` parameter.

--- a/github/Workflow.py
+++ b/github/Workflow.py
@@ -56,7 +56,7 @@ import github.GithubObject
 import github.NamedUser
 import github.Tag
 import github.WorkflowRun
-from github.GithubObject import Attribute, CompletableGithubObject, NotSet, Opt, ignore_return_types
+from github.GithubObject import Attribute, CompletableGithubObject, NotSet, Opt, ignore_return_type
 from github.PaginatedList import PaginatedList
 
 if TYPE_CHECKING:
@@ -172,7 +172,7 @@ class Workflow(CompletableGithubObject):
         ...
 
     # v3: default throw to True
-    @ignore_return_types(types=[github.WorkflowRun.WorkflowRun])
+    @ignore_return_type(ignore_type="WorkflowRun")
     def create_dispatch(
         self,
         ref: github.Branch.Branch | github.Tag.Tag | github.Commit.Commit | str,

--- a/scripts/openapi.py
+++ b/scripts/openapi.py
@@ -779,23 +779,6 @@ class CstMethods(abc.ABC):
             if isinstance(name, SimpleString)
         ]
 
-    @staticmethod
-    def get_ignored_return_types(decorators: Sequence[cst.Decorator]) -> list[str]:
-        """
-        Returns the class names given in the ``types`` argument of the ``ignore_return_types`` decorators.
-        """
-        return [
-            cst.Module([]).code_for_node(element.value).strip().replace('"', "")
-            for decorator in decorators
-            for decorator in [decorator.decorator]
-            if isinstance(decorator, cst.Call)
-            and isinstance(decorator.func, cst.Name)
-            and decorator.func.value == "ignore_return_types"
-            for arg in decorator.args
-            if isinstance(arg.keyword, cst.Name) and arg.keyword.value == "types" and isinstance(arg.value, cst.List)
-            for element in arg.value.elements
-        ]
-
     @classmethod
     def create_subscript(cls, name: str) -> cst.Subscript:
         fields = name.rstrip("]").split("[", maxsplit=1)
@@ -1096,7 +1079,7 @@ class IndexPythonClassesVisitor(CstVisitorBase):
         return super().leave_ClassDef(node)
 
     @staticmethod
-    def return_types(return_type: str | None, ignore: list[str] | None = None) -> list[str]:
+    def return_types(return_type: str | None, ignore: list[str]) -> list[str]:
         if return_type is None:
             return []
 
@@ -1115,7 +1098,7 @@ class IndexPythonClassesVisitor(CstVisitorBase):
 
         types = [rt.strip().replace('"', "") for rt in types]
 
-        # remove types that are annotated to be ignored, compare pure class names
+        # remove types that are to be ignored, compare pure class names
         if ignore:
             ignored = {t.split(".")[-1] for t in ignore}
             types = [rt for rt in types if rt.split(".")[-1] not in ignored]
@@ -1124,13 +1107,18 @@ class IndexPythonClassesVisitor(CstVisitorBase):
 
     def visit_FunctionDef(self, node: cst.FunctionDef) -> None:
         method_name = node.name.value
+
         decorators = self.get_decorators(node.decorators, "method_returns")
         path_property = next(
             iter([decorator["schema_property"] for decorator in decorators if "schema_property" in decorator]), None
         )
+
+        decorators = self.get_decorators(node.decorators, "ignore_return_type")
+        ignore_types = [decorator["ignore_type"] for decorator in decorators]
+
         returns = self.return_types(
             cst.Module([]).code_for_node(node.returns.annotation) if node.returns else None,
-            ignore=self.get_ignored_return_types(node.decorators),
+            ignore=ignore_types,
         )
 
         if self.is_github_object_property(node):

--- a/scripts/openapi.py
+++ b/scripts/openapi.py
@@ -779,6 +779,23 @@ class CstMethods(abc.ABC):
             if isinstance(name, SimpleString)
         ]
 
+    @staticmethod
+    def get_ignored_return_types(decorators: Sequence[cst.Decorator]) -> list[str]:
+        """
+        Returns the class names given in the ``types`` argument of the ``ignore_return_types`` decorators.
+        """
+        return [
+            cst.Module([]).code_for_node(element.value).strip().replace('"', "")
+            for decorator in decorators
+            for decorator in [decorator.decorator]
+            if isinstance(decorator, cst.Call)
+            and isinstance(decorator.func, cst.Name)
+            and decorator.func.value == "ignore_return_types"
+            for arg in decorator.args
+            if isinstance(arg.keyword, cst.Name) and arg.keyword.value == "types" and isinstance(arg.value, cst.List)
+            for element in arg.value.elements
+        ]
+
     @classmethod
     def create_subscript(cls, name: str) -> cst.Subscript:
         fields = name.rstrip("]").split("[", maxsplit=1)
@@ -1079,7 +1096,7 @@ class IndexPythonClassesVisitor(CstVisitorBase):
         return super().leave_ClassDef(node)
 
     @staticmethod
-    def return_types(return_type: str | None) -> list[str]:
+    def return_types(return_type: str | None, ignore: list[str] | None = None) -> list[str]:
         if return_type is None:
             return []
 
@@ -1096,7 +1113,14 @@ class IndexPythonClassesVisitor(CstVisitorBase):
         if "|" in return_type and "[" not in return_type:
             types = return_type.split("|") + none
 
-        return [rt.strip().replace('"', "") for rt in types]
+        types = [rt.strip().replace('"', "") for rt in types]
+
+        # remove types that are annotated to be ignored, compare pure class names
+        if ignore:
+            ignored = {t.split(".")[-1] for t in ignore}
+            types = [rt for rt in types if rt.split(".")[-1] not in ignored]
+
+        return types
 
     def visit_FunctionDef(self, node: cst.FunctionDef) -> None:
         method_name = node.name.value
@@ -1104,7 +1128,10 @@ class IndexPythonClassesVisitor(CstVisitorBase):
         path_property = next(
             iter([decorator["schema_property"] for decorator in decorators if "schema_property" in decorator]), None
         )
-        returns = self.return_types(cst.Module([]).code_for_node(node.returns.annotation) if node.returns else None)
+        returns = self.return_types(
+            cst.Module([]).code_for_node(node.returns.annotation) if node.returns else None,
+            ignore=self.get_ignored_return_types(node.decorators),
+        )
 
         if self.is_github_object_property(node):
             # collect schemas of this property


### PR DESCRIPTION
OpenAPI script wrongly suggested `WorkflowRun` to implement the schema used by `Workflow.create_dispatch` to construct the instance. However, the schemata are not compatible.

Introduces an OpenAPI annotation to ignore some method return types.

Follow-up on #3471.