### PR TITLE
Replace responses with vcrpy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -234,7 +234,8 @@ Exception
 
 Tests live in `tests/`, one file per PyGithub class (e.g. `tests/Repository.py`).
 
-- Framework: `unittest` + [`responses`](https://github.com/getsentry/responses) for HTTP mocking.
+- Framework: `unittest` + [`vcrpy`](https://github.com/kevin1024/vcrpy) for HTTP mocking, via a custom serializer
+  (`tests/VcrSerializer.py`) that reads/writes the pre-existing `tests/ReplayData/*.txt` cassette format unchanged.
 - Shared base class: `tests/Framework.py`.
 - A frame-buffer debug system in `Requester` (`NEW_DEBUG_FRAME()`) records request/response pairs for low-level
   inspection.

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,4 +4,4 @@ pytest >=5.3
 pytest-cov >=2.8
 pytest-github-actions-annotate-failures <1.0.0
 pytest-subtests >=0.11.0
-responses
+vcrpy

--- a/tests/Connection.py
+++ b/tests/Connection.py
@@ -31,86 +31,74 @@
 
 
 import itertools
-from io import StringIO
-from unittest.mock import Mock
 
 import pytest
-import responses
 
-from . import Framework
+from . import VcrSerializer
 
 PARAMETERS = itertools.product(
+    ["http", "https"],
     [
-        (Framework.ReplayingHttpConnection, "http"),
-        (Framework.ReplayingHttpsConnection, "https"),
-    ],
-    [
-        (
-            '{"body":"BODY TEXT"}',
-            "\nGET\napi.github.com\nNone\n/user\n{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}\nNone\n200\n[]\n{\"body\":\"BODY TEXT\"}\n\n",
-        ),
-        (
-            '{"body":"BODY\xa0TEXT"}',
-            "\nGET\napi.github.com\nNone\n/user\n{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}\nNone\n200\n[]\n{\"body\":\"BODY\xa0TEXT\"}\n\n",
-        ),
-        (
-            "BODY TEXT",
-            "\nGET\napi.github.com\nNone\n/user\n{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}\nNone\n200\n[]\nBODY TEXT\n\n",
-        ),
-        (
-            "BODY\xa0TEXT",
-            "\nGET\napi.github.com\nNone\n/user\n{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}\nNone\n200\n[]\nBODY\xa0TEXT\n\n",
-        ),
+        '{"body":"BODY TEXT"}',
+        '{"body":"BODY\xa0TEXT"}',
+        "BODY TEXT",
+        "BODY\xa0TEXT",
     ],
 )
 
 
-class RecordingMockConnection(Framework.RecordingConnection):
-    def __init__(self, protocol, host, port, realConnection):
-        self._realConnection = realConnection
-        super().__init__(protocol, host, port)
+def _cassette_dict(protocol, response_body):
+    uri = f"{protocol}://api.github.com/user"
+    return {
+        "version": VcrSerializer.CASSETTE_FORMAT_VERSION,
+        "interactions": [
+            {
+                "request": {
+                    "method": "GET",
+                    "uri": uri,
+                    "body": None,
+                    "headers": {
+                        "Authorization": ["Basic p4ssw0rd"],
+                        "User-Agent": ["PyGithub/Python"],
+                    },
+                },
+                "response": {
+                    "status": {"code": 200, "message": ""},
+                    "headers": {},
+                    "body": {"string": response_body.encode("utf-8")},
+                },
+            },
+        ],
+    }
 
 
-@pytest.mark.parametrize(
-    ("replaying_connection_class", "protocol", "response_body", "expected_recording"),
-    list(tuple(itertools.chain(*p)) for p in PARAMETERS),
-)
-@responses.activate
-def testRecordAndReplay(replaying_connection_class, protocol, response_body, expected_recording):
-    file = StringIO()
-    host = "api.github.com"
-    verb = "GET"
-    url = "/user"
-    headers = {"Authorization": "Basic p4ssw0rd", "User-Agent": "PyGithub/Python"}
+@pytest.mark.parametrize(("protocol", "response_body"), list(PARAMETERS))
+def testRecordAndReplay(protocol, response_body):
+    cassette_dict = _cassette_dict(protocol, response_body)
 
-    response = Mock()
-    response.status = 200
-    response.getheaders.return_value = {}
-    response.read.return_value = response_body
+    # serializing scrubs the Authorization header and writes the expected on-disk record shape
+    text = VcrSerializer.serialize(cassette_dict)
+    expected = (
+        f"{protocol}\n"
+        "GET\n"
+        "api.github.com\n"
+        "None\n"
+        "/user\n"
+        "{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}\n"
+        "None\n"
+        "200\n"
+        "[]\n"
+        f"{response_body}\n"
+        "\n"
+    )
+    assert text == expected
 
-    connection = Mock()
-    connection.getresponse.return_value = response
-
-    # write mock response to buffer
-    rdf = Framework.ReplayDataFile("string", file)
-    RecordingMockConnection.setOpenFile(lambda mode: rdf)
-    recording_connection = RecordingMockConnection(protocol, host, None, lambda *args, **kwds: connection)
-    recording_connection.request(verb, url, None, headers)
-    recording_connection.getresponse()
-    recording_connection.close()
-
-    # validate contents of buffer
-    file_value_lines = file.getvalue().split("\n")
-    expected_recording_lines = (protocol + expected_recording).split("\n")
-    assert file_value_lines[:5] == expected_recording_lines[:5]
-    assert eval(file_value_lines[5]) == eval(expected_recording_lines[5])
-    # dict literal, so keys not in guaranteed order
-    assert file_value_lines[6:] == expected_recording_lines[6:]
-
-    # rewind buffer and attempt to replay response from it
-    file.seek(0)
-    rdf = Framework.ReplayDataFile("string", file)
-    replaying_connection_class.setOpenFile(lambda mode: rdf)
-    replaying_connection = replaying_connection_class(host=host, port=None)
-    replaying_connection.request(verb, url, None, headers)
-    replaying_connection.getresponse()
+    # deserializing that same text reconstructs the original response body byte for byte
+    data = VcrSerializer.deserialize(text)
+    assert len(data["interactions"]) == 1
+    interaction = data["interactions"][0]
+    assert interaction["request"]["method"] == "GET"
+    assert interaction["request"]["uri"] == f"{protocol}://api.github.com/user"
+    assert interaction["request"]["headers"]["Authorization"] == ["Basic login_and_password_removed"]
+    assert interaction["response"]["status"]["code"] == 200
+    assert interaction["response"]["body"]["string"] == response_body.encode("utf-8")

--- a/tests/Framework.py
+++ b/tests/Framework.py
@@ -73,7 +73,6 @@ from urllib.parse import urlsplit
 
 import vcr
 from requests.structures import CaseInsensitiveDict
-from urllib3.util import Url
 
 import github
 from github import Consts
@@ -147,7 +146,8 @@ _vcr.register_serializer("pygithub-replaydata", VcrSerializer)
 
 
 class CassetteConnection:
-    """Base for the classes injected via ``Requester.injectConnectionClasses``.
+    """
+    Base for the classes injected via ``Requester.injectConnectionClasses``.
 
     All the actual HTTP interception (matching, recording, replaying) is done by ``vcrpy``,
     patched in transparently underneath ``self._realConnection`` (an unmodified
@@ -157,6 +157,7 @@ class CassetteConnection:
     before the connection is used, mirroring how many real requests happen to reuse a
     single connection per test (``Requester.__persist`` is disabled while testing, so a new
     connection is created for every single HTTP request).
+
     """
 
     def __init__(self, host, port, *args, **kwds):
@@ -303,9 +304,11 @@ class BasicTestCase(unittest.TestCase):
 
     @classmethod
     def ensureCassette(cls) -> None:
-        """Called once per HTTP connection (i.e. once per request, connection reuse is disabled
-        while testing) to make sure the vcrpy cassette matching the currently running
-        setUp/test/tearDown method -- or a ``replayData()`` override -- is the active one."""
+        """
+        Called once per HTTP connection (i.e. once per request, connection reuse is disabled while testing) to make
+        sure the vcrpy cassette matching the currently running setUp/test/tearDown method -- or a ``replayData()``
+        override -- is the active one.
+        """
         self = cls.__activeInstance
         if self is not None:
             self.__ensureCassette()
@@ -387,7 +390,7 @@ class BasicTestCase(unittest.TestCase):
                 dict(request.headers),
                 request.body,
                 response["status"]["code"],
-                response_headers,
+                {k: v for k, v in response_headers.lower_items()},
                 response["body"]["string"],
             ),
         )

--- a/tests/Framework.py
+++ b/tests/Framework.py
@@ -61,24 +61,24 @@
 
 from __future__ import annotations
 
-import base64
 import contextlib
-import json
 import os
 import traceback
 import unittest
 import warnings
-from collections.abc import Callable, Generator
+from collections.abc import Generator
 from dataclasses import dataclass
-from io import BytesIO
 from typing import Any
+from urllib.parse import urlsplit
 
-import responses
+import vcr
 from requests.structures import CaseInsensitiveDict
 from urllib3.util import Url
 
 import github
 from github import Consts
+
+from . import VcrSerializer
 
 APP_PRIVATE_KEY = """
 -----BEGIN RSA PRIVATE KEY-----
@@ -97,41 +97,6 @@ m1Iq8LMJGYl/LkDJA10CQBV1C+Xu3ukknr7C4A/4lDCa6Xb27cr1HanY7i89A+Ab
 eatdM6f/XVqWp8uPT9RggUV9TjppJobYGT2WrWJMkYw=
 -----END RSA PRIVATE KEY-----
 """
-
-
-class FakeHttpResponse:
-    def __init__(self, status, headers, output):
-        self.status = status
-        self.__headers = headers
-        self.__output = output
-
-    def getheaders(self):
-        return self.__headers
-
-    def read(self):
-        return self.__output
-
-    def iter_content(self, chunk_size=1):
-        return iter([self.__output[i : i + chunk_size] for i in range(0, len(self.__output), chunk_size)])
-
-    def raise_for_status(self):
-        pass
-
-
-def fixAuthorizationHeader(headers):
-    if "Authorization" in headers:
-        if headers["Authorization"].endswith("ZmFrZV9sb2dpbjpmYWtlX3Bhc3N3b3Jk"):
-            # This special case is here to test the real Authorization header
-            # sent by PyGithub. It would have avoided issue https://github.com/jacquev6/PyGithub/issues/153
-            # because we would have seen that Python 3 was not generating the same
-            # header as Python 2
-            pass
-        elif headers["Authorization"].startswith("token "):
-            headers["Authorization"] = "token private_token_removed"
-        elif headers["Authorization"].startswith("Basic "):
-            headers["Authorization"] = "Basic login_and_password_removed"
-        elif headers["Authorization"].startswith("Bearer "):
-            headers["Authorization"] = "Bearer jwt_removed"
 
 
 @dataclass
@@ -173,272 +138,61 @@ class RequestResponse(Request):
     output: bytes
 
 
-class Connection:
-    __openFile: Callable[[str], ReplayDataFile] | None = None
-    __requests: list[RequestResponse] = []
-
-    @classmethod
-    def setOpenFile(cls, func: Callable[[str], ReplayDataFile]):
-        cls.__openFile = func
-
-    @classmethod
-    def openFile(cls, mode: str):
-        assert cls.__openFile is not None
-        return cls.__openFile(mode)
-
-    @classmethod
-    def resetRequests(cls, requests: list[RequestResponse]) -> list[RequestResponse]:
-        try:
-            return cls.__requests
-        finally:
-            cls.__requests = requests
-
-    @classmethod
-    def addRequest(cls, request: RequestResponse):
-        cls.__requests.append(request)
+# A single VCR instance, shared across all tests: it patches http.client/urllib3 generically
+# enough that it transparently intercepts both "requests" and "niquests" traffic (see
+# https://niquests.readthedocs.io/en/latest/community/extensions.html), unlike "responses",
+# which required fooling it into believing niquests IS requests via sys.modules aliasing.
+_vcr = vcr.VCR(serializer="pygithub-replaydata", record_mode="none")
+_vcr.register_serializer("pygithub-replaydata", VcrSerializer)
 
 
-class RecordingConnection(Connection):
-    def __init__(self, protocol, host, port, *args, **kwds):
-        self.__file = self.openFile("w")
-        # write operations make the assumption that the file is not in binary mode
-        assert isinstance(self.__file, ReplayDataFile)
-        self.__request = None
-        self.__protocol = protocol
-        self.__host = host
-        self.__port = port
+class CassetteConnection:
+    """Base for the classes injected via ``Requester.injectConnectionClasses``.
+
+    All the actual HTTP interception (matching, recording, replaying) is done by ``vcrpy``,
+    patched in transparently underneath ``self._realConnection`` (an unmodified
+    ``HTTP[S]RequestsConnectionClass``, i.e. the real ``requests``/``niquests`` ``Session``).
+    The only thing this class does is make sure the *correct* cassette -- matching the
+    currently running setUp/test/tearDown method, or a ``replayData()`` override -- is active
+    before the connection is used, mirroring how many real requests happen to reuse a
+    single connection per test (``Requester.__persist`` is disabled while testing, so a new
+    connection is created for every single HTTP request).
+    """
+
+    def __init__(self, host, port, *args, **kwds):
+        BasicTestCase.ensureCassette()
         self.__cnx = self._realConnection(host, port, *args, **kwds)
-        self.__stream = False
 
     @property
     def host(self):
-        return self.__host
+        return self.__cnx.host
 
     def request(self, verb, url, input, headers, stream=False):
-        self.__cnx.request(verb, url, input, headers)
-        self.__stream = stream
-        # fixAuthorizationHeader changes the parameter directly to remove Authorization token.
-        # however, this is the real dictionary that *will be sent* by "requests",
-        # since we are writing here *before* doing the actual request.
-        # So we must avoid changing the real "headers" or this create this:
-        # https://github.com/PyGithub/PyGithub/pull/664#issuecomment-389964369
-        # https://github.com/PyGithub/PyGithub/issues/822
-        # Since it's dict[str, str], a simple copy is enough.
-        anonymous_headers = headers.copy()
-        fixAuthorizationHeader(anonymous_headers)
-        self.__request = Request(self.__protocol, verb, self.__host, self.__port, url, anonymous_headers, input)
-        self.__writeLine(self.__protocol)
-        self.__writeLine(verb)
-        self.__writeLine(self.__host)
-        self.__writeLine(self.__port)
-        self.__writeLine(url)
-        self.__writeLine(anonymous_headers)
-        self.__writeLine(str(input).replace("\n", "").replace("\r", ""))
+        self.__cnx.request(verb, url, input, headers, stream=stream)
 
     def getresponse(self):
-        res = self.__cnx.getresponse()
-
-        status = res.status
-        headers = res.getheaders()
-        output = res if self.__stream else res.read()
-
-        self.__writeLine(status)
-        self.__writeLine(list(headers))
-        if self.__stream:
-            chunks = [chunk for chunk in output.iter_content(chunk_size=64)]
-            output = b"".join(chunks)
-            for chunk in chunks:
-                self.__writeLine(base64.b64encode(chunk).decode("ascii"))
-            self.__writeLine("")
-        else:
-            self.__writeLine(output)
-        self.__writeLine("")
-
-        self.addRequest(self.__request.with_response(status, dict(headers), output))
-        self.__request = None
-
-        return FakeHttpResponse(status, headers, output)
+        return self.__cnx.getresponse()
 
     def close(self):
         return self.__cnx.close()
 
-    def __writeLine(self, line):
-        self.__file.write(str(line) + "\n")
 
-
-class RecordingHttpConnection(RecordingConnection):
+class CassetteHttpConnection(CassetteConnection):
     _realConnection = github.Requester.HTTPRequestsConnectionClass
 
-    def __init__(self, *args, **kwds):
-        super().__init__("http", *args, **kwds)
 
-
-class RecordingHttpsConnection(RecordingConnection):
+class CassetteHttpsConnection(CassetteConnection):
     _realConnection = github.Requester.HTTPSRequestsConnectionClass
-
-    def __init__(self, *args, **kwds):
-        super().__init__("https", *args, **kwds)
-
-
-class ReplayingConnection(Connection):
-    def __init__(self, protocol, host, port, *args, **kwds):
-        self.__file = self.openFile("r")
-        self.__protocol = protocol
-        self.__host = host
-        self.__port = port
-        self.__stream = False
-        self.response_headers = CaseInsensitiveDict()
-
-        self.__cnx = self._realConnection(host, port, *args, **kwds)
-
-    @property
-    def host(self):
-        return self.__host
-
-    def request(
-        self,
-        verb,
-        url,
-        input,
-        headers,
-        stream: bool = False,
-    ):
-        port = self.__port if self.__port else 443 if self.__protocol == "https" else 80
-        full_url = Url(scheme=self.__protocol, host=self.__host, port=port, path=url)
-
-        response_headers = self.response_headers.copy()
-        responses.add_callback(
-            method=verb,
-            url=full_url.url,
-            callback=lambda request: self.__request_callback(verb, full_url.url, response_headers),
-        )
-
-        self.__stream = stream
-        self.__cnx.request(verb, url, input, headers, stream=stream)
-
-    def __replayDataMismatchLine(self) -> str:
-        return f"Replay data mismatch in {self.__file}"
-
-    def __readNextRequest(self, verb, url, input, headers) -> Request:
-        fixAuthorizationHeader(headers)
-        request = Request(self.__protocol, verb, self.__host, self.__port, url, headers, input)
-        assert request.protocol == self.__file.readline(), self.__replayDataMismatchLine()
-        assert request.verb == self.__file.readline(), self.__replayDataMismatchLine()
-        assert request.host == self.__file.readline(), self.__replayDataMismatchLine()
-        assert str(request.port) == self.__file.readline(), self.__replayDataMismatchLine()
-        assert self.__splitUrl(request.url) == self.__splitUrl(self.__file.readline()), self.__replayDataMismatchLine()
-        assert request.request_headers == eval(self.__file.readline()), self.__replayDataMismatchLine()
-        expectedInput = self.__file.readline()
-        if isinstance(input, str):
-            trInput = input.replace("\n", "").replace("\r", "")
-            if input.startswith("{"):
-                assert expectedInput.startswith("{"), self.__replayDataMismatchLine()
-                assert json.loads(trInput) == json.loads(expectedInput), self.__replayDataMismatchLine()
-            else:
-                assert trInput == expectedInput, self.__replayDataMismatchLine()
-        else:
-            # for non-string input (e.g. upload asset), let it pass.
-            pass
-
-        return request
-
-    def __splitUrl(self, url):
-        splitedUrl = url.split("?")
-        if len(splitedUrl) == 1:
-            return splitedUrl
-        assert len(splitedUrl) == 2
-        base, qs = splitedUrl
-        return (base, sorted(qs.split("&")))
-
-    def __request_callback(self, request, uri, response_headers):
-        request = self.__readNextRequest(self.__cnx.verb, self.__cnx.url, self.__cnx.input, self.__cnx.headers)
-
-        status = int(self.__file.readline())
-        self.response_headers = CaseInsensitiveDict(eval(self.__file.readline()))
-        if self.__stream:
-            output = BytesIO()
-            while True:
-                line = self.__file.readline()
-                if not line:
-                    break
-                output.write(base64.b64decode(line))
-            output = output.getvalue()
-        else:
-            output = bytearray(self.__file.readline(), "utf-8")
-        self.__file.readline()
-
-        # make a copy of the headers and remove the ones that interfere with the response handling
-        adding_headers = CaseInsensitiveDict(self.response_headers)
-        adding_headers.pop("content-length", None)
-        adding_headers.pop("transfer-encoding", None)
-        adding_headers.pop("content-encoding", None)
-
-        response_headers.update(adding_headers)
-        self.addRequest(request.with_response(status, response_headers, output))
-
-        return [status, response_headers, output]
-
-    def getresponse(self):
-        response = self.__cnx.getresponse()
-
-        # restore original headers to the response
-        response.headers = self.response_headers
-
-        return response
-
-    def close(self):
-        self.__cnx.close()
-
-
-class ReplayingHttpConnection(ReplayingConnection):
-    _realConnection = github.Requester.HTTPRequestsConnectionClass
-
-    def __init__(self, *args, **kwds):
-        super().__init__("http", *args, **kwds)
-
-
-class ReplayingHttpsConnection(ReplayingConnection):
-    _realConnection = github.Requester.HTTPSRequestsConnectionClass
-
-    def __init__(self, *args, **kwds):
-        super().__init__("https", *args, **kwds)
-
-
-class ReplayDataFile:
-    @staticmethod
-    def open(filename: str, mode: str, encoding: str) -> ReplayDataFile:
-        file = open(filename, mode, encoding=encoding)
-        return ReplayDataFile(filename, file)
-
-    def __init__(self, filename: str, file):
-        self.__filename = filename
-        self.__file = file
-        self.__line = 0
-
-    def __repr__(self) -> str:
-        return f"{self.__filename}:{self.__line}"
-
-    def write(self, string: str):
-        self.__file.write(string)
-
-    def readline(self) -> str:
-        self.__line += 1
-        line = self.__file.readline()
-        if isinstance(line, bytes):
-            line = line.decode("utf-8")
-        return line.strip()
-
-    @property
-    def line_number(self):
-        return self.__line
-
-    def close(self):
-        self.__file.close()
 
 
 class BasicTestCase(unittest.TestCase):
     recordMode = False
     replayDataFolder = os.path.join(os.path.dirname(__file__), "ReplayData")
+
+    # The test currently running, i.e. the one whose stack `ensureCassette()` should inspect
+    # to resolve the active replay file. `CassetteConnection.__init__` cannot reach this any
+    # other way, since `Requester.injectConnectionClasses` only takes classes, not instances.
+    __activeInstance: BasicTestCase | None = None
 
     def __init__(self, methodName="runTest") -> None:
         super().__init__(methodName)
@@ -452,17 +206,19 @@ class BasicTestCase(unittest.TestCase):
     def setUp(self):
         super().setUp()
         self.__customFilename: str | None = None
-        self.__fileName = ""
-        self.__file = None
+        self.__cassettePath: str | None = None
+        self.__cassetteCm = None
+        self.__cassette = None
+        self.__capturedRequests: list[RequestResponse] | None = None
+        BasicTestCase.__activeInstance = self
+
+        github.Requester.Requester.injectConnectionClasses(
+            CassetteHttpConnection,
+            CassetteHttpsConnection,
+        )
         if (
             self.recordMode
         ):  # pragma no cover (Branch useful only when recording new tests, not used during automated tests)
-            RecordingHttpConnection.setOpenFile(self.__openFile)
-            RecordingHttpsConnection.setOpenFile(self.__openFile)
-            github.Requester.Requester.injectConnectionClasses(
-                RecordingHttpConnection,
-                RecordingHttpsConnection,
-            )
             import GithubCredentials  # type: ignore
 
             self.oauth_token = (
@@ -475,17 +231,9 @@ class BasicTestCase(unittest.TestCase):
                 else None
             )
         else:
-            ReplayingHttpConnection.setOpenFile(self.__openFile)
-            ReplayingHttpsConnection.setOpenFile(self.__openFile)
-            github.Requester.Requester.injectConnectionClasses(
-                ReplayingHttpConnection,
-                ReplayingHttpsConnection,
-            )
             self.oauth_token = github.Auth.Token("oauth_token")
             self.jwt = github.Auth.AppAuthToken("jwt")
             self.app_auth = github.Auth.AppAuth(123456, APP_PRIVATE_KEY)
-
-            responses.start()
 
     def setPerPage(self, per_page):
         self.per_page = per_page
@@ -516,10 +264,9 @@ class BasicTestCase(unittest.TestCase):
 
     def tearDown(self):
         super().tearDown()
-        responses.stop()
-        responses.reset()
-        self.__closeReplayFileIfNeeded(silent=self.thisTestFailed)
+        self.__closeCassetteIfNeeded(silent=self.thisTestFailed)
         github.Requester.Requester.resetConnectionClasses()
+        BasicTestCase.__activeInstance = None
 
     def assertWarning(self, warning, expected):
         self.assertWarnings(warning, expected)
@@ -547,37 +294,103 @@ class BasicTestCase(unittest.TestCase):
     @contextlib.contextmanager
     def captureRequests(self) -> Generator[list[RequestResponse]]:
         requests: list[RequestResponse] = []
-        earlier_requests = Connection.resetRequests(requests)
+        previous = self.__capturedRequests
+        self.__capturedRequests = requests
         try:
             yield requests
         finally:
-            earlier_requests.extend(requests)
-            Connection.resetRequests(earlier_requests)
+            self.__capturedRequests = previous
 
-    def __openFile(self, mode):
-        fileName = None
+    @classmethod
+    def ensureCassette(cls) -> None:
+        """Called once per HTTP connection (i.e. once per request, connection reuse is disabled
+        while testing) to make sure the vcrpy cassette matching the currently running
+        setUp/test/tearDown method -- or a ``replayData()`` override -- is the active one."""
+        self = cls.__activeInstance
+        if self is not None:
+            self.__ensureCassette()
+
+    def __resolveFileName(self) -> str | None:
         if self.__customFilename:
-            fileName = self.__customFilename
-        else:
-            for _, _, functionName, _ in traceback.extract_stack():
-                if functionName.startswith("test") or functionName == "setUp" or functionName == "tearDown":
-                    # because in class Hook(Framework.TestCase), method testTest calls Hook.test
-                    if functionName != "test":
-                        fileName = f"{self.__class__.__name__}.{functionName}.txt"
-        fileName = os.path.join(self.replayDataFolder, fileName) if fileName else None
-        if fileName != self.__fileName:
-            self.__closeReplayFileIfNeeded()
-            self.__fileName = fileName
-            self.__file = ReplayDataFile.open(self.__fileName, mode, encoding="utf-8")
-        return self.__file
+            return self.__customFilename
+        fileName = None
+        for _, _, functionName, _ in traceback.extract_stack():
+            if functionName.startswith("test") or functionName == "setUp" or functionName == "tearDown":
+                # because in class Hook(Framework.TestCase), method testTest calls Hook.test
+                if functionName != "test":
+                    fileName = f"{self.__class__.__name__}.{functionName}.txt"
+        return fileName
 
-    def __closeReplayFileIfNeeded(self, silent=False):
-        if self.__file is not None:
+    def __ensureCassette(self) -> None:
+        fileName = self.__resolveFileName()
+        path = os.path.join(self.replayDataFolder, fileName) if fileName else None
+        if path == self.__cassettePath:
+            return
+        self.__closeCassetteIfNeeded()
+        self.__cassettePath = path
+        if path is None:
+            return
+        record_mode = "all" if self.recordMode else "none"
+        cassetteCm = _vcr.use_cassette(path, record_mode=record_mode)
+        self.__cassette = cassetteCm.__enter__()
+        self.__cassetteCm = cassetteCm
+        # wired unconditionally (not just while captureRequests() is active) and exactly once per
+        # cassette: __recordInteraction() itself checks __capturedRequests, so this single wiring
+        # transparently reflects whatever captureRequests() call is active by the time each
+        # request actually happens, without ever double-wrapping play_response/append.
+        self.__wireCaptureHook(self.__cassette)
+
+    def __closeCassetteIfNeeded(self, silent=False):
+        if self.__cassetteCm is not None:
             if (
                 not self.recordMode and not silent
             ):  # pragma no branch (Branch useful only when recording new tests, not used during automated tests)
-                self.assertEqual(self.__file.readline(), "", self.__file)
-            self.__file.close()
+                self.assertTrue(
+                    self.__cassette.all_played,
+                    f"Not all replay data was used in {self.__cassettePath}",
+                )
+            self.__cassetteCm.__exit__(None, None, None)
+            self.__cassetteCm = None
+            self.__cassette = None
+
+    def __wireCaptureHook(self, cassette) -> None:
+        originalPlayResponse = cassette.play_response
+        originalAppend = cassette.append
+
+        def play_response(request):
+            response = originalPlayResponse(request)
+            self.__recordInteraction(request, response)
+            return response
+
+        def append(request, response):
+            originalAppend(request, response)
+            self.__recordInteraction(request, response)
+
+        cassette.play_response = play_response
+        cassette.append = append
+
+    def __recordInteraction(self, request, response) -> None:
+        if self.__capturedRequests is None:
+            return
+        parts = urlsplit(request.uri)
+        url = parts.path + (f"?{parts.query}" if parts.query else "")
+        response_headers = CaseInsensitiveDict(
+            {name: values[0] if isinstance(values, list) else values for name, values in response["headers"].items()},
+        )
+        self.__capturedRequests.append(
+            RequestResponse(
+                parts.scheme,
+                request.method,
+                parts.hostname,
+                parts.port,
+                url,
+                dict(request.headers),
+                request.body,
+                response["status"]["code"],
+                response_headers,
+                response["body"]["string"],
+            ),
+        )
 
     def assertListKeyEqual(self, elements, key, expectedKeys):
         realKeys = [key(element) for element in elements]

--- a/tests/Framework.py
+++ b/tests/Framework.py
@@ -334,6 +334,12 @@ class BasicTestCase(unittest.TestCase):
         if path is None:
             return
         record_mode = "all" if self.recordMode else "none"
+        if self.recordMode and os.path.exists(path):
+            # vcrpy's "all" record mode never plays back existing interactions, but it still
+            # loads them from disk and keeps them in Cassette.data -- so without this, recording
+            # over an existing replay file would append the freshly recorded interactions after
+            # the stale ones instead of replacing them.
+            os.remove(path)
         cassetteCm = _vcr.use_cassette(path, record_mode=record_mode)
         self.__cassette = cassetteCm.__enter__()
         self.__cassetteCm = cassetteCm

--- a/tests/Framework.py
+++ b/tests/Framework.py
@@ -143,6 +143,7 @@ class RequestResponse(Request):
 # which required fooling it into believing niquests IS requests via sys.modules aliasing.
 _vcr = vcr.VCR(serializer="pygithub-replaydata", record_mode="none")
 _vcr.register_serializer("pygithub-replaydata", VcrSerializer)
+_vcr.register_persister(VcrSerializer.Utf8FilesystemPersister)
 
 
 class CassetteConnection:

--- a/tests/Framework.py
+++ b/tests/Framework.py
@@ -62,6 +62,7 @@
 from __future__ import annotations
 
 import contextlib
+import functools
 import os
 import traceback
 import unittest
@@ -72,7 +73,9 @@ from typing import Any
 from urllib.parse import urlsplit
 
 import vcr
+import vcr.cassette
 from requests.structures import CaseInsensitiveDict
+from vcr.matchers import requests_match
 
 import github
 from github import Consts
@@ -137,11 +140,45 @@ class RequestResponse(Request):
     output: bytes
 
 
+class OrderedCassette(vcr.cassette.Cassette):
+    """
+    Same as vcrpy's ``Cassette``, but only ever considers the next not-yet-played interaction as a candidate match,
+    instead of searching the whole cassette for any not-yet-played interaction that matches.
+
+    vcrpy's default behavior replays same-shaped requests in recording order (since
+    it always returns the earliest unplayed match), but happily serves requests out of order
+    relative to *other*, differently-shaped requests -- e.g. cassette [A, B, C] replays fine as
+    [B, A, C] as long as each of A, B, C individually matches something unplayed. That would let a
+    refactor that accidentally reorders API calls pass silently. Requiring an exact match against
+    the next interaction turns that into a hard ``CannotOverwriteExistingCassetteException``.
+
+    """
+
+    def _responses(self, request):
+        request = self._before_record_request(request)
+        for index, (stored_request, response) in enumerate(self.data):
+            if self.play_counts[index] == 0:
+                if requests_match(request, stored_request, self._match_on):
+                    yield index, response
+                return
+
+
+class OrderedVCR(vcr.VCR):
+    def _use_cassette(self, with_current_defaults=False, **kwargs):
+        if with_current_defaults:
+            config = self.get_merged_config(**kwargs)
+            return OrderedCassette.use(**config)
+        args_getter = functools.partial(self.get_merged_config, **kwargs)
+        return OrderedCassette.use_arg_getter(args_getter)
+
+
 # A single VCR instance, shared across all tests: it patches http.client/urllib3 generically
 # enough that it transparently intercepts both "requests" and "niquests" traffic (see
 # https://niquests.readthedocs.io/en/latest/community/extensions.html), unlike "responses",
 # which required fooling it into believing niquests IS requests via sys.modules aliasing.
-_vcr = vcr.VCR(serializer="pygithub-replaydata", record_mode="none")
+# OrderedVCR additionally enforces that requests are replayed in exactly the order they were
+# recorded (see OrderedCassette above).
+_vcr = OrderedVCR(serializer="pygithub-replaydata", record_mode="none")
 _vcr.register_serializer("pygithub-replaydata", VcrSerializer)
 _vcr.register_persister(VcrSerializer.Utf8FilesystemPersister)
 

--- a/tests/GithubIntegration.py
+++ b/tests/GithubIntegration.py
@@ -37,7 +37,6 @@
 
 import time  # NOQA
 
-import requests  # NOQA
 from urllib3.exceptions import InsecureRequestWarning
 
 import github

--- a/tests/Retry.py
+++ b/tests/Retry.py
@@ -32,7 +32,6 @@
 ################################################################################
 
 import requests
-import responses
 import urllib3
 
 import github
@@ -51,34 +50,36 @@ class Retry(Framework.TestCase):
         super().setUp()
 
     def testShouldNotRetryWhenStatusNotOnList(self):
-        with self.assertRaises(github.GithubException):
+        with self.captureRequests() as calls, self.assertRaises(github.GithubException):
             self.g.get_repo(REPO_NAME)
-        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(len(calls), 1)
 
     def testReturnsRepoAfter3Retries(self):
-        repository = self.g.get_repo(REPO_NAME)
-        self.assertEqual(len(responses.calls), 4)
-        for call in responses.calls:
-            self.assertEqual(call.request.path_url, "/repos/" + REPO_NAME)
+        with self.captureRequests() as calls:
+            repository = self.g.get_repo(REPO_NAME)
+        self.assertEqual(len(calls), 4)
+        for call in calls:
+            self.assertEqual(call.url, "/repos/" + REPO_NAME)
 
         self.assertIsInstance(repository, github.Repository.Repository)
         self.assertEqual(repository.full_name, REPO_NAME)
 
     def testReturnsRepoAfter1Retry(self):
-        repository = self.g.get_repo(REPO_NAME)
-        self.assertEqual(len(responses.calls), 2)
-        for call in responses.calls:
-            self.assertEqual(call.request.path_url, "/repos/" + REPO_NAME)
+        with self.captureRequests() as calls:
+            repository = self.g.get_repo(REPO_NAME)
+        self.assertEqual(len(calls), 2)
+        for call in calls:
+            self.assertEqual(call.url, "/repos/" + REPO_NAME)
 
         self.assertIsInstance(repository, github.Repository.Repository)
         self.assertEqual(repository.full_name, REPO_NAME)
 
     def testRaisesRetryErrorAfterMaxRetries(self):
-        with self.assertRaises(requests.exceptions.RetryError):
+        with self.captureRequests() as calls, self.assertRaises(requests.exceptions.RetryError):
             self.g.get_repo("PyGithub/PyGithub")
-        self.assertEqual(len(responses.calls), 4)
-        for call in responses.calls:
-            self.assertEqual(call.request.path_url, "/repos/PyGithub/PyGithub")
+        self.assertEqual(len(calls), 4)
+        for call in calls:
+            self.assertEqual(call.url, "/repos/PyGithub/PyGithub")
 
     def testReturnsRepoAfterSettingRetryHttp(self):
         g = github.Github(

--- a/tests/VcrSerializer.py
+++ b/tests/VcrSerializer.py
@@ -55,8 +55,13 @@ from __future__ import annotations
 
 import base64
 import binascii
+from pathlib import Path
 from typing import Any
 from urllib.parse import SplitResult, urlsplit
+
+from vcr.persisters.filesystem import CassetteDecodeError, CassetteNotFoundError
+from vcr.serialize import deserialize as _vcr_deserialize
+from vcr.serialize import serialize as _vcr_serialize
 
 CASSETTE_FORMAT_VERSION = 1
 
@@ -232,3 +237,32 @@ def serialize(cassette_dict: dict[str, Any]) -> str:
         lines.append("")
 
     return "\n".join(lines) + ("\n" if lines else "")
+
+
+class Utf8FilesystemPersister:
+    """
+    Same as vcrpy's built-in ``FilesystemPersister``, but reads/writes cassette files with an
+    explicit ``encoding="utf-8"`` instead of the platform's locale-preferred encoding (``cp1252``
+    on Windows). Without this, non-ASCII cassette content is silently corrupted or, worse, made to
+    look entirely missing: a decode failure is treated by ``vcr.cassette.Cassette._load()`` as "no
+    cassette recorded yet" rather than being raised, so any fixture containing a byte sequence that
+    happens to be invalid cp1252 loads as if it had zero interactions.
+    """
+
+    @staticmethod
+    def load_cassette(cassette_path: str, serializer: Any) -> tuple[list[Any], list[Any]]:
+        path = Path(cassette_path)
+        if not path.is_file():
+            raise CassetteNotFoundError()
+        try:
+            data = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as error:
+            raise CassetteDecodeError("Can't read Cassette, Encoding is broken") from error
+        return _vcr_deserialize(data, serializer)
+
+    @staticmethod
+    def save_cassette(cassette_path: str, cassette_dict: dict[str, Any], serializer: Any) -> None:
+        data = _vcr_serialize(cassette_dict, serializer)
+        path = Path(cassette_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(data, encoding="utf-8")

--- a/tests/VcrSerializer.py
+++ b/tests/VcrSerializer.py
@@ -1,0 +1,233 @@
+############################ Copyrights and license ############################
+#                                                                              #
+# Copyright 2026 Enrico Minack <github@enrico.minack.dev>                      #
+#                                                                              #
+# This file is part of PyGithub.                                               #
+# http://pygithub.readthedocs.io/                                              #
+#                                                                              #
+# PyGithub is free software: you can redistribute it and/or modify it under    #
+# the terms of the GNU Lesser General Public License as published by the Free  #
+# Software Foundation, either version 3 of the License, or (at your option)    #
+# any later version.                                                           #
+#                                                                              #
+# PyGithub is distributed in the hope that it will be useful, but WITHOUT ANY  #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS    #
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more #
+# details.                                                                     #
+#                                                                              #
+# You should have received a copy of the GNU Lesser General Public License     #
+# along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+#                                                                              #
+################################################################################
+
+"""A vcrpy serializer that reads and writes PyGithub's pre-existing ``tests/ReplayData/*.txt``
+format unchanged, so switching the HTTP interception layer from ``responses`` to ``vcrpy``
+required no conversion of the ~1000 recorded fixtures already committed to the repo.
+
+The on-disk format is a flat sequence of fixed-shape records, one per HTTP request/response
+pair, in the exact order they were originally issued:
+
+    <protocol>          e.g. "https"
+    <verb>               e.g. "GET"
+    <host>
+    <port>                "None" for the scheme's default port
+    <url>                 path + "?" + query, if any
+    <request headers>     repr() of a plain dict
+    <input body>          str(body) with embedded newlines stripped, or "None"
+    <status code>
+    <response headers>    repr() of a list of (name, value) tuples (may repeat names)
+    <response body>       either one line of text, or N lines of base64 (64 raw bytes each,
+                           chosen when the original recording streamed the response), followed
+                           by a blank line
+
+    <blank line>          record separator
+
+Records are separated by a single blank line; nothing in the format says up front whether a
+given response body is plain text or base64-chunked, so on read we resolve that ambiguity by
+trying ``base64.b64decode(line, validate=True)`` and falling back to UTF-8 text. This is safe in
+practice: JSON/text response bodies always contain characters outside the base64 alphabet
+(``{``, ``"``, ``:``, spaces, ...), and this has been verified against every file currently in
+tests/ReplayData with zero ambiguous cases.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from typing import Any
+from urllib.parse import SplitResult, urlsplit
+
+CASSETTE_FORMAT_VERSION = 1
+
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+def fixAuthorizationHeader(headers: dict[str, Any]) -> None:
+    if "Authorization" in headers:
+        if headers["Authorization"].endswith("ZmFrZV9sb2dpbjpmYWtlX3Bhc3N3b3Jk"):
+            # This special case is here to test the real Authorization header
+            # sent by PyGithub. It would have avoided issue https://github.com/jacquev6/PyGithub/issues/153
+            # because we would have seen that Python 3 was not generating the same
+            # header as Python 2
+            pass
+        elif headers["Authorization"].startswith("token "):
+            headers["Authorization"] = "token private_token_removed"
+        elif headers["Authorization"].startswith("Basic "):
+            headers["Authorization"] = "Basic login_and_password_removed"
+        elif headers["Authorization"].startswith("Bearer "):
+            headers["Authorization"] = "Bearer jwt_removed"
+
+
+def _default_port(scheme: str) -> int | None:
+    return _DEFAULT_PORTS.get(scheme)
+
+
+def _build_uri(protocol: str, host: str, port: int | None, url: str) -> str:
+    if port is not None and port != _default_port(protocol):
+        netloc = f"{host}:{port}"
+    else:
+        netloc = host
+    return f"{protocol}://{netloc}{url}"
+
+
+def _decode_body(body_lines: list[str]) -> bytes:
+    if len(body_lines) == 0:
+        return b""
+    if len(body_lines) == 1:
+        line = body_lines[0]
+        try:
+            return base64.b64decode(line, validate=True)
+        except (binascii.Error, ValueError):
+            return line.encode("utf-8")
+    # multiple lines only occur for a response that was recorded while streaming;
+    # each line is one base64-encoded chunk of (up to) 64 raw bytes
+    return b"".join(base64.b64decode(line) for line in body_lines)
+
+
+def deserialize(cassette_string: str) -> dict[str, Any]:
+    lines = cassette_string.split("\n")
+    n = len(lines)
+    i = 0
+    interactions = []
+
+    while i < n:
+        protocol = lines[i].strip()
+        if protocol == "":
+            i += 1
+            continue
+        if i + 9 > n:
+            break
+
+        verb = lines[i + 1].strip()
+        host = lines[i + 2].strip()
+        port_field = lines[i + 3].strip()
+        url = lines[i + 4].strip()
+        headers = eval(lines[i + 5].strip())  # noqa: S307
+        input_line = lines[i + 6].strip()
+        status = int(lines[i + 7].strip())
+        response_headers = eval(lines[i + 8].strip())  # noqa: S307
+
+        j = i + 9
+        body_lines = []
+        while j < n and lines[j].strip() != "":
+            body_lines.append(lines[j].strip())
+            j += 1
+        if j < n:
+            j += 1  # consume the record's blank-line separator
+        if j < n and lines[j].strip() == "":
+            j += 1  # a streamed record writes a second blank line, consume it too if present
+        i = j
+
+        port = None if port_field == "None" else int(port_field)
+        uri = _build_uri(protocol, host, port, url)
+
+        response_headers_dict: dict[str, list[str]] = {}
+        for name, value in response_headers:
+            response_headers_dict.setdefault(name, []).append(value)
+
+        interactions.append(
+            {
+                "request": {
+                    "method": verb,
+                    "uri": uri,
+                    "body": input_line,
+                    "headers": {name: [value] for name, value in headers.items()},
+                },
+                "response": {
+                    "status": {"code": status, "message": ""},
+                    "headers": response_headers_dict,
+                    "body": {"string": _decode_body(body_lines)},
+                },
+            },
+        )
+
+    return {"version": CASSETTE_FORMAT_VERSION, "interactions": interactions}
+
+
+def _split_url(uri: str) -> SplitResult:
+    return urlsplit(uri)
+
+
+def _request_line_fields(request: dict[str, Any]) -> tuple[str, str, int | None, str]:
+    parts = _split_url(request["uri"])
+    url = parts.path + (f"?{parts.query}" if parts.query else "")
+    return parts.scheme, parts.hostname or "", parts.port, url
+
+
+def _body_to_input_line(body: Any) -> str:
+    if isinstance(body, bytes):
+        try:
+            body = body.decode("utf-8")
+        except UnicodeDecodeError:
+            body = repr(body)
+    return str(body).replace("\n", "").replace("\r", "")
+
+
+def _headers_single_valued(headers: dict[str, Any]) -> dict[str, str]:
+    result = {}
+    for name, value in headers.items():
+        result[name] = value[0] if isinstance(value, (list, tuple)) else value
+    return result
+
+
+def serialize(cassette_dict: dict[str, Any]) -> str:
+    lines: list[str] = []
+
+    for interaction in cassette_dict["interactions"]:
+        request = interaction["request"]
+        response = interaction["response"]
+
+        protocol, host, port, url = _request_line_fields(request)
+        headers = _headers_single_valued(request.get("headers") or {})
+        fixAuthorizationHeader(headers)
+
+        lines.append(protocol)
+        lines.append(request["method"])
+        lines.append(host)
+        lines.append("None" if port is None else str(port))
+        lines.append(url)
+        lines.append(str(headers))
+        lines.append(_body_to_input_line(request.get("body")))
+
+        status = response["status"]["code"]
+        response_headers_list = []
+        for name, values in (response.get("headers") or {}).items():
+            for value in values if isinstance(values, (list, tuple)) else [values]:
+                response_headers_list.append((name, value))
+
+        body = response.get("body", {}).get("string") or b""
+        if isinstance(body, str):
+            body = body.encode("utf-8")
+
+        lines.append(str(status))
+        lines.append(str(response_headers_list))
+        try:
+            lines.append(body.decode("utf-8"))
+        except UnicodeDecodeError:
+            chunk_size = 64
+            for offset in range(0, len(body), chunk_size):
+                lines.append(base64.b64encode(body[offset : offset + chunk_size]).decode("ascii"))
+            lines.append("")
+        lines.append("")
+
+    return "\n".join(lines) + ("\n" if lines else "")

--- a/tests/VcrSerializer.py
+++ b/tests/VcrSerializer.py
@@ -241,12 +241,14 @@ def serialize(cassette_dict: dict[str, Any]) -> str:
 
 class Utf8FilesystemPersister:
     """
-    Same as vcrpy's built-in ``FilesystemPersister``, but reads/writes cassette files with an
-    explicit ``encoding="utf-8"`` instead of the platform's locale-preferred encoding (``cp1252``
-    on Windows). Without this, non-ASCII cassette content is silently corrupted or, worse, made to
+    Same as vcrpy's built-in ``FilesystemPersister``, but reads/writes cassette files with an explicit
+    ``encoding="utf-8"`` instead of the platform's locale-preferred encoding (``cp1252`` on Windows).
+
+    Without this, non-ASCII cassette content is silently corrupted or, worse, made to
     look entirely missing: a decode failure is treated by ``vcr.cassette.Cassette._load()`` as "no
     cassette recorded yet" rather than being raised, so any fixture containing a byte sequence that
     happens to be invalid cp1252 loads as if it had zero interactions.
+
     """
 
     @staticmethod

--- a/tests/VcrSerializer.py
+++ b/tests/VcrSerializer.py
@@ -19,10 +19,10 @@
 # along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
 #                                                                              #
 ################################################################################
-
-"""A vcrpy serializer that reads and writes PyGithub's pre-existing ``tests/ReplayData/*.txt``
-format unchanged, so switching the HTTP interception layer from ``responses`` to ``vcrpy``
-required no conversion of the ~1000 recorded fixtures already committed to the repo.
+"""
+A vcrpy serializer that reads and writes PyGithub's pre-existing ``tests/ReplayData/*.txt`` format unchanged, so
+switching the HTTP interception layer from ``responses`` to ``vcrpy`` required no conversion of the ~1000 recorded
+fixtures already committed to the repo.
 
 The on-disk format is a flat sequence of fixed-shape records, one per HTTP request/response
 pair, in the exact order they were originally issued:
@@ -48,6 +48,7 @@ trying ``base64.b64decode(line, validate=True)`` and falling back to UTF-8 text.
 practice: JSON/text response bodies always contain characters outside the base64 alphabet
 (``{``, ``"``, ``:``, spaces, ...), and this has been verified against every file currently in
 tests/ReplayData with zero ambiguous cases.
+
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Replaces PyGithub bespoke recording facilities with `vcrpy`. Keeps recorded data as is using a custom serializer.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>