### PR TITLE
Make niquests dependency optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,17 +19,20 @@ jobs:
 
   test:
     runs-on: ${{ matrix.os }}
-    name: test (Python ${{ matrix.python-version }} on ${{ matrix.os-label }})
+    name: test (${{ matrix.request-lib }} and Python ${{ matrix.python-version }} on ${{ matrix.os-label }})
     strategy:
       fail-fast: false
       matrix:
-        # keep in sync with tox.ini [gh-actions] section
+        # keep in sync with tox.ini [gh-actions] / [gh-actions:env] sections
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
+        request-lib: ["requests", "niquests"]
         os: ["ubuntu-latest"]
         os-label: ["Ubuntu"]
         include:
-          - {python-version: "3.10", os: "windows-latest", os-label: "Windows"}
-          - {python-version: "3.10", os: "macos-latest", os-label: "macOS"}
+          - {python-version: "3.10", request-lib: "requests", os: "windows-latest", os-label: "Windows"}
+          - {python-version: "3.10", request-lib: "niquests", os: "windows-latest", os-label: "Windows"}
+          - {python-version: "3.10", request-lib: "requests", os: "macos-latest", os-label: "macOS"}
+          - {python-version: "3.10", request-lib: "niquests", os: "macos-latest", os-label: "macOS"}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Set up Python
@@ -43,11 +46,13 @@ jobs:
           pip install tox tox-gh-actions
       - name: Run tests
         run: tox
+        env:
+          REQUEST_LIB: ${{ matrix.request-lib }}
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: Test Results (Python ${{ matrix.python-version }} on ${{ matrix.os-label }})
+          name: Test Results (${{ matrix.request-lib }} and Python ${{ matrix.python-version }} on ${{ matrix.os-label }})
           path: pytest.xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0

--- a/github/Auth.py
+++ b/github/Auth.py
@@ -40,11 +40,11 @@ from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Union
 
 import jwt
-from niquests import utils
 
 from github import Consts
 from github.InstallationAuthorization import InstallationAuthorization
 from github.Requester import Requester, WithRequester
+from github.requestlib import utils
 
 if TYPE_CHECKING:
     from github.GithubIntegration import GithubIntegration

--- a/github/GithubIntegration.py
+++ b/github/GithubIntegration.py
@@ -40,7 +40,6 @@ import urllib.parse
 import warnings
 from typing import Any
 
-import niquests
 from typing_extensions import deprecated
 
 import github
@@ -52,6 +51,7 @@ from github.Installation import Installation
 from github.InstallationAuthorization import InstallationAuthorization
 from github.PaginatedList import PaginatedList
 from github.Requester import Requester
+from github.requestlib import Retry
 
 
 class GithubIntegration:
@@ -79,7 +79,7 @@ class GithubIntegration:
         user_agent: str = Consts.DEFAULT_USER_AGENT,
         per_page: int = Consts.DEFAULT_PER_PAGE,
         verify: bool | str = True,
-        retry: int | niquests.RetryConfiguration | None = None,
+        retry: int | Retry | None = None,
         pool_size: int | None = None,
         seconds_between_requests: float | None = Consts.DEFAULT_SECONDS_BETWEEN_REQUESTS,
         seconds_between_writes: float | None = Consts.DEFAULT_SECONDS_BETWEEN_WRITES,
@@ -122,7 +122,7 @@ class GithubIntegration:
         assert user_agent is None or isinstance(user_agent, str), user_agent
         assert isinstance(per_page, int), per_page
         assert isinstance(verify, (bool, str)), verify
-        assert retry is None or isinstance(retry, int) or isinstance(retry, niquests.RetryConfiguration), retry
+        assert retry is None or isinstance(retry, int) or isinstance(retry, Retry), retry
         assert pool_size is None or isinstance(pool_size, int), pool_size
         assert seconds_between_requests is None or seconds_between_requests >= 0
         assert seconds_between_writes is None or seconds_between_writes >= 0

--- a/github/GithubRetry.py
+++ b/github/GithubRetry.py
@@ -42,7 +42,7 @@ from typing_extensions import Self
 
 from github.GithubException import GithubException, RateLimitExceededExceedsMaxWait
 from github.Requester import Requester
-from github.requestlib import CaseInsensitiveDict, Response, Retry, get_encoding_from_headers, urllib3
+from github.requestlib import CaseInsensitiveDict, Response, Retry, urllib3, utils
 
 DEFAULT_SECONDARY_RATE_WAIT: int = 60
 
@@ -238,7 +238,7 @@ class GithubRetry(Retry):
         response.headers = CaseInsensitiveDict(getattr(resp, "headers", {}))
 
         # Set encoding.
-        response.encoding = get_encoding_from_headers(response.headers)
+        response.encoding = utils.get_encoding_from_headers(response.headers)
         response.raw = resp
         response.reason = response.raw.reason  # type: ignore
 

--- a/github/GithubRetry.py
+++ b/github/GithubRetry.py
@@ -38,21 +38,16 @@ from logging import Logger
 from types import TracebackType
 from typing import Any
 
-from niquests import Response, RetryConfiguration
-from niquests.models import CaseInsensitiveDict
-from niquests.packages.urllib3.connectionpool import ConnectionPool
-from niquests.packages.urllib3.exceptions import MaxRetryError
-from niquests.packages.urllib3.response import HTTPResponse
-from niquests.utils import get_encoding_from_headers
 from typing_extensions import Self
 
 from github.GithubException import GithubException, RateLimitExceededExceedsMaxWait
 from github.Requester import Requester
+from github.requestlib import CaseInsensitiveDict, Response, Retry, get_encoding_from_headers, urllib3
 
 DEFAULT_SECONDARY_RATE_WAIT: int = 60
 
 
-class GithubRetry(RetryConfiguration):
+class GithubRetry(Retry):
     """
     A Github-specific implementation of `urllib3.Retry`
 
@@ -94,9 +89,7 @@ class GithubRetry(RetryConfiguration):
         # we retry 403 and look into the response header via Retry.increment
         # to determine if we really retry that 403
         kwargs["status_forcelist"] = kwargs.get("status_forcelist", list(range(500, 600))) + [403]
-        kwargs["allowed_methods"] = kwargs.get(
-            "allowed_methods", RetryConfiguration.DEFAULT_ALLOWED_METHODS.union({"GET", "POST"})
-        )
+        kwargs["allowed_methods"] = kwargs.get("allowed_methods", Retry.DEFAULT_ALLOWED_METHODS.union({"GET", "POST"}))
         super().__init__(**kwargs)
 
     def new(self, **kw: Any) -> Self:
@@ -107,11 +100,11 @@ class GithubRetry(RetryConfiguration):
         self,
         method: str | None = None,
         url: str | None = None,
-        response: HTTPResponse | None = None,  # type: ignore[override]
+        response: urllib3.response.HTTPResponse | None = None,  # type: ignore[override]
         error: Exception | None = None,
-        _pool: ConnectionPool | None = None,
+        _pool: urllib3.ConnectionPool | None = None,
         _stacktrace: TracebackType | None = None,
-    ) -> RetryConfiguration:
+    ) -> Retry:
         if response:
             # we retry 403 only when there is a Retry-After header (indicating it is retry-able)
             # or the body message does imply a rate limit error
@@ -214,7 +207,7 @@ class GithubRetry(RetryConfiguration):
                             "Response message does not indicate retry-able error",
                         )
                         raise Requester.createException(response.status, response.headers, content)  # type: ignore
-                    except (MaxRetryError, GithubException):
+                    except (urllib3.exceptions.MaxRetryError, GithubException):
                         raise
                     except Exception as e:
                         # we want to fall back to the actual github exception (probably a rate limit error)
@@ -234,7 +227,7 @@ class GithubRetry(RetryConfiguration):
         return super().increment(method, url, response, error, _pool, _stacktrace)
 
     @staticmethod
-    def get_content(resp: HTTPResponse, url: str) -> bytes:  # type: ignore[override]
+    def get_content(resp: urllib3.response.HTTPResponse, url: str) -> bytes:  # type: ignore[override]
         # logic taken from HTTPAdapter.build_response (requests.adapters)
         response = Response()
 

--- a/github/MainClass.py
+++ b/github/MainClass.py
@@ -106,8 +106,6 @@ import warnings
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, BinaryIO, TypeVar, overload
 
-import niquests
-
 import github.ApplicationOAuth
 import github.Auth
 import github.AuthenticatedUser
@@ -142,6 +140,7 @@ from github.GithubObject import (
 from github.GithubRetry import GithubRetry
 from github.PaginatedList import PaginatedList
 from github.Requester import Requester
+from github.requestlib import Retry
 
 if TYPE_CHECKING:
     from github.AppAuthentication import AppAuthentication
@@ -200,7 +199,7 @@ class Github:
         user_agent: str = Consts.DEFAULT_USER_AGENT,
         per_page: int = Consts.DEFAULT_PER_PAGE,
         verify: bool | str = True,
-        retry: int | niquests.RetryConfiguration | None = default_retry,
+        retry: int | Retry | None = default_retry,
         pool_size: int | None = None,
         seconds_between_requests: float | None = Consts.DEFAULT_SECONDS_BETWEEN_REQUESTS,
         seconds_between_writes: float | None = Consts.DEFAULT_SECONDS_BETWEEN_WRITES,
@@ -241,7 +240,7 @@ class Github:
         assert user_agent is None or isinstance(user_agent, str), user_agent
         assert isinstance(per_page, int), per_page
         assert isinstance(verify, (bool, str)), verify
-        assert retry is None or isinstance(retry, int) or isinstance(retry, niquests.RetryConfiguration), retry
+        assert retry is None or isinstance(retry, int) or isinstance(retry, Retry), retry
         assert pool_size is None or isinstance(pool_size, int), pool_size
         assert seconds_between_requests is None or seconds_between_requests >= 0
         assert seconds_between_writes is None or seconds_between_writes >= 0

--- a/github/Requester.py
+++ b/github/Requester.py
@@ -103,13 +103,11 @@ from datetime import datetime, timezone
 from io import IOBase
 from typing import TYPE_CHECKING, Any, BinaryIO, Deque, Generic, TypeVar
 
-import niquests
-import niquests.adapters
-
 import github.Consts as Consts
 import github.GithubException
 import github.GithubException as GithubException
 from github.GithubObject import Opt, as_rest_api_attributes, is_undefined
+from github.requestlib import PreparedRequest, Response, Retry, Session, adapters
 
 if TYPE_CHECKING:
     from .AppAuthentication import AppAuthentication
@@ -126,7 +124,7 @@ ACCESS_TOKEN_REFRESH_THRESHOLD_SECONDS = 20
 
 class RequestsResponse:
     # mimic the httplib response object
-    def __init__(self, r: niquests.Response):
+    def __init__(self, r: Response):
         self.status = r.status_code
         self.headers = r.headers
         self.response = r
@@ -145,7 +143,7 @@ class RequestsResponse:
 
 
 class HTTPSRequestsConnectionClass:
-    retry: int | niquests.RetryConfiguration
+    retry: int | Retry
 
     # mimic the httplib connection object
     def __init__(
@@ -154,7 +152,7 @@ class HTTPSRequestsConnectionClass:
         port: int | None = None,
         strict: bool = False,
         timeout: int | None = None,
-        retry: int | niquests.RetryConfiguration | None = None,
+        retry: int | Retry | None = None,
         pool_size: int | None = None,
         **kwargs: Any,
     ) -> None:
@@ -165,18 +163,26 @@ class HTTPSRequestsConnectionClass:
         self.verify = kwargs.get("verify", True)
 
         if retry is None:
-            self.retry = niquests.adapters.DEFAULT_RETRIES
+            self.retry = adapters.DEFAULT_RETRIES
         else:
             self.retry = retry
 
         if pool_size is None:
-            self.pool_size = niquests.adapters.DEFAULT_POOLSIZE
+            self.pool_size = adapters.DEFAULT_POOLSIZE
         else:
             self.pool_size = pool_size
 
-        self.session = niquests.Session(
-            retries=self.retry, pool_connections=self.pool_size, pool_maxsize=self.pool_size
+        # breaking change (with niquest only):
+        # self.session = Session(
+        #    retries=self.retry, pool_connections=self.pool_size, pool_maxsize=self.pool_size
+        # )
+        self.adapter = adapters.HTTPAdapter(
+            max_retries=self.retry,
+            pool_connections=self.pool_size,
+            pool_maxsize=self.pool_size,
         )
+        self.session = Session()
+        self.session.mount("https://", self.adapter)
         # having Session.auth set something other than None disables falling back to .netrc file
         # https://github.com/psf/requests/blob/d63e94f552ebf77ccf45d97e5863ac46500fa2c7/src/requests/sessions.py#L480-L481
         # see https://github.com/PyGithub/PyGithub/pull/2703
@@ -221,7 +227,7 @@ class HTTPRequestsConnectionClass:
         port: int | None = None,
         strict: bool = False,
         timeout: int | None = None,
-        retry: int | niquests.RetryConfiguration | None = None,
+        retry: int | Retry | None = None,
         pool_size: int | None = None,
         **kwargs: Any,
     ):
@@ -232,18 +238,26 @@ class HTTPRequestsConnectionClass:
         self.verify = kwargs.get("verify", True)
 
         if retry is None:
-            self.retry = niquests.adapters.DEFAULT_RETRIES
+            self.retry = adapters.DEFAULT_RETRIES
         else:
             self.retry = retry  # type: ignore
 
         if pool_size is None:
-            self.pool_size = niquests.adapters.DEFAULT_POOLSIZE
+            self.pool_size = adapters.DEFAULT_POOLSIZE
         else:
             self.pool_size = pool_size
 
-        self.session = niquests.Session(
-            retries=self.retry, pool_connections=self.pool_size, pool_maxsize=self.pool_size
+        # breaking change (with niquest only):
+        # self.session = Session(
+        #    retries=self.retry, pool_connections=self.pool_size, pool_maxsize=self.pool_size
+        # )
+        self.adapter = adapters.HTTPAdapter(
+            max_retries=self.retry,
+            pool_connections=self.pool_size,
+            pool_maxsize=self.pool_size,
         )
+        self.session = Session()
+        self.session.mount("http://", self.adapter)
         # having Session.auth set something other than None disables falling back to .netrc file
         # https://github.com/psf/requests/blob/d63e94f552ebf77ccf45d97e5863ac46500fa2c7/src/requests/sessions.py#L480-L481
         # see https://github.com/PyGithub/PyGithub/pull/2703
@@ -285,7 +299,7 @@ class Requester:
     _frameBuffer: list[Any]
 
     @staticmethod
-    def noopAuth(request: niquests.models.PreparedRequest) -> niquests.models.PreparedRequest:
+    def noopAuth(request: PreparedRequest) -> PreparedRequest:
         return request
 
     @classmethod
@@ -388,7 +402,7 @@ class Requester:
         user_agent: str,
         per_page: int,
         verify: bool | str,
-        retry: int | niquests.RetryConfiguration | None,
+        retry: int | Retry | None,
         pool_size: int | None,
         seconds_between_requests: float | None = None,
         seconds_between_writes: float | None = None,

--- a/github/requestlib/__init__.py
+++ b/github/requestlib/__init__.py
@@ -5,35 +5,31 @@ active: str | None = None
 netrc_auth_utils: Any
 
 try:
-    import niquests
-    from niquests import Response, Session, adapters, exceptions, utils
-    from niquests import RetryConfiguration as Retry
-    from niquests.models import CaseInsensitiveDict, PreparedRequest
-    from niquests.packages import urllib3
-    from niquests.packages.urllib3.util import Url
-    from niquests.utils import get_encoding_from_headers
+    import urllib3
+    from requests import Response, Session, adapters, exceptions, utils
+    from requests.models import PreparedRequest
+    from requests.structures import CaseInsensitiveDict
+    from urllib3 import Retry
+    from urllib3.util import Url
 
-    requests = niquests
-    netrc_auth_utils = niquests.utils.get_netrc_auth
+    def noop() -> None:
+        pass
 
-    active = "niquests"
+    netrc_auth_utils = noop
+    netrc_auth_utils.cache_clear = noop
+
+    active = "requests"
 except ModuleNotFoundError:
     try:
-        import urllib3
-        from requests import Response, Session, adapters, exceptions, utils
-        from requests.models import PreparedRequest
-        from requests.structures import CaseInsensitiveDict
-        from requests.utils import get_encoding_from_headers
-        from urllib3 import Retry
-        from urllib3.util import Url
+        from niquests import Response, Session, adapters, exceptions, utils
+        from niquests import RetryConfiguration as Retry
+        from niquests.models import CaseInsensitiveDict, PreparedRequest
+        from niquests.packages import urllib3
+        from niquests.packages.urllib3.util import Url
 
-        def noop() -> None:
-            pass
+        netrc_auth_utils = utils.get_netrc_auth
 
-        netrc_auth_utils = noop
-        netrc_auth_utils.cache_clear = noop
-
-        active = "requests"
+        active = "niquests"
     except ModuleNotFoundError:
         raise ModuleNotFoundError(
             "Neither requests nor niquests package found, please install one. "
@@ -54,6 +50,5 @@ __all__ = [
     "Retry",
     "Url",
     "urllib3",
-    "get_encoding_from_headers",
     "netrc_auth_utils",
 ]

--- a/github/requestlib/__init__.py
+++ b/github/requestlib/__init__.py
@@ -36,7 +36,9 @@ except ModuleNotFoundError:
         active = "requests"
     except ModuleNotFoundError:
         raise ModuleNotFoundError(
-            "Neither requests nor niquests package found, please install one. Install them together with PyGithub via 'pip install PyGithub[requests]' or 'pip install PyGithub[niquests]'."
+            "Neither requests nor niquests package found, please install one. "
+            "Install them together with PyGithub via 'pip install PyGithub[requests]' "
+            "or 'pip install PyGithub[niquests]'."
         )
 
 

--- a/github/requestlib/__init__.py
+++ b/github/requestlib/__init__.py
@@ -1,4 +1,8 @@
-active = None
+from typing import Any
+
+active: str | None = None
+
+netrc_auth_utils: Any
 
 try:
     import niquests
@@ -15,23 +19,25 @@ try:
     active = "niquests"
 except ModuleNotFoundError:
     try:
+        import urllib3
         from requests import Response, Session, adapters, exceptions, utils
         from requests.models import PreparedRequest
         from requests.structures import CaseInsensitiveDict
         from requests.utils import get_encoding_from_headers
-
-        import urllib3
         from urllib3 import Retry
         from urllib3.util import Url
 
-        class netrc_auth_utils:
-            @staticmethod
-            def cache_clear():
-                pass
+        def noop() -> None:
+            pass
+
+        netrc_auth_utils = noop
+        netrc_auth_utils.cache_clear = noop
 
         active = "requests"
-    except ModuleNotFoundError as e:
-        raise ModuleNotFoundError("Neither requests nor niquests package found, please install one. Install them together with PyGithub via 'pip install PyGithub[requests]' or 'pip install PyGithub[niquests]'.")
+    except ModuleNotFoundError:
+        raise ModuleNotFoundError(
+            "Neither requests nor niquests package found, please install one. Install them together with PyGithub via 'pip install PyGithub[requests]' or 'pip install PyGithub[niquests]'."
+        )
 
 
 __all__ = [

--- a/github/requestlib/__init__.py
+++ b/github/requestlib/__init__.py
@@ -14,20 +14,24 @@ try:
 
     active = "niquests"
 except ModuleNotFoundError:
-    import urllib3
-    from requests import Response, Session, adapters, exceptions, utils
-    from requests.models import PreparedRequest
-    from requests.structures import CaseInsensitiveDict
-    from requests.utils import get_encoding_from_headers
-    from urllib3 import Retry
-    from urllib3.util import Url
+    try:
+        from requests import Response, Session, adapters, exceptions, utils
+        from requests.models import PreparedRequest
+        from requests.structures import CaseInsensitiveDict
+        from requests.utils import get_encoding_from_headers
 
-    class netrc_auth_utils:
-        @staticmethod
-        def cache_clear():
-            pass
+        import urllib3
+        from urllib3 import Retry
+        from urllib3.util import Url
 
-    active = "requests"
+        class netrc_auth_utils:
+            @staticmethod
+            def cache_clear():
+                pass
+
+        active = "requests"
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError("Neither requests nor niquests package found, please install one. Install them together with PyGithub via 'pip install PyGithub[requests]' or 'pip install PyGithub[niquests]'.")
 
 
 __all__ = [

--- a/github/requestlib/__init__.py
+++ b/github/requestlib/__init__.py
@@ -1,0 +1,47 @@
+active = None
+
+try:
+    import niquests
+    from niquests import Response, Session, adapters, exceptions, utils
+    from niquests import RetryConfiguration as Retry
+    from niquests.models import CaseInsensitiveDict, PreparedRequest
+    from niquests.packages import urllib3
+    from niquests.packages.urllib3.util import Url
+    from niquests.utils import get_encoding_from_headers
+
+    requests = niquests
+    netrc_auth_utils = niquests.utils.get_netrc_auth
+
+    active = "niquests"
+except ModuleNotFoundError:
+    import urllib3
+    from requests import Response, Session, adapters, exceptions, utils
+    from requests.models import PreparedRequest
+    from requests.structures import CaseInsensitiveDict
+    from requests.utils import get_encoding_from_headers
+    from urllib3 import Retry
+    from urllib3.util import Url
+
+    class netrc_auth_utils:
+        @staticmethod
+        def cache_clear():
+            pass
+
+    active = "requests"
+
+
+__all__ = [
+    "active",
+    "adapters",
+    "exceptions",
+    "utils",
+    "Response",
+    "Session",
+    "PreparedRequest",
+    "CaseInsensitiveDict",
+    "Retry",
+    "Url",
+    "urllib3",
+    "get_encoding_from_headers",
+    "netrc_auth_utils",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ integrations = []
 # e.g. `pip install PyGithub[requests]` or `pip install PyGithub[niquests]`.
 # Note that pip has no notion of a default extra, so a bare `pip install PyGithub` installs neither
 # and PyGithub will fail to import until you pick one.
-requests = ["requests>=2.14.0"]
+requests = ["requests>=2.14.0", "urllib3>=1.26.0"]
 niquests = ["niquests>=3.12,<4"]
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,10 @@ Tracker = "https://github.com/pygithub/pygithub/issues"
 
 [project.optional-dependencies]
 integrations = []
-# requests and niquests are mutually exclusive HTTP backends (see github/requestlib): install
-# exactly one, e.g. `pip install PyGithub[requests]` (the default/recommended choice) or
-# `pip install PyGithub[niquests]`. pip has no notion of a default extra, so a bare
-# `pip install PyGithub` installs neither and PyGithub will fail to import until you pick one.
+# requests and niquests are mutually exclusive HTTP backends: install exactly one,
+# e.g. `pip install PyGithub[requests]` or `pip install PyGithub[niquests]`.
+# Note that pip has no notion of a default extra, so a bare `pip install PyGithub` installs neither
+# and PyGithub will fail to import until you pick one.
 requests = ["requests>=2.14.0"]
 niquests = ["niquests>=3.12,<4"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dynamic = ["version"]
 
 dependencies = [
   "pynacl>=1.4.0",
-  "niquests>=3.12,<4",
   "pyjwt[crypto]>=2.4.0",
   "typing-extensions>=4.5.0",
 ]
@@ -42,6 +41,12 @@ Tracker = "https://github.com/pygithub/pygithub/issues"
 
 [project.optional-dependencies]
 integrations = []
+# requests and niquests are mutually exclusive HTTP backends (see github/requestlib): install
+# exactly one, e.g. `pip install PyGithub[requests]` (the default/recommended choice) or
+# `pip install PyGithub[niquests]`. pip has no notion of a default extra, so a bare
+# `pip install PyGithub` installs neither and PyGithub will fail to import until you pick one.
+requests = ["requests>=2.14.0"]
+niquests = ["niquests>=3.12,<4"]
 
 [tool.setuptools_scm]
 

--- a/tests/Authentication.py
+++ b/tests/Authentication.py
@@ -51,10 +51,10 @@ from unittest import mock
 from unittest.mock import Mock
 
 import jwt
-import niquests.utils
 
 import github
 from github.Auth import Auth, Login
+from github.requestlib import netrc_auth_utils
 
 from . import Framework
 from .GithubIntegration import APP_ID, PRIVATE_KEY, PUBLIC_KEY
@@ -269,7 +269,7 @@ class Authentication(Framework.BasicTestCase):
         self.assertEqual(user.login, "EnricoMi")
 
     def testNetrcAuth(self):
-        niquests.utils.get_netrc_auth.cache_clear()
+        netrc_auth_utils.cache_clear()
         with NamedTemporaryFile("wt", delete=False) as tmp:
             # write temporary netrc file
             tmp.write("machine api.github.com\n")
@@ -287,7 +287,7 @@ class Authentication(Framework.BasicTestCase):
             self.assertEqual(auth.token_type, "Basic")
 
     def testNetrcAuthFails(self):
-        niquests.utils.get_netrc_auth.cache_clear()
+        netrc_auth_utils.cache_clear()
         # provide an empty netrc file to make sure this test does not find one
         with NamedTemporaryFile("wt", delete=False) as tmp:
             tmp.close()

--- a/tests/Framework.py
+++ b/tests/Framework.py
@@ -74,11 +74,11 @@ from urllib.parse import urlsplit
 
 import vcr
 import vcr.cassette
-from requests.structures import CaseInsensitiveDict
 from vcr.matchers import requests_match
 
 import github
 from github import Consts
+from github.requestlib import CaseInsensitiveDict, Url
 
 from . import VcrSerializer
 

--- a/tests/Framework.py
+++ b/tests/Framework.py
@@ -78,7 +78,7 @@ from vcr.matchers import requests_match
 
 import github
 from github import Consts
-from github.requestlib import CaseInsensitiveDict, Url
+from github.requestlib import CaseInsensitiveDict
 
 from . import VcrSerializer
 

--- a/tests/GithubIntegration.py
+++ b/tests/GithubIntegration.py
@@ -37,8 +37,6 @@
 
 import time  # NOQA
 
-import requests  # NOQA
-
 import github
 from github import Consts
 from github.Auth import AppInstallationAuth, Login

--- a/tests/GithubIntegration.py
+++ b/tests/GithubIntegration.py
@@ -38,11 +38,11 @@
 import time  # NOQA
 
 import requests  # NOQA
-from niquests.packages.urllib3.exceptions import InsecureRequestWarning
 
 import github
 from github import Consts
 from github.Auth import AppInstallationAuth, Login
+from github.requestlib import urllib3
 
 from . import Framework
 
@@ -176,7 +176,7 @@ class GithubIntegration(Framework.BasicTestCase):
     def testGetGithubForInstallation(self):
         # with verify=False, urllib3.connectionpool rightly may issue an InsecureRequestWarning
         # we ignore InsecureRequestWarning from urllib3.connectionpool
-        with self.ignoreWarning(category=InsecureRequestWarning, module="urllib3.connectionpool"):
+        with self.ignoreWarning(category=urllib3.exceptions.InsecureRequestWarning, module="urllib3.connectionpool"):
             kwargs = dict(
                 auth=github.Auth.AppAuth(APP_ID, PRIVATE_KEY),
                 # http protocol used to deviate from default base url, recording data might require https

--- a/tests/GithubRetry.py
+++ b/tests/GithubRetry.py
@@ -33,10 +33,9 @@ from datetime import datetime
 from io import BytesIO
 from unittest import mock
 
-import niquests.packages.urllib3.response
-
 import github
 from github.GithubRetry import DEFAULT_SECONDARY_RATE_WAIT
+from github.requestlib import Retry, urllib3
 
 from . import Requester
 
@@ -78,7 +77,7 @@ class GithubRetry(unittest.TestCase):
             orig_retry = retry
             with mock.patch.object(retry, "_GithubRetry__log") as log:
                 if expect_retry_error:
-                    with self.assertRaises(niquests.packages.urllib3.exceptions.MaxRetryError):
+                    with self.assertRaises(urllib3.exceptions.MaxRetryError):
                         retry.increment("TEST", "URL", response)
                     retry = None
                 else:
@@ -114,7 +113,7 @@ class GithubRetry(unittest.TestCase):
     def response_func(content, reset=None):
         def response():
             stream = BytesIO(content.encode("utf8"))
-            return niquests.packages.urllib3.response.HTTPResponse(
+            return urllib3.response.HTTPResponse(
                 body=stream,
                 preload_content=False,
                 headers={"X-RateLimit-Reset": f"{reset}"} if reset else {},
@@ -348,7 +347,7 @@ class GithubRetry(unittest.TestCase):
         test_increment(retry, response(), expect_retry_error=True)
 
     def do_test_default_behaviour(self, retry, response):
-        expected = niquests.RetryConfiguration(total=retry.total, backoff_factor=retry.backoff_factor)
+        expected = Retry(total=retry.total, backoff_factor=retry.backoff_factor)
         self.assertTrue(retry.total > 0)
         for _ in range(retry.total):
             retry = retry.increment("TEST", "URL", response)
@@ -356,14 +355,14 @@ class GithubRetry(unittest.TestCase):
             self.assertEqual(expected.total, retry.total)
             self.assertEqual(expected.get_backoff_time(), retry.get_backoff_time())
 
-        with self.assertRaises(niquests.packages.urllib3.exceptions.MaxRetryError):
+        with self.assertRaises(urllib3.exceptions.MaxRetryError):
             retry.increment("TEST", "URL", response)
-        with self.assertRaises(niquests.packages.urllib3.exceptions.MaxRetryError):
+        with self.assertRaises(urllib3.exceptions.MaxRetryError):
             expected.increment("TEST", "URL", response)
 
     def test_403_with_retry_after(self):
         retry = github.GithubRetry(total=3)
-        response = niquests.packages.urllib3.response.HTTPResponse(status=403, headers={"Retry-After": "123"})
+        response = urllib3.response.HTTPResponse(status=403, headers={"Retry-After": "123"})
         self.do_test_default_behaviour(retry, response)
 
     def test_403_with_non_retryable_error(self):
@@ -377,17 +376,17 @@ class GithubRetry(unittest.TestCase):
 
     def test_misc_response(self):
         retry = github.GithubRetry(total=3)
-        response = niquests.packages.urllib3.response.HTTPResponse()
+        response = urllib3.response.HTTPResponse()
         self.do_test_default_behaviour(retry, response)
 
     def test_misc_response_exponential_backoff(self):
         retry = github.GithubRetry(total=3, backoff_factor=10)
-        response = niquests.packages.urllib3.response.HTTPResponse()
+        response = urllib3.response.HTTPResponse()
         self.do_test_default_behaviour(retry, response)
 
     def test_error_inspecting_response_body(self):
         retry = github.GithubRetry(total=3)
-        response = niquests.packages.urllib3.response.HTTPResponse(status=403, reason="NOT GOOD")
+        response = urllib3.response.HTTPResponse(status=403, reason="NOT GOOD")
 
         with mock.patch.object(retry, "_GithubRetry__log") as log:
             with self.assertRaises(github.GithubException) as exp:
@@ -401,10 +400,12 @@ class GithubRetry(unittest.TestCase):
             self.assertEqual(("Failed to inspect response message",), exp.exception.__cause__.args)
 
             self.assertIsInstance(exp.exception.__cause__.__cause__, ValueError)
-            self.assertEqual(
-                ("Expecting value: line 1 column 1 (char 0)",),
-                exp.exception.__cause__.__cause__.args,
-            )
+            expected_cause = None
+            if github.requestlib.active == "requests":
+                expected_cause = 'Unable to determine whether fp is closed.'
+            if github.requestlib.active == "niquests":
+                expected_cause = "Expecting value: line 1 column 1 (char 0)"
+            self.assertEqual((expected_cause,), exp.exception.__cause__.__cause__.args)
 
         log.assert_called_once_with(logging.INFO, "Request TEST URL failed with 403: NOT GOOD")
 

--- a/tests/GithubRetry.py
+++ b/tests/GithubRetry.py
@@ -355,9 +355,9 @@ class GithubRetry(unittest.TestCase):
             self.assertEqual(expected.total, retry.total)
             self.assertEqual(expected.get_backoff_time(), retry.get_backoff_time())
 
-        with self.assertRaises(urllib3.exceptions.MaxRetryError):
+        with self.assertRaises(Exception):
             retry.increment("TEST", "URL", response)
-        with self.assertRaises(urllib3.exceptions.MaxRetryError):
+        with self.assertRaises(Exception):
             expected.increment("TEST", "URL", response)
 
     def test_403_with_retry_after(self):

--- a/tests/GithubRetry.py
+++ b/tests/GithubRetry.py
@@ -402,7 +402,7 @@ class GithubRetry(unittest.TestCase):
             self.assertIsInstance(exp.exception.__cause__.__cause__, ValueError)
             expected_cause = None
             if github.requestlib.active == "requests":
-                expected_cause = 'Unable to determine whether fp is closed.'
+                expected_cause = "Unable to determine whether fp is closed."
             if github.requestlib.active == "niquests":
                 expected_cause = "Expecting value: line 1 column 1 (char 0)"
             self.assertEqual((expected_cause,), exp.exception.__cause__.__cause__.args)

--- a/tests/Installation.py
+++ b/tests/Installation.py
@@ -41,11 +41,10 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from niquests.packages.urllib3.exceptions import InsecureRequestWarning
-
 import github
 from github import Consts
 from github.Auth import AppAuth, AppInstallationAuth
+from github.requestlib import urllib3
 
 from . import Framework, GithubIntegration
 
@@ -96,7 +95,7 @@ class Installation(Framework.BasicTestCase):
     def testGetGithubForInstallation(self):
         # with verify=False, urllib3.connectionpool rightly may issue an InsecureRequestWarning
         # we ignore InsecureRequestWarning from urllib3.connectionpool
-        with self.ignoreWarning(category=InsecureRequestWarning, module="urllib3.connectionpool"):
+        with self.ignoreWarning(category=urllib3.exceptions.InsecureRequestWarning, module="urllib3.connectionpool"):
             kwargs = dict(
                 auth=AppAuth(319953, GithubIntegration.PRIVATE_KEY),
                 # http protocol used to deviate from default base url, recording data might require https

--- a/tests/Retry.py
+++ b/tests/Retry.py
@@ -31,10 +31,8 @@
 #                                                                              #
 ################################################################################
 
-import niquests
-import requests
-
 import github
+from github.requestlib import exceptions
 
 from . import Framework
 
@@ -45,7 +43,7 @@ class Retry(Framework.TestCase):
     def setUp(self):
         # status codes returned on random github server errors
         status_forcelist = (500, 502, 504)
-        retry = niquests.RetryConfiguration(total=3, read=3, connect=3, status_forcelist=status_forcelist)
+        retry = github.requestlib.Retry(total=3, read=3, connect=3, status_forcelist=status_forcelist)
         self.setRetry(retry)
         super().setUp()
 
@@ -75,7 +73,7 @@ class Retry(Framework.TestCase):
         self.assertEqual(repository.full_name, REPO_NAME)
 
     def testRaisesRetryErrorAfterMaxRetries(self):
-        with self.captureRequests() as calls, self.assertRaises(requests.exceptions.RetryError):
+        with self.captureRequests() as calls, self.assertRaises(exceptions.RetryError):
             self.g.get_repo("PyGithub/PyGithub")
         self.assertEqual(len(calls), 4)
         for call in calls:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,17 +36,20 @@
 
 from sys import modules
 
-import niquests
-from niquests.packages import urllib3
+try:
+    import niquests
+    from niquests.packages import urllib3
 
-# module 'responses' is tied to Requests, and Niquests is entirely compatible with it.
-# we can fool it without effort.
-modules["requests"] = niquests
-modules["requests.adapters"] = niquests.adapters
-modules["requests.models"] = niquests.models
-modules["requests.exceptions"] = niquests.exceptions
-modules["requests.packages.urllib3"] = urllib3
-
+    # module 'responses' is tied to Requests, and Niquests is entirely compatible with it.
+    # we can fool it without effort.
+    modules["requests"] = niquests
+    modules["requests.adapters"] = niquests.adapters
+    modules["requests.models"] = niquests.models
+    modules["requests.exceptions"] = niquests.exceptions
+    modules["requests.packages.urllib3"] = urllib3
+    modules["urllib3"] = urllib3
+except ModuleNotFoundError:
+    pass
 
 from . import Framework  # noqa: E402
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,24 +34,7 @@
 #                                                                              #
 ################################################################################
 
-from sys import modules
-
-try:
-    import niquests
-    from niquests.packages import urllib3
-
-    # module 'responses' is tied to Requests, and Niquests is entirely compatible with it.
-    # we can fool it without effort.
-    modules["requests"] = niquests
-    modules["requests.adapters"] = niquests.adapters
-    modules["requests.models"] = niquests.models
-    modules["requests.exceptions"] = niquests.exceptions
-    modules["requests.packages.urllib3"] = urllib3
-    modules["urllib3"] = urllib3
-except ModuleNotFoundError:
-    pass
-
-from . import Framework  # noqa: E402
+from . import Framework
 
 
 def pytest_addoption(parser):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint,
-    py{310-315},
+    py{310-315}-{requests,niquests},
     docs
 
 [gh-actions]
@@ -15,7 +15,16 @@ python =
     3.14: py314
     3.15: py315
 
+[gh-actions:env]
+# keep in sync with workflows/ci.yaml matrix
+REQUEST_LIB =
+    requests: requests
+    niquests: niquests
+
 [testenv]
+extras =
+    requests: requests
+    niquests: niquests
 deps = -rrequirements/test.txt
 commands = pytest --junit-xml pytest.xml --cov=github --cov-report=xml {posargs}
 


### PR DESCRIPTION
This allows to choose between running PyGithub with `requests` or `niquests`. This provides full control over the HTTP library dependency used.

**This is a breaking change.** Installing `PyGithub` does not install `requests` as a dependency any more.

To restore this behaviour, instead of

    pygithub

use

    pygithub[requests]

in your `requirements.txt` or dependencies list. For instance, instead use

    pip install pygithub[requests]

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>