### PR TITLE
Add `signature` parameter to `Repository.create_git_commit`

### DIFF
--- a/doc/examples/Commit.rst
+++ b/doc/examples/Commit.rst
@@ -26,3 +26,74 @@ Get commit date
     2018-10-11 03:04:52
     >>> print(commit.commit.committer.date)
     2018-10-11 03:04:52
+
+Create a signed commit
+----------------------
+
+:meth:`github.Repository.Repository.create_git_commit` takes an optional ``signature`` argument,
+an ASCII-armored detached PGP signature that Github stores in the ``gpgsig`` header of the commit.
+
+The signature has to be made over the commit payload, in the canonical format git uses::
+
+    tree <tree sha>
+    parent <parent sha>
+    author <name> <email> <unix timestamp> <utc offset>
+    committer <name> <email> <unix timestamp> <utc offset>
+
+    <commit message>
+
+The author and committer in that payload must be identical to the ones sent to the API, otherwise
+Github considers the signature invalid. Pass them explicitly rather than letting Github fill them in:
+
+.. code-block:: python
+
+    import subprocess
+    from datetime import datetime
+
+    from github import InputGitAuthor
+
+
+    def git_date(date: datetime) -> str:
+        # the API takes ISO-8601 dates, the signed payload takes "<timestamp> <offset>"
+        return f"{int(date.timestamp())} {date.strftime('%z')}"
+
+
+    branch = repo.get_branch("main")
+    parent = repo.get_git_commit(branch.commit.sha)
+    tree = repo.get_git_tree(parent.tree.sha)
+
+    # drop sub-second precision: isoformat() keeps it, git_date() truncates it,
+    # and a one second disagreement is enough to invalidate the signature
+    date = datetime.now().astimezone().replace(microsecond=0)
+    author = InputGitAuthor("Monalisa Octocat", "octocat@github.com", date.isoformat())
+    message = "Commit created by PyGithub"
+
+    payload = (
+        f"tree {tree.sha}\n"
+        f"parent {parent.sha}\n"
+        f"author Monalisa Octocat <octocat@github.com> {git_date(date)}\n"
+        f"committer Monalisa Octocat <octocat@github.com> {git_date(date)}\n"
+        f"\n{message}\n"
+    )
+
+    # any PGP implementation will do, here gpg signs the payload read from stdin
+    signature = subprocess.run(
+        ["gpg", "--armor", "--detach-sign", "--output", "-"],
+        input=payload.encode(),
+        capture_output=True,
+        check=True,
+    ).stdout.decode()
+
+    commit = repo.create_git_commit(
+        message, tree, [parent], author=author, committer=author, signature=signature
+    )
+    repo.get_git_ref("heads/main").edit(commit.sha)
+
+Github reports the result of its own verification on the commit it created:
+
+.. code-block:: python
+
+    >>> commit.verification.verified
+    True
+    >>> commit.verification.reason
+    'valid'

--- a/github/Repository.py
+++ b/github/Repository.py
@@ -1440,6 +1440,7 @@ class Repository(CompletableGithubObject):
         parents: list[GitCommit],
         author: Opt[InputGitAuthor] = NotSet,
         committer: Opt[InputGitAuthor] = NotSet,
+        signature: Opt[str] = NotSet,
     ) -> GitCommit:
         """
         :calls: `POST /repos/{owner}/{repo}/git/commits <https://docs.github.com/en/rest/reference/git#commits>`_
@@ -1448,6 +1449,7 @@ class Repository(CompletableGithubObject):
         :param parents: list of :class:`github.GitCommit.GitCommit`
         :param author: :class:`github.InputGitAuthor.InputGitAuthor`
         :param committer: :class:`github.InputGitAuthor.InputGitAuthor`
+        :param signature: string
         :rtype: :class:`github.GitCommit.GitCommit`
         """
         assert isinstance(message, str), message
@@ -1455,6 +1457,7 @@ class Repository(CompletableGithubObject):
         assert all(isinstance(element, github.GitCommit.GitCommit) for element in parents), parents
         assert is_optional(author, github.InputGitAuthor), author
         assert is_optional(committer, github.InputGitAuthor), committer
+        assert is_optional(signature, str), signature
         post_parameters: dict[str, Any] = {
             "message": message,
             "tree": tree._identity,
@@ -1464,6 +1467,8 @@ class Repository(CompletableGithubObject):
             post_parameters["author"] = author._identity
         if is_defined(committer):
             post_parameters["committer"] = committer._identity
+        if is_defined(signature):
+            post_parameters["signature"] = signature
         headers, data = self._requester.requestJsonAndCheck("POST", f"{self.url}/git/commits", input=post_parameters)
         return github.GitCommit.GitCommit(self._requester, headers, data, completed=True)
 

--- a/tests/ReplayData/Repository.testCreateGitCommitWithSignature.txt
+++ b/tests/ReplayData/Repository.testCreateGitCommitWithSignature.txt
@@ -1,0 +1,21 @@
+https
+GET
+api.github.com
+None
+/repos/PyGithub/PyGithub/git/trees/107139a922f33bab6fbeb9f9eb8787e7f19e0528
+{'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
+None
+200
+[('status', '200 OK'), ('x-ratelimit-remaining', '4994'), ('content-length', '381'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"f33782d7031ff19c5301bb52068533cf"'), ('date', 'Fri, 01 Jun 2012 20:02:40 GMT'), ('content-type', 'application/json; charset=utf-8')]
+{"url":"https://api.github.com/repos/PyGithub/PyGithub/git/trees/107139a922f33bab6fbeb9f9eb8787e7f19e0528","sha":"107139a922f33bab6fbeb9f9eb8787e7f19e0528","tree":[{"type":"blob","url":"https://api.github.com/repos/PyGithub/PyGithub/git/blobs/5dd930f591cd5188e9ea7200e308ad355182a1d8","sha":"5dd930f591cd5188e9ea7200e308ad355182a1d8","size":0,"path":"Barbaz.txt","mode":"100644"}]}
+
+https
+POST
+api.github.com
+None
+/repos/PyGithub/PyGithub/git/commits
+{'Content-Type': 'application/json', 'Authorization': 'token private_token_removed', 'User-Agent': 'PyGithub/Python'}
+{"parents": [], "message": "Commit created by PyGithub", "tree": "107139a922f33bab6fbeb9f9eb8787e7f19e0528", "signature": "-----BEGIN PGP SIGNATURE-----\n\niQEcBAABAgAGBQJUxSb3AAoJEFdOFQKAcAilr+MH/1MYbYt4rZaEBiXqNKPhLzT2\n-----END PGP SIGNATURE-----\n"}
+201
+[('status', '201 Created'), ('x-ratelimit-remaining', '4931'), ('content-length', '601'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"7719e5a3f5b064dc0871853dba33302b"'), ('date', 'Sun, 27 May 2012 05:50:59 GMT'), ('content-type', 'application/json; charset=utf-8'), ('location', 'https://api.github.com/repos/PyGithub/PyGithub/git/commits/0b820628236ab8bab3890860fc414fa757ca15f4')]
+{"author":{"email":"github.com@vincent-jacques.net","name":"Vincent Jacques","date":"2012-05-26T22:50:59-07:00"},"url":"https://api.github.com/repos/PyGithub/PyGithub/git/commits/0b820628236ab8bab3890860fc414fa757ca15f4","message":"Commit created by PyGithub","committer":{"email":"github.com@vincent-jacques.net","name":"Vincent Jacques","date":"2012-05-26T22:50:59-07:00"},"sha":"0b820628236ab8bab3890860fc414fa757ca15f4","parents":[],"tree":{"url":"https://api.github.com/repos/PyGithub/PyGithub/git/trees/107139a922f33bab6fbeb9f9eb8787e7f19e0528","sha":"107139a922f33bab6fbeb9f9eb8787e7f19e0528"},"verification":{"verified":true,"reason":"valid","signature":"-----BEGIN PGP SIGNATURE-----\n\niQEcBAABAgAGBQJUxSb3AAoJEFdOFQKAcAilr+MH/1MYbYt4rZaEBiXqNKPhLzT2\n-----END PGP SIGNATURE-----\n","payload":"tree 107139a922f33bab6fbeb9f9eb8787e7f19e0528\n","verified_at":"2012-05-26T22:50:59Z"}}

--- a/tests/Repository.py
+++ b/tests/Repository.py
@@ -530,6 +530,20 @@ class Repository(Framework.TestCase):
         )
         self.assertEqual(commit.sha, "526946197ae9da59c6507cacd13ad6f1cfb686ea")
 
+    def testCreateGitCommitWithSignature(self):
+        tree = self.repo.get_git_tree("107139a922f33bab6fbeb9f9eb8787e7f19e0528")
+        signature = (
+            "-----BEGIN PGP SIGNATURE-----\n"
+            "\n"
+            "iQEcBAABAgAGBQJUxSb3AAoJEFdOFQKAcAilr+MH/1MYbYt4rZaEBiXqNKPhLzT2\n"
+            "-----END PGP SIGNATURE-----\n"
+        )
+        commit = self.repo.create_git_commit("Commit created by PyGithub", tree, [], signature=signature)
+        self.assertEqual(commit.sha, "0b820628236ab8bab3890860fc414fa757ca15f4")
+        self.assertTrue(commit.verification.verified)
+        self.assertEqual(commit.verification.reason, "valid")
+        self.assertEqual(commit.verification.signature, signature)
+
     def testCreateGitRelease(self):
         release = self.repo.create_git_release(
             "vX.Y.Z-by-PyGithub-acctest",


### PR DESCRIPTION
`POST /repos/{owner}/{repo}/git/commits` accepts an optional `signature` field, which Github stores in the `gpgsig` header of the commit it creates and uses to verify it. `Repository.create_git_commit` did not expose that field, so commits created through PyGithub could not be signed and were always reported as unverified.

cf. https://docs.github.com/en/rest/git/commits#create-a-commit

Added an optional `signature: Opt[str]` argument to `Repository.create_git_commit`, handled the same way as the existing `author` and `committer` arguments: validated with `is_optional` and only added to the post parameters when defined. The argument comes last, so existing callers are unaffected.

Also added an example to `doc/examples/Commit.rst`. Building the payload to sign is the part that is easy to get wrong, so the example spells out the canonical commit format and notes that the author and committer in that payload must match the ones sent to the API, otherwise Github considers the signature invalid.

`Repository.testCreateGitCommitWithSignature` creates a commit with an armored signature and asserts the sha and the returned verification. Removing the two lines that send the parameter makes it fail on the recorded request body, so the test covers the change rather than just the happy path.